### PR TITLE
Make the Task Rack a pragmatic daily tool

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,11 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
+          cache: maven
       - name: Build with Maven
         run: mvn -B verify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ NMOX-Studio/
 | **core** | Platform services and infrastructure | `ServiceManager`, `ThemeInstaller`, `FileCache`, `PerformanceMonitor` |
 | **editor** | File editing and language support | `JavaScriptLexer`, `JavaScriptDataObject`, `TypeScriptDataObject`, completion providers |
 | **tools** | Development tools and integrations | `NpmService`, `WebProjectFactory`, `BuildToolService`, `TestRunnerService` |
-| **rack** | Reason-style virtual task rack | `RackTopComponent`, `Rack`/`RackDevice` model, 14 task devices, patch-cable wiring, `RackIO` persistence |
+| **rack** | Reason-style virtual task rack | `RackTopComponent`, `Rack`/`RackDevice` model, 15 task devices, patch-cable wiring, `FileWatcher`, `RackIO` persistence |
 | **project** | Project management | `ProjectExplorerTopComponent`, `WebProject`, wizards |
 | **ui** | Core UI components | `MainWindow`, `WelcomeScreen`, `StartupInitializer`, actions |
 | **branding** | Application identity | Splash screen, icons, custom branding |

--- a/editor/src/main/java/org/nmox/studio/editor/javascript/JavaScriptLanguageHierarchy.java
+++ b/editor/src/main/java/org/nmox/studio/editor/javascript/JavaScriptLanguageHierarchy.java
@@ -1,9 +1,8 @@
 package org.nmox.studio.editor.javascript;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.netbeans.spi.lexer.LanguageHierarchy;
 import org.netbeans.spi.lexer.Lexer;
@@ -14,25 +13,6 @@ import org.netbeans.spi.lexer.LexerRestartInfo;
  * Defines the structure and tokens for the JavaScript language.
  */
 public class JavaScriptLanguageHierarchy extends LanguageHierarchy<JavaScriptTokenId> {
-    
-    private static final List<JavaScriptTokenId> tokens = Arrays.asList(new JavaScriptTokenId[] {
-        JavaScriptTokenId.KEYWORD,
-        JavaScriptTokenId.STRING,
-        JavaScriptTokenId.NUMBER,
-        JavaScriptTokenId.BOOLEAN,
-        JavaScriptTokenId.NULL,
-        JavaScriptTokenId.UNDEFINED,
-        JavaScriptTokenId.REGEX,
-        JavaScriptTokenId.IDENTIFIER,
-        JavaScriptTokenId.OPERATOR,
-        JavaScriptTokenId.DELIMITER,
-        JavaScriptTokenId.LINE_COMMENT,
-        JavaScriptTokenId.BLOCK_COMMENT,
-        JavaScriptTokenId.WHITESPACE,
-        JavaScriptTokenId.ERROR,
-        JavaScriptTokenId.TEMPLATE_STRING,
-        JavaScriptTokenId.TEMPLATE_EXPRESSION
-    });
     
     private static final Map<String, JavaScriptTokenId> flyweights = new HashMap<>();
     
@@ -68,7 +48,9 @@ public class JavaScriptLanguageHierarchy extends LanguageHierarchy<JavaScriptTok
     
     @Override
     protected synchronized Collection<JavaScriptTokenId> createTokenIds() {
-        return tokens;
+        // computed here, not in a static field: a static reference to the
+        // enum constants re-creates the TokenId<->Hierarchy init cycle
+        return EnumSet.allOf(JavaScriptTokenId.class);
     }
     
     @Override

--- a/editor/src/main/java/org/nmox/studio/editor/javascript/JavaScriptTokenId.java
+++ b/editor/src/main/java/org/nmox/studio/editor/javascript/JavaScriptTokenId.java
@@ -48,10 +48,20 @@ public enum JavaScriptTokenId implements TokenId {
         return category;
     }
     
-    private static final Language<JavaScriptTokenId> language = 
-            new JavaScriptLanguageHierarchy().language();
-    
+    /**
+     * Lazy holder: building the Language touches JavaScriptLanguageHierarchy,
+     * which references this enum's constants. Initializing it eagerly here
+     * creates a static-init cycle that blows up with "Ids cannot be null"
+     * whenever the hierarchy class happens to load first (order depends on
+     * which test or caller runs first). The holder defers construction until
+     * language() is called, after both classes are fully initialized.
+     */
+    private static final class LanguageHolder {
+        static final Language<JavaScriptTokenId> LANGUAGE =
+                new JavaScriptLanguageHierarchy().language();
+    }
+
     public static Language<JavaScriptTokenId> language() {
-        return language;
+        return LanguageHolder.LANGUAGE;
     }
 }

--- a/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
+++ b/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
@@ -104,10 +104,25 @@ public final class RackTopComponent extends TopComponent {
         rack.addListener(new Rack.Listener() {
             @Override
             public void projectChanged() {
-                javax.swing.SwingUtilities.invokeLater(RackTopComponent.this::updateProjectLabel);
+                javax.swing.SwingUtilities.invokeLater(() -> {
+                    updateProjectLabel();
+                    autoLoadPatch();
+                });
             }
         });
         followOpenProjects();
+    }
+
+    /**
+     * A project that carries a saved patch gets it mounted automatically
+     * the moment the rack aims at it - the rack file is part of the
+     * project, like its package.json.
+     */
+    private void autoLoadPatch() {
+        File patch = new File(rack.getProjectDir(), RackIO.DEFAULT_FILENAME);
+        if (patch.isFile()) {
+            loadPatch(patch);
+        }
     }
 
     /**
@@ -165,13 +180,8 @@ public final class RackTopComponent extends TopComponent {
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             chooser.setDialogTitle("Select Project Directory");
             if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+                // a saved patch in the chosen project loads automatically
                 rack.setProjectDir(chooser.getSelectedFile());
-                File patch = new File(chooser.getSelectedFile(), RackIO.DEFAULT_FILENAME);
-                if (patch.isFile() && JOptionPane.showConfirmDialog(this,
-                        "This project has a saved rack patch. Load it?", "Task Rack",
-                        JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
-                    loadPatch(patch);
-                }
             }
         });
         bar.add(chooseProject);

--- a/rack/src/main/java/org/nmox/studio/rack/devices/BuildDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BuildDevice.java
@@ -10,8 +10,23 @@ import org.nmox.studio.rack.ui.controls.ToggleSwitch;
 /**
  * FORGE Build Engine: drives the project's bundler. AUTO uses the
  * package.json build script; the other positions call the tool directly.
+ *
+ * In WATCH mode the process never exits, so FORGE listens to the build
+ * output instead and fires OK/FAIL on every rebuild - patch OK into
+ * VERITAS or PING and each save ripples down the pipeline.
  */
 public class BuildDevice extends CommandDevice {
+
+    /** Rebuild-finished markers across vite, webpack/CRA, rollup, esbuild. */
+    private static final String[] WATCH_OK_MARKERS = {
+        "built in", "compiled successfully", "build completed", "build finished", "created "
+    };
+    private static final String[] WATCH_FAIL_MARKERS = {
+        "build failed", "failed to compile", "error in ", "[!] error", "error ts"
+    };
+    private static final long WATCH_FIRE_COOLDOWN_MS = 1500;
+
+    private volatile long lastWatchFire;
 
     private static final String[] TOOLS = {"auto", "vite", "webpack", "rollup", "esbuild", "parcel"};
 
@@ -34,6 +49,41 @@ public class BuildDevice extends CommandDevice {
         param("tool", toolKnob);
         param("prod", prodSwitch);
         param("watch", watchSwitch);
+    }
+
+    @Override
+    protected void onLine(String line) {
+        if (!watchSwitch.isOn() || !isProcessRunning()) {
+            return;
+        }
+        String lower = line.toLowerCase();
+        boolean ok = matchesAny(lower, WATCH_OK_MARKERS);
+        boolean fail = !ok && matchesAny(lower, WATCH_FAIL_MARKERS);
+        if (!ok && !fail) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastWatchFire < WATCH_FIRE_COOLDOWN_MS) {
+            return;
+        }
+        lastWatchFire = now;
+        onEdt(() -> {
+            okLed.setOn(ok);
+            failLed.setOn(fail);
+            statusLcd.setTextColor(ok ? org.nmox.studio.rack.ui.controls.RackStyle.LCD_TEXT
+                    : new Color(255, 90, 80));
+            statusLcd.setText(ok ? "REBUILT — WATCHING" : "REBUILD FAILED — WATCHING");
+        });
+        emit(ok ? "ok" : "fail", org.nmox.studio.rack.model.Signal.trigger(ok));
+    }
+
+    private static boolean matchesAny(String line, String[] markers) {
+        for (String marker : markers) {
+            if (line.contains(marker)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/rack/src/main/java/org/nmox/studio/rack/devices/CommandDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/CommandDevice.java
@@ -3,6 +3,7 @@ package org.nmox.studio.rack.devices;
 import java.awt.Color;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.nmox.studio.rack.model.Port;
 import org.nmox.studio.rack.model.RackDevice;
 import org.nmox.studio.rack.model.Signal;
@@ -23,6 +24,9 @@ import org.nmox.studio.rack.ui.controls.VuMeter;
  */
 public abstract class CommandDevice extends RackDevice {
 
+    /** Exit codes from STOP-button kills (SIGINT/SIGKILL/SIGTERM); not real failures. */
+    private static final Set<Integer> KILL_EXIT_CODES = Set.of(130, 137, 143);
+
     protected final VuMeter activity = new VuMeter("ACTIVITY", false);
     protected final Led runLed = new Led("RUN", new Color(255, 190, 60));
     protected final Led okLed = new Led("OK", new Color(80, 235, 100));
@@ -30,6 +34,7 @@ public abstract class CommandDevice extends RackDevice {
     protected final LcdDisplay statusLcd;
 
     private volatile long startedAt;
+    private volatile long lastToastAt;
 
     protected CommandDevice(String typeId, String title, String tagline, Color accent, int units) {
         super(typeId, title, tagline, accent, units);
@@ -92,8 +97,36 @@ public abstract class CommandDevice extends RackDevice {
                 statusLcd.setText((ok ? "OK" : "FAIL [" + code + "]") + "  " + (elapsed / 1000.0) + "s");
             });
             onFinished(code);
+            if (!ok && !KILL_EXIT_CODES.contains(code)) {
+                toastFailure(code);
+            }
             emit(ok ? "ok" : "fail", Signal.trigger(ok));
             emit("done", Signal.trigger(ok));
+        });
+    }
+
+    /**
+     * Surfaces a real failure as an IDE notification balloon so a broken
+     * chained pipeline is noticed even with the rack window buried.
+     * Rate-limited per device; STOP-button kills never toast.
+     */
+    private void toastFailure(int code) {
+        long now = System.currentTimeMillis();
+        if (now - lastToastAt < 10_000) {
+            return;
+        }
+        lastToastAt = now;
+        onEdt(() -> {
+            try {
+                org.openide.awt.NotificationDisplayer.getDefault().notify(
+                        getTitle() + " failed (exit " + code + ")",
+                        javax.swing.UIManager.getIcon("OptionPane.errorIcon"),
+                        "Project: " + projectDir().getName()
+                                + " — see the \"Rack: " + getTitle() + "\" output tab",
+                        null);
+            } catch (RuntimeException | LinkageError ignored) {
+                // notification service unavailable (tests, stripped platform)
+            }
         });
     }
 

--- a/rack/src/main/java/org/nmox/studio/rack/devices/ConsoleDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/ConsoleDevice.java
@@ -23,7 +23,7 @@ public class ConsoleDevice extends RackDevice {
         super("console", "MONITOR", "OUTPUT CONSOLE", new Color(80, 200, 120), 3);
 
         int screenW = RackStyle.RACK_WIDTH - 2 * RackStyle.EAR_WIDTH - 160;
-        screen = place(new LcdDisplay(screenW, 6), RackStyle.EAR_WIDTH + 14, 42);
+        screen = place(new LcdDisplay(screenW, 8), RackStyle.EAR_WIDTH + 14, 42);
         RackButton clear = place(new RackButton("CLEAR", new Color(255, 190, 60)),
                 RackStyle.RACK_WIDTH - RackStyle.EAR_WIDTH - 130, 42);
         meter = place(new VuMeter("FEED", false), RackStyle.RACK_WIDTH - RackStyle.EAR_WIDTH - 130, 92);

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
@@ -11,6 +11,7 @@ import org.nmox.studio.rack.model.RackDevice;
 public enum DeviceType {
 
     MASTER("master", "MAESTRO", "Master Control — fire whole pipelines", new Color(240, 196, 25), MasterControlDevice::new),
+    REFLEX("reflex", "REFLEX", "File Watcher — fire pipelines on save", new Color(236, 106, 168), ReflexDevice::new),
     NPM_SCRIPT("npm-script", "NPM-9000", "Script Sequencer — run package.json scripts", new Color(203, 56, 55), NpmScriptDevice::new),
     PACKAGE_MANAGER("package-manager", "CRATE", "Package Manager — install & update deps", new Color(214, 121, 41), PackageManagerDevice::new),
     BUILD("build", "FORGE", "Build Engine — vite/webpack/rollup & co", new Color(232, 166, 35), BuildDevice::new),

--- a/rack/src/main/java/org/nmox/studio/rack/devices/ReflexDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/ReflexDevice.java
@@ -1,0 +1,124 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.nmox.studio.rack.engine.FileWatcher;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.ui.controls.Knob;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.Led;
+import org.nmox.studio.rack.ui.controls.ToggleSwitch;
+import org.nmox.studio.rack.ui.controls.VuMeter;
+
+/**
+ * REFLEX File Watcher: the automation keystone. Arm it and every save
+ * in the project fires the CHANGED trigger - patch it into VERITAS for
+ * a TDD loop, into PURITY for lint-on-save, or into FORGE for rebuilds
+ * with bundlers that have no watch mode of their own.
+ */
+public class ReflexDevice extends RackDevice {
+
+    private static final String[] FILTERS = {"all", "code", "styles", "docs"};
+    private static final List<Set<String>> FILTER_EXTENSIONS = List.of(
+            Set.of(),  // unused for "all"
+            Set.of("js", "jsx", "ts", "tsx", "mjs", "cjs", "vue", "svelte", "json"),
+            Set.of("css", "scss", "sass", "less", "styl"),
+            Set.of("html", "htm", "md", "mdx", "xml", "svg"));
+
+    private final ToggleSwitch armSwitch;
+    private final Knob filterKnob;
+    private final LcdDisplay lastChangeLcd;
+    private final Led eyeLed;
+    private final VuMeter meter;
+    private FileWatcher watcher;
+
+    public ReflexDevice() {
+        super("reflex", "REFLEX", "FILE WATCHER", new Color(236, 106, 168), 2);
+
+        armSwitch = place(new ToggleSwitch("WATCH", false), 44, 42);
+        filterKnob = place(new Knob("FILTER", FILTERS, 0), 118, 40);
+        lastChangeLcd = place(new LcdDisplay(300, 1), 196, 46);
+        lastChangeLcd.setText("DISARMED");
+        eyeLed = place(new Led("EYE", new Color(236, 106, 168)), 510, 52);
+        meter = place(new VuMeter("CHANGES", false), 560, 46);
+
+        armSwitch.addChangeListener(this::restartWatcher);
+        filterKnob.addChangeListener(this::restartWatcher);
+
+        addOutPort("changed", "CHANGED", SignalType.TRIGGER);
+        addOutPort("path", "PATH", SignalType.DATA);
+
+        param("armed", armSwitch);
+        param("filter", filterKnob);
+    }
+
+    @Override
+    protected void onAttached() {
+        restartWatcher();
+    }
+
+    @Override
+    public void projectChanged(File dir) {
+        restartWatcher();
+    }
+
+    private synchronized void restartWatcher() {
+        if (watcher != null) {
+            watcher.stop();
+            watcher = null;
+        }
+        boolean armed = armSwitch.isOn();
+        onEdt(() -> {
+            eyeLed.setBlinking(armed);
+            lastChangeLcd.setText(armed ? "WATCHING " + projectDir().getName() : "DISARMED");
+        });
+        if (!armed || getRack() == null) {
+            return;
+        }
+        int filter = filterKnob.getSelectedIndex();
+        Set<String> extensions = filter == 0 ? null : FILTER_EXTENSIONS.get(filter);
+        watcher = new FileWatcher(projectDir(), 1200, extensions, this::filesChanged);
+        watcher.start();
+    }
+
+    private void filesChanged(List<Path> changed) {
+        Path first = changed.get(0);
+        Path root = projectDir().toPath();
+        String shown;
+        try {
+            shown = root.relativize(first).toString();
+        } catch (IllegalArgumentException ex) {
+            shown = first.getFileName().toString();
+        }
+        if (changed.size() > 1) {
+            shown += "  (+" + (changed.size() - 1) + ")";
+        }
+        final String text = shown;
+        onEdt(() -> lastChangeLcd.setText(text));
+        meter.pulse(Math.min(1.0, 0.4 + changed.size() * 0.15));
+        emit("changed", Signal.trigger());
+        emit("path", Signal.data(first.toString()));
+    }
+
+    @Override
+    public void applyState(java.util.Map<String, String> state) {
+        super.applyState(state);
+        restartWatcher();
+    }
+
+    @Override
+    public void dispose() {
+        synchronized (this) {
+            if (watcher != null) {
+                watcher.stop();
+                watcher = null;
+            }
+        }
+        super.dispose();
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/engine/FileWatcher.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/FileWatcher.java
@@ -1,0 +1,155 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Watches a project tree for source changes by polling modification
+ * times. Polling (rather than WatchService) is deliberate: it behaves
+ * identically on every platform - macOS WatchService can lag multiple
+ * seconds and miss bursts - and the scan is cheap because the heavy
+ * directories (node_modules, .git, dist...) are skipped outright.
+ */
+public final class FileWatcher {
+
+    private static final Set<String> SKIP_DIRS = Set.of(
+            "node_modules", ".git", "dist", "build", "target", "out",
+            ".next", ".nuxt", ".svelte-kit", "coverage", ".cache", ".idea");
+    private static final int MAX_DEPTH = 12;
+    private static final int MAX_FILES = 50_000;
+
+    private final File root;
+    private final long intervalMs;
+    private final Set<String> extensions;   // lower-case, no dot; null = all files
+    private final Consumer<List<Path>> onChange;
+
+    private volatile boolean running;
+    private Thread thread;
+
+    /**
+     * @param root       directory to watch
+     * @param intervalMs poll interval
+     * @param extensions file extensions to track (null = every file)
+     * @param onChange   called on the watcher thread with changed paths
+     */
+    public FileWatcher(File root, long intervalMs, Set<String> extensions, Consumer<List<Path>> onChange) {
+        this.root = root;
+        this.intervalMs = Math.max(200, intervalMs);
+        this.extensions = extensions;
+        this.onChange = onChange;
+    }
+
+    public synchronized void start() {
+        if (running) {
+            return;
+        }
+        running = true;
+        thread = new Thread(() -> {
+            Map<Path, Long> baseline = scan();
+            while (running) {
+                try {
+                    Thread.sleep(intervalMs);
+                } catch (InterruptedException ex) {
+                    return;
+                }
+                if (!running) {
+                    return;
+                }
+                Map<Path, Long> current = scan();
+                List<Path> changed = diff(baseline, current);
+                baseline = current;
+                if (!changed.isEmpty() && running) {
+                    onChange.accept(changed);
+                }
+            }
+        }, "nmox-rack-watcher");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    public synchronized void stop() {
+        running = false;
+        if (thread != null) {
+            thread.interrupt();
+            thread = null;
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    private Map<Path, Long> scan() {
+        Map<Path, Long> result = new HashMap<>();
+        if (!root.isDirectory()) {
+            return result;
+        }
+        try {
+            Files.walkFileTree(root.toPath(), Set.of(), MAX_DEPTH, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    String name = dir.getFileName() == null ? "" : dir.getFileName().toString();
+                    if (SKIP_DIRS.contains(name) || name.startsWith(".") && !dir.equals(root.toPath())) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (result.size() >= MAX_FILES) {
+                        return FileVisitResult.TERMINATE;
+                    }
+                    if (matches(file)) {
+                        result.put(file, attrs.lastModifiedTime().toMillis());
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException ignored) {
+            // partial scan is fine; next poll catches up
+        }
+        return result;
+    }
+
+    private boolean matches(Path file) {
+        if (extensions == null) {
+            return true;
+        }
+        String name = file.getFileName().toString();
+        int dot = name.lastIndexOf('.');
+        return dot >= 0 && extensions.contains(name.substring(dot + 1).toLowerCase());
+    }
+
+    private static List<Path> diff(Map<Path, Long> before, Map<Path, Long> after) {
+        List<Path> changed = new ArrayList<>();
+        for (Map.Entry<Path, Long> e : after.entrySet()) {
+            Long old = before.get(e.getKey());
+            if (old == null || !old.equals(e.getValue())) {
+                changed.add(e.getKey());     // new or modified
+            }
+        }
+        for (Path p : before.keySet()) {
+            if (!after.containsKey(p)) {
+                changed.add(p);              // deleted
+            }
+        }
+        return changed;
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/model/Rack.java
+++ b/rack/src/main/java/org/nmox/studio/rack/model/Rack.java
@@ -47,6 +47,25 @@ public final class Rack {
     private volatile File projectDir = new File(System.getProperty("user.home"));
     private int cableColorCursor;
 
+    /** Dev servers and watchers must not outlive the IDE as orphans. */
+    private final Thread processReaper = new Thread(() -> {
+        for (RackDevice d : getDevices()) {
+            try {
+                d.panic();
+            } catch (RuntimeException ignored) {
+                // best effort during JVM shutdown
+            }
+        }
+    }, "nmox-rack-reaper");
+
+    public Rack() {
+        try {
+            Runtime.getRuntime().addShutdownHook(processReaper);
+        } catch (IllegalStateException ignored) {
+            // already shutting down
+        }
+    }
+
     // ---- devices ----
 
     public synchronized List<RackDevice> getDevices() {
@@ -247,5 +266,10 @@ public final class Rack {
             d.dispose();
         }
         router.shutdownNow();
+        try {
+            Runtime.getRuntime().removeShutdownHook(processReaper);
+        } catch (IllegalStateException ignored) {
+            // already shutting down
+        }
     }
 }

--- a/rack/src/main/java/org/nmox/studio/rack/ui/PalettePanel.java
+++ b/rack/src/main/java/org/nmox/studio/rack/ui/PalettePanel.java
@@ -76,6 +76,13 @@ public class PalettePanel extends JPanel {
         scroll.setBorder(BorderFactory.createEmptyBorder());
         scroll.getViewport().setBackground(RackStyle.RACK_BG);
         add(scroll, BorderLayout.CENTER);
+
+        JLabel hint = new JLabel("<html>Drag a device onto the rack &middot; Tab flips the rack"
+                + " &middot; drag jacks to patch cables</html>");
+        hint.setForeground(RackStyle.SILKSCREEN_DIM);
+        hint.setFont(RackStyle.TINY_FONT);
+        hint.setBorder(BorderFactory.createEmptyBorder(6, 10, 8, 10));
+        add(hint, BorderLayout.SOUTH);
         setPreferredSize(new Dimension(228, 400));
     }
 

--- a/rack/src/test/java/org/nmox/studio/rack/engine/FileWatcherTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/FileWatcherTest.java
@@ -1,0 +1,102 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileWatcherTest {
+
+    @TempDir
+    Path projectDir;
+
+    private FileWatcher watcher;
+
+    @AfterEach
+    void tearDown() {
+        if (watcher != null) {
+            watcher.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Should report a newly created source file")
+    void shouldReportNewFile() throws Exception {
+        CountDownLatch fired = new CountDownLatch(1);
+        List<Path> seen = new CopyOnWriteArrayList<>();
+        watcher = new FileWatcher(projectDir.toFile(), 200, null, changed -> {
+            seen.addAll(changed);
+            fired.countDown();
+        });
+        watcher.start();
+        Thread.sleep(400); // let the baseline scan settle
+
+        Path file = projectDir.resolve("index.js");
+        Files.writeString(file, "console.log('hi')");
+
+        assertThat(fired.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(seen).contains(file);
+    }
+
+    @Test
+    @DisplayName("Should ignore changes inside node_modules")
+    void shouldIgnoreNodeModules() throws Exception {
+        File nm = new File(projectDir.toFile(), "node_modules/leftpad");
+        assertThat(nm.mkdirs()).isTrue();
+
+        CountDownLatch fired = new CountDownLatch(1);
+        watcher = new FileWatcher(projectDir.toFile(), 200, null, changed -> fired.countDown());
+        watcher.start();
+        Thread.sleep(400);
+
+        Files.writeString(nm.toPath().resolve("index.js"), "module.exports = x => x");
+
+        assertThat(fired.await(1500, TimeUnit.MILLISECONDS))
+                .as("node_modules changes must not fire")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should respect the extension filter")
+    void shouldFilterByExtension() throws Exception {
+        CountDownLatch fired = new CountDownLatch(1);
+        List<Path> seen = new CopyOnWriteArrayList<>();
+        watcher = new FileWatcher(projectDir.toFile(), 200, Set.of("css"), changed -> {
+            seen.addAll(changed);
+            fired.countDown();
+        });
+        watcher.start();
+        Thread.sleep(400);
+
+        Files.writeString(projectDir.resolve("notes.txt"), "ignored");
+        Files.writeString(projectDir.resolve("style.css"), "body { margin: 0 }");
+
+        assertThat(fired.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(seen).containsExactly(projectDir.resolve("style.css"));
+    }
+
+    @Test
+    @DisplayName("Should stop cleanly and fire nothing afterwards")
+    void shouldStopCleanly() throws Exception {
+        CountDownLatch fired = new CountDownLatch(1);
+        watcher = new FileWatcher(projectDir.toFile(), 200, null, changed -> fired.countDown());
+        watcher.start();
+        Thread.sleep(300);
+        watcher.stop();
+
+        Files.writeString(projectDir.resolve("late.js"), "too late");
+
+        assertThat(watcher.isRunning()).isFalse();
+        assertThat(fired.await(1, TimeUnit.SECONDS)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #3: closes the gap between "impressive demo" and "tool you leave running all day". Five additions, each targeting a real daily-workflow need:

### 1. REFLEX File Watcher — the automation keystone
A new device that watches the project tree and fires its **CHANGED** trigger on every save (plus a **PATH** data jack with the changed file). Patch it into VERITAS for a TDD loop, PURITY for lint-on-save, or FORGE for rebuild-on-save. Polling-based by design — consistent across platforms where macOS WatchService lags — and it skips `node_modules`/`.git`/`dist`/build directories outright, with a FILTER knob (all / code / styles / docs).

### 2. Watch-mode aware FORGE
With WATCH on, the bundler process never exits — previously the rack only spoke on exit. FORGE now recognizes per-rebuild markers in the output (vite "built in", webpack/CRA "compiled successfully", rollup "created …", error variants) and fires **OK/FAIL on every rebuild** while the process lives. Save a file, and the change ripples down the cables.

### 3. Failure notifications
A device whose command genuinely fails (STOP-button kills excluded by exit code) raises an IDE notification balloon naming the device and its output tab — rate-limited to one per device per 10s, so a broken pipeline running buried under other windows gets noticed.

### 4. Zero-friction patch persistence
A project's `.nmoxrack.json` now mounts automatically whenever the rack aims at that project — on IDE project switch or manual selection. The patch travels with the repo like its `package.json`; the confirm dialog is gone.

### 5. No orphaned processes
A JVM shutdown hook kills every device's child processes (dev servers, file watchers) when the IDE quits — previously they could outlive it.

Also: MONITOR's screen grew to 8 lines, and the palette footer documents the three core gestures (drag to mount, Tab to flip, drag jacks to patch).

## Test plan
- `mvn test -pl rack -am` — 17 rack tests green, including 4 new FileWatcher tests (new-file detection, `node_modules` exclusion, extension filtering, clean stop)
- Existing catalog round-trip tests automatically cover the REFLEX device's creation and persistence
- Manual: rebuilt and relaunched the IDE; verified REFLEX appears on the shelf and the default pipeline still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)