### PR TITLE
Fix field bugs from first real-world rack use

### DIFF
--- a/rack/src/main/java/org/nmox/studio/rack/devices/BrowserDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BrowserDevice.java
@@ -25,7 +25,7 @@ public class BrowserDevice extends RackDevice {
         super("browser", "SCOPE", "BROWSER LINK", new Color(54, 174, 222), 2);
 
         urlLcd = place(new LcdDisplay(300, 1), 44, 46);
-        urlLcd.setText("http://localhost:3000");
+        urlLcd.setText("http://localhost:5173"); // matches SURGE's default port
         urlLcd.setEditable("URL to open");
         RackButton open = place(new RackButton("OPEN", new Color(80, 235, 100)), 354, 52);
         openedLed = place(new Led("SENT", new Color(64, 200, 255)), 422, 58);

--- a/rack/src/main/java/org/nmox/studio/rack/devices/CommandDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/CommandDevice.java
@@ -66,11 +66,28 @@ public abstract class CommandDevice extends RackDevice {
     }
 
     /**
+     * Whether this device only makes sense inside an npm project. When
+     * true (the default), launches are refused unless the project dir
+     * has a package.json - running eslint or npm install against the
+     * user's home directory is never what anyone wanted.
+     */
+    protected boolean requiresPackageJson() {
+        return true;
+    }
+
+    /**
      * Launches a command with the full standard treatment: LEDs, meter,
      * status LCD, OUT data per line, OK/FAIL/DONE triggers on exit.
      */
     protected void launch(List<String> command) {
         if (command == null || command.isEmpty()) {
+            return;
+        }
+        if (requiresPackageJson() && !new java.io.File(projectDir(), "package.json").isFile()) {
+            onEdt(() -> {
+                statusLcd.setTextColor(RackStyle.LCD_AMBER);
+                statusLcd.setText("NO PACKAGE.JSON — USE PROJECT… TO AIM THE RACK");
+            });
             return;
         }
         startedAt = System.currentTimeMillis();
@@ -121,9 +138,8 @@ public abstract class CommandDevice extends RackDevice {
                 org.openide.awt.NotificationDisplayer.getDefault().notify(
                         getTitle() + " failed (exit " + code + ")",
                         javax.swing.UIManager.getIcon("OptionPane.errorIcon"),
-                        "Project: " + projectDir().getName()
-                                + " — see the \"Rack: " + getTitle() + "\" output tab",
-                        null);
+                        "Project: " + projectDir().getName() + " — click to open the output",
+                        e -> org.nmox.studio.rack.engine.CommandExecutor.showOutput(getTitle()));
             } catch (RuntimeException | LinkageError ignored) {
                 // notification service unavailable (tests, stripped platform)
             }

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DevServerDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DevServerDevice.java
@@ -48,6 +48,13 @@ public class DevServerDevice extends CommandDevice {
         param("port", portKnob);
     }
 
+    /** Static servers (http-server, serve) happily serve plain folders. */
+    @Override
+    protected boolean requiresPackageJson() {
+        String server = serverKnob.getSelectedOption();
+        return !"http-server".equals(server) && !"serve".equals(server);
+    }
+
     private String port() {
         return PORTS[portKnob.getSelectedIndex()];
     }

--- a/rack/src/main/java/org/nmox/studio/rack/devices/GitDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/GitDevice.java
@@ -49,6 +49,12 @@ public class GitDevice extends CommandDevice {
         });
     }
 
+    /** Git works in any repository, package.json or not. */
+    @Override
+    protected boolean requiresPackageJson() {
+        return false;
+    }
+
     @Override
     protected void onAttached() {
         refreshBranch();

--- a/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
@@ -138,11 +138,21 @@ public final class CommandExecutor {
 
     private static InputOutput getIO(String tabName) {
         try {
-            InputOutput io = IOProvider.getDefault().getIO("Rack: " + tabName, false);
-            io.select();
-            return io;
+            // never select(): stealing focus on every run is hostile, and a
+            // select before the window system settles detaches the output
+            // into a broken floating window. The failure toast offers an
+            // explicit way in instead.
+            return IOProvider.getDefault().getIO("Rack: " + tabName, false);
         } catch (RuntimeException ex) {
             return null; // headless (tests) or window system not ready
+        }
+    }
+
+    /** Focuses a device's output tab - for explicit user requests only. */
+    public static void showOutput(String tabName) {
+        try {
+            IOProvider.getDefault().getIO("Rack: " + tabName, false).select();
+        } catch (RuntimeException ignored) {
         }
     }
 }

--- a/rack/src/test/java/org/nmox/studio/rack/devices/CommandDeviceGuardTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/CommandDeviceGuardTest.java
@@ -1,0 +1,83 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nmox.studio.rack.model.Rack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The project guard: web-tool devices must refuse to launch against a
+ * directory with no package.json (e.g. the rack still aimed at the
+ * user's home directory) instead of unleashing eslint/npm on it.
+ */
+class CommandDeviceGuardTest {
+
+    @TempDir
+    Path projectDir;
+
+    private static class EchoDevice extends CommandDevice {
+
+        final CountDownLatch finished = new CountDownLatch(1);
+        volatile int exitCode = Integer.MIN_VALUE;
+
+        EchoDevice() {
+            super("test-echo", "ECHO", "TEST", Color.GRAY, 2);
+        }
+
+        @Override
+        protected List<String> buildCommand() {
+            return List.of("echo", "hello");
+        }
+
+        @Override
+        protected void onFinished(int code) {
+            exitCode = code;
+            finished.countDown();
+        }
+    }
+
+    private static void flushEdt() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+        });
+    }
+
+    @Test
+    @DisplayName("Should refuse to launch without a package.json")
+    void shouldRefuseWithoutPackageJson() throws Exception {
+        Rack rack = new Rack();
+        rack.setProjectDir(projectDir.toFile());
+        EchoDevice device = new EchoDevice();
+        rack.addDevice(device);
+
+        device.primaryAction();
+        flushEdt();
+
+        assertThat(device.finished.await(500, TimeUnit.MILLISECONDS))
+                .as("command must not run").isFalse();
+        assertThat(device.statusLcd.getText()).contains("NO PACKAGE.JSON");
+    }
+
+    @Test
+    @DisplayName("Should launch normally when package.json exists")
+    void shouldLaunchWithPackageJson() throws Exception {
+        Files.writeString(projectDir.resolve("package.json"), "{\"name\":\"demo\"}");
+        Rack rack = new Rack();
+        rack.setProjectDir(projectDir.toFile());
+        EchoDevice device = new EchoDevice();
+        rack.addDevice(device);
+
+        device.primaryAction();
+
+        assertThat(device.finished.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(device.exitCode).isZero();
+    }
+}

--- a/ui/src/main/java/org/nmox/studio/ui/actions/NewProjectAction.java
+++ b/ui/src/main/java/org/nmox/studio/ui/actions/NewProjectAction.java
@@ -19,7 +19,7 @@ import org.openide.NotifyDescriptor;
         displayName = "#CTL_NewProjectAction"
 )
 @ActionReferences({
-    @ActionReference(path = "Menu/File", position = 100),
+    @ActionReference(path = "Menu/File", position = 110),
     @ActionReference(path = "Toolbars/File", position = 100),
     @ActionReference(path = "Shortcuts", name = "D-N")
 })

--- a/ui/src/main/java/org/nmox/studio/ui/actions/NewWebProjectAction.java
+++ b/ui/src/main/java/org/nmox/studio/ui/actions/NewWebProjectAction.java
@@ -19,7 +19,7 @@ import org.openide.util.NbBundle.Messages;
 @ActionRegistration(
         displayName = "#CTL_NewWebProjectAction"
 )
-@ActionReference(path = "Menu/File", position = 100)
+@ActionReference(path = "Menu/File", position = 120)
 @Messages("CTL_NewWebProjectAction=New Web Project...")
 public final class NewWebProjectAction implements ActionListener {
 


### PR DESCRIPTION
## Summary

Four bugs observed while actually using the Task Rack (screenshot-driven debugging):

1. **Output tab focus stealing / broken floating mini-window** — `CommandExecutor` called `io.select()` on every command launch, which stole focus each run and, when fired before the window system settled, detached the output into a tiny orphaned floating window at the screen corner. It no longer auto-selects; instead the **failure notification toast is now clickable** and focuses that device's output tab on demand.
2. **Devices ran against the home directory** — with the rack still aimed at `~`, pressing LINT ran `eslint .` across the entire home dir (3s, exit 2). Web-tool devices now refuse to launch when the target has no `package.json`, with an LCD message pointing at the Project… button. TIMELINE (git works in any repo) and SURGE's static-server modes (`http-server`/`serve` serve plain folders) are deliberately exempt.
3. **Default port mismatch** — SCOPE's URL defaulted to `localhost:3000` while SURGE's port knob defaults to `5173`; now consistent.
4. **Menu position collision** — New Project / New Web Project both claimed `Menu/File` position 100 (also colliding with the platform's own New Project), producing startup ordering warnings; now 110/120.

## Test plan
- New `CommandDeviceGuardTest` covers both sides of the launch guard (refusal without `package.json`, normal run with it)
- `mvn clean test` — full reactor green, 19 rack tests
- Manual: relaunched the IDE, confirmed no floating output window appears and an unaimed rack shows the LCD hint instead of running

🤖 Generated with [Claude Code](https://claude.com/claude-code)