### PR TITLE
DX pass: tools actually launch, prompts never hang, gates patch

### DIFF
--- a/rack/src/main/java/org/nmox/studio/rack/devices/CommandProbe.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/CommandProbe.java
@@ -23,7 +23,13 @@ final class CommandProbe {
         Thread t = new Thread(() -> {
             int code = -1;
             try {
-                Process p = new ProcessBuilder(command).directory(dir).redirectErrorStream(true).start();
+                ProcessBuilder pb = new ProcessBuilder(
+                        org.nmox.studio.rack.engine.ToolLocator.resolveCommand(command))
+                        .directory(dir)
+                        .redirectErrorStream(true);
+                pb.environment().put("PATH", org.nmox.studio.rack.engine.ToolLocator.augmentedPath());
+                pb.environment().put("GIT_TERMINAL_PROMPT", "0");
+                Process p = pb.start();
                 try (BufferedReader r = new BufferedReader(
                         new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
                     String line;

--- a/rack/src/main/java/org/nmox/studio/rack/devices/TempoDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/TempoDevice.java
@@ -46,6 +46,10 @@ public class TempoDevice extends RackDevice {
 
         addInPort("run", "RUN", SignalType.TRIGGER);
         addInPort("halt", "HALT", SignalType.TRIGGER);
+        // gate-driven clock: patch SURGE's RUNNING gate in and the clock
+        // ticks exactly while the dev server lives - health checks,
+        // recurring scans, whatever is cabled to TICK, only when it matters
+        addInPort("enable", "ENABLE", SignalType.GATE);
         addOutPort("tick", "TICK", SignalType.TRIGGER);
         addOutPort("bar", "BAR", SignalType.TRIGGER);
         addOutPort("running", "RUNNING", SignalType.GATE);
@@ -97,6 +101,7 @@ public class TempoDevice extends RackDevice {
         switch (in.getId()) {
             case "run" -> onEdt(() -> runSwitch.setOn(true));
             case "halt" -> onEdt(() -> runSwitch.setOn(false));
+            case "enable" -> onEdt(() -> runSwitch.setOn(signal.high()));
             default -> {
             }
         }

--- a/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
@@ -51,9 +51,19 @@ public final class CommandExecutor {
 
         Process process;
         try {
-            ProcessBuilder pb = new ProcessBuilder(command)
+            // resolve the tool against the augmented path: a Finder-launched
+            // IDE has a bare PATH with no node/npm/git on it
+            ProcessBuilder pb = new ProcessBuilder(ToolLocator.resolveCommand(command))
                     .directory(dir)
-                    .redirectErrorStream(true);
+                    .redirectErrorStream(true)
+                    // no terminal is attached: an interactive prompt would
+                    // hang forever, so give prompts an empty stdin instead
+                    .redirectInput(devNull());
+            pb.environment().put("PATH", ToolLocator.augmentedPath());
+            // belt and braces against prompts and ANSI art:
+            pb.environment().put("npm_config_yes", "true");   // npx auto-confirms downloads
+            pb.environment().put("GIT_TERMINAL_PROMPT", "0"); // git fails fast, never prompts
+            pb.environment().put("NO_COLOR", "1");            // tools that honor it skip ANSI
             pb.environment().putAll(env);
             process = pb.start();
         } catch (IOException ex) {
@@ -80,10 +90,11 @@ public final class CommandExecutor {
                     new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
+                    String clean = stripAnsi(line);
                     if (out != null) {
-                        out.println(line);
+                        out.println(clean);
                     }
-                    safeAccept(onLine, line);
+                    safeAccept(onLine, clean);
                 }
             } catch (IOException ignored) {
                 // stream closes when the process dies or is killed
@@ -126,6 +137,21 @@ public final class CommandExecutor {
                 return process.isAlive();
             }
         };
+    }
+
+    /** ANSI CSI/OSC escape sequences, e.g. color codes from vite/vitest. */
+    private static final java.util.regex.Pattern ANSI = java.util.regex.Pattern.compile(
+            "\\u001B(?:\\[[0-9;?]*[ -/]*[@-~]|\\][^\\u0007\\u001B]*(?:\\u0007|\\u001B\\\\)?)");
+
+    /** Removes ANSI escapes so LCDs and the output window show clean text. */
+    static String stripAnsi(String line) {
+        return line.indexOf('\u001B') < 0 ? line : ANSI.matcher(line).replaceAll("");
+    }
+
+    /** The platform's empty input stream (no terminal is attached). */
+    private static File devNull() {
+        return new File(System.getProperty("os.name", "").toLowerCase().contains("win")
+                ? "NUL" : "/dev/null");
     }
 
     private static void safeAccept(Consumer<String> onLine, String line) {

--- a/rack/src/main/java/org/nmox/studio/rack/engine/ToolLocator.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/ToolLocator.java
@@ -1,0 +1,134 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Finds developer tools when the IDE was launched from Finder or the
+ * Dock, where macOS hands GUI apps a bare PATH (/usr/bin:/bin:...)
+ * that contains neither node, npm nor git. Terminal launches never hit
+ * this, which is exactly why it ships broken so often.
+ *
+ * Two jobs:
+ *  - resolve a command name to an absolute path by scanning the real
+ *    PATH plus every common toolchain install location (Homebrew on
+ *    both architectures, nvm, volta, fnm, asdf, MacPorts)
+ *  - provide the augmented PATH so child processes (npm scripts that
+ *    spawn node, npx that spawns installed tools) resolve too
+ */
+public final class ToolLocator {
+
+    private static final Map<String, String> CACHE = new ConcurrentHashMap<>();
+    private static volatile String augmentedPath;
+
+    private ToolLocator() {
+    }
+
+    /**
+     * Resolves a command to an absolute path if it can be found in the
+     * augmented search path; otherwise returns the name unchanged and
+     * lets the OS try (and report) it.
+     */
+    public static String resolve(String command) {
+        if (command.contains(File.separator)) {
+            return command; // already a path
+        }
+        return CACHE.computeIfAbsent(command, name -> {
+            for (String dir : searchDirs()) {
+                File candidate = new File(dir, name);
+                if (candidate.isFile() && candidate.canExecute()) {
+                    return candidate.getAbsolutePath();
+                }
+                // Windows: PATHEXT resolution, the common two suffice here
+                File exe = new File(dir, name + ".exe");
+                if (exe.isFile()) {
+                    return exe.getAbsolutePath();
+                }
+                File cmd = new File(dir, name + ".cmd");
+                if (cmd.isFile()) {
+                    return cmd.getAbsolutePath();
+                }
+            }
+            return name;
+        });
+    }
+
+    /** A command list with its executable resolved. */
+    public static List<String> resolveCommand(List<String> command) {
+        if (command.isEmpty()) {
+            return command;
+        }
+        List<String> resolved = new ArrayList<>(command);
+        resolved.set(0, resolve(command.get(0)));
+        return resolved;
+    }
+
+    /** PATH including every toolchain dir that exists on this machine. */
+    public static String augmentedPath() {
+        String cached = augmentedPath;
+        if (cached == null) {
+            cached = String.join(File.pathSeparator, searchDirs());
+            augmentedPath = cached;
+        }
+        return cached;
+    }
+
+    private static List<String> searchDirs() {
+        Set<String> dirs = new LinkedHashSet<>();
+        String envPath = System.getenv("PATH");
+        if (envPath != null) {
+            dirs.addAll(Arrays.asList(envPath.split(File.pathSeparator)));
+        }
+        String home = System.getProperty("user.home");
+        // Homebrew (Apple Silicon, Intel), MacPorts, common Linux
+        dirs.add("/opt/homebrew/bin");
+        dirs.add("/usr/local/bin");
+        dirs.add("/opt/local/bin");
+        dirs.add("/usr/bin");
+        dirs.add("/bin");
+        // version managers: newest node first where versioned
+        addNewestVersionDir(dirs, new File(home, ".nvm/versions/node"), "bin");
+        dirs.add(home + "/.volta/bin");
+        addNewestVersionDir(dirs, new File(home, ".fnm/node-versions"), "installation/bin");
+        addNewestVersionDir(dirs, new File(home, ".asdf/installs/nodejs"), "bin");
+        dirs.add(home + "/.asdf/shims");
+        dirs.add(home + "/.local/bin");
+
+        List<String> existing = new ArrayList<>();
+        for (String d : dirs) {
+            if (d != null && !d.isBlank() && new File(d).isDirectory()) {
+                existing.add(d);
+            }
+        }
+        return existing;
+    }
+
+    /** Adds versionsRoot/&lt;newest&gt;/suffix if such a directory exists. */
+    private static void addNewestVersionDir(Set<String> dirs, File versionsRoot, String suffix) {
+        File[] versions = versionsRoot.listFiles(File::isDirectory);
+        if (versions == null || versions.length == 0) {
+            return;
+        }
+        Arrays.sort(versions, Comparator.comparing(File::getName).reversed());
+        for (File version : versions) {
+            File bin = new File(version, suffix);
+            if (bin.isDirectory()) {
+                dirs.add(bin.getAbsolutePath());
+                return;
+            }
+        }
+    }
+
+    /** Test hook: forget cached lookups (the filesystem changed). */
+    static void reset() {
+        CACHE.clear();
+        augmentedPath = null;
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/RackPresets.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/RackPresets.java
@@ -63,6 +63,25 @@ public enum RackPresets {
         }
     },
 
+    UPTIME_WATCH("Uptime Watch",
+            "While the dev server runs, TEMPO clocks PING health checks") {
+        @Override
+        void wire(Rack rack) {
+            RackDevice server = add(rack, DeviceType.DEV_SERVER, null);
+            RackDevice browser = add(rack, DeviceType.BROWSER, null);
+            // 30s health-check clock, gated by the server's RUNNING state
+            RackDevice tempo = add(rack, DeviceType.TEMPO, Map.of("rate", "2", "running", "false"));
+            RackDevice ping = add(rack, DeviceType.HTTP, null);
+            RackDevice console = add(rack, DeviceType.CONSOLE, null);
+            rack.connect(server.getPort("url"), browser.getPort("url"));
+            rack.connect(server.getPort("ready"), browser.getPort("open"));
+            rack.connect(server.getPort("running"), tempo.getPort("enable"));
+            rack.connect(server.getPort("url"), ping.getPort("url"));
+            rack.connect(tempo.getPort("tick"), ping.getPort("send"));
+            rack.connect(ping.getPort("body"), console.getPort("in"));
+        }
+    },
+
     SHIP_LANE("Ship Lane",
             "Prod build → security scan → armed deploy, with console trail") {
         @Override

--- a/rack/src/test/java/org/nmox/studio/rack/devices/TempoGateTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/TempoGateTest.java
@@ -1,0 +1,31 @@
+package org.nmox.studio.rack.devices;
+
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.rack.model.Signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The ENABLE gate makes GATE outputs (SURGE.RUNNING, WORMHOLE.LIVE)
+ * actually consumable: the clock runs exactly while the gate is high.
+ */
+class TempoGateTest {
+
+    @Test
+    @DisplayName("ENABLE gate high starts the clock, low stops it")
+    void gateDrivesTheClock() throws Exception {
+        TempoDevice tempo = new TempoDevice();
+
+        tempo.receive(tempo.getPort("enable"), Signal.gate(true));
+        SwingUtilities.invokeAndWait(() -> { });
+        assertThat(tempo.getState()).containsEntry("running", "true");
+
+        tempo.receive(tempo.getPort("enable"), Signal.gate(false));
+        SwingUtilities.invokeAndWait(() -> { });
+        assertThat(tempo.getState()).containsEntry("running", "false");
+
+        tempo.dispose();
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/engine/CommandExecutorTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/CommandExecutorTest.java
@@ -1,0 +1,60 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommandExecutorTest {
+
+    @Test
+    @DisplayName("Should strip ANSI color and OSC sequences")
+    void shouldStripAnsi() {
+        assertThat(CommandExecutor.stripAnsi("[32m✓ built in 1.2s[0m"))
+                .isEqualTo("✓ built in 1.2s");
+        assertThat(CommandExecutor.stripAnsi("]0;titleplain")).isEqualTo("plain");
+        assertThat(CommandExecutor.stripAnsi("no escapes")).isEqualTo("no escapes");
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    @DisplayName("Children must get the non-interactive guard environment")
+    void shouldInjectGuardEnvironment() throws Exception {
+        CountDownLatch done = new CountDownLatch(1);
+        StringBuilder output = new StringBuilder();
+        CommandExecutor.run("test", new File("."), Map.of(),
+                List.of("sh", "-c", "echo $npm_config_yes/$GIT_TERMINAL_PROMPT/$NO_COLOR"),
+                output::append, code -> done.countDown());
+
+        assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(output.toString()).isEqualTo("true/0/1");
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    @DisplayName("A command that reads stdin must finish instantly, not hang")
+    void shouldNotHangOnStdinReads() throws Exception {
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicInteger exit = new AtomicInteger(99);
+        CommandExecutor.run("test", new File("."), Map.of(),
+                List.of("sh", "-c", "read answer"),
+                line -> { }, code -> {
+                    exit.set(code);
+                    done.countDown();
+                });
+
+        // stdin is /dev/null: `read` sees EOF and fails immediately
+        assertThat(done.await(5, TimeUnit.SECONDS))
+                .as("process must not wait for interactive input")
+                .isTrue();
+        assertThat(exit.get()).isNotEqualTo(0);
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/engine/ToolLocatorTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/ToolLocatorTest.java
@@ -1,0 +1,60 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ToolLocatorTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    @DisplayName("Should resolve a standard tool to an absolute path")
+    void shouldResolveStandardTool() {
+        String resolved = ToolLocator.resolve("sh");
+        assertThat(resolved).startsWith("/");
+        assertThat(new File(resolved)).exists();
+    }
+
+    @Test
+    @DisplayName("Should leave unknown tools unchanged for the OS to report")
+    void shouldLeaveUnknownToolsAlone() {
+        assertThat(ToolLocator.resolve("definitely-not-a-real-tool-xyz"))
+                .isEqualTo("definitely-not-a-real-tool-xyz");
+    }
+
+    @Test
+    @DisplayName("Should not touch commands that are already paths")
+    void shouldNotTouchAbsolutePaths() {
+        String path = File.separator + "opt" + File.separator + "thing";
+        assertThat(ToolLocator.resolve(path)).isEqualTo(path);
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    @DisplayName("Should resolve only the executable of a command line")
+    void shouldResolveCommandHead() {
+        List<String> resolved = ToolLocator.resolveCommand(List.of("sh", "-c", "echo hi"));
+        assertThat(resolved.get(0)).startsWith("/");
+        assertThat(resolved.subList(1, 3)).containsExactly("-c", "echo hi");
+    }
+
+    @Test
+    @DisplayName("Augmented PATH must include every existing PATH entry")
+    void augmentedPathKeepsExistingEntries() {
+        String envPath = System.getenv("PATH");
+        if (envPath == null) {
+            return;
+        }
+        String augmented = ToolLocator.augmentedPath();
+        for (String dir : envPath.split(File.pathSeparator)) {
+            if (!dir.isBlank() && new File(dir).isDirectory()) {
+                assertThat(augmented).contains(dir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A deep logical pass on what a developer needs **actually working** — every finding here was invisible in our terminal-launched testing and would have hit real users immediately:

### 1. The IDE couldn't find node/npm/git when launched from Finder
macOS hands GUI apps a bare `PATH` (`/usr/bin:/bin:...`). Launched from the Dock, **every single device** failed with "launch failed: Cannot run program npm". New `ToolLocator` resolves executables against the real PATH plus Homebrew (Intel + Apple Silicon), nvm, volta, fnm, asdf, and MacPorts install locations — and exports that augmented PATH to child processes so npm scripts and npx spawns resolve their own tools too. Git status probes routed through it as well.

### 2. Interactive prompts hung forever
No terminal is attached, so `npx`'s "Ok to proceed? (y)" and git credential prompts blocked eternally behind a blinking RUN LED. Now: stdin from `/dev/null`, `npm_config_yes=true` (npx auto-confirms), `GIT_TERMINAL_PROMPT=0` (git fails fast with a real error instead of waiting for input that can never come).

### 3. ANSI escape garbage on the LCDs
vite/vitest/eslint colorize output; MONITOR and PHOSPHOR showed raw `[32m` codes. `NO_COLOR=1` asks tools to stop; a central stripper in the output pump enforces it for tools that don't listen.

### 4. Gate signals had nowhere to go
SURGE.RUNNING, WORMHOLE.LIVE and TEMPO.RUNNING emitted gates, but **no device had a gate input** — blue cables literally couldn't be patched. TEMPO grew an **ENABLE** gate jack (clock runs exactly while the gate is high), and a new **Uptime Watch** preset demonstrates the pattern: server RUNNING gates the clock, the clock ticks PING health checks, responses scroll on the console — and it all winds down by itself when the server stops.

## Test plan
- 9 new tests: tool resolution, guard-env injection into real child processes, stdin non-hang (a `read` exits instantly instead of blocking), ANSI stripping, gate-driven clocking
- 123 rack tests green; full reactor green; IDE relaunched with all fixes live

🤖 Generated with [Claude Code](https://claude.com/claude-code)