### PR TITLE
Infra Designer: Node-RED-style DigitalOcean networking designer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ NMOX-Studio/
 ├── editor/                  # File type support, JavaScript lexer, syntax highlighting, completion
 ├── tools/                   # NPM integration, build tools, debugging, test runners
 ├── rack/                    # Reason-style task rack: drag-drop device wiring, control surfaces
+├── infra/                   # Node-RED-style DigitalOcean infrastructure designer
 ├── project/                 # Project templates, scaffolding, project explorer UI
 ├── ui/                      # Main windows, actions, welcome screen, startup logic
 ├── branding/               # Application theming, splash screen, icons
@@ -112,6 +113,7 @@ NMOX-Studio/
 | **editor** | File editing and language support | `JavaScriptLexer`, `JavaScriptDataObject`, `TypeScriptDataObject`, completion providers |
 | **tools** | Development tools and integrations | `NpmService`, `WebProjectFactory`, `BuildToolService`, `TestRunnerService` |
 | **rack** | Reason-style virtual task rack + project lifecycle | `RackTopComponent`, `Rack`/`RackDevice` model, 23 task devices (incl. ROSETTA mixed-repo selector, IGNITION polyglot runtime, INSPECTOR debug launcher, TEMPO clock, TYPEGUARD tsc, WORMHOLE tunnel, GAUNTLET bench, PHOSPHOR terminal), patch-cable wiring, `FileWatcher`, `RackIO` persistence, `RackService`, `ProjectStudioTopComponent` (templates, file CRUD, package.json editor, presets) |
+| **infra** | DigitalOcean infra designer | `InfraDesignerTopComponent`, `NodeKind` catalog (22 DO offerings), `FlowCanvas`, `DeployPlanner`, `DigitalOceanClient`, cost estimation, `.nmoxinfra.json` persistence |
 | **project** | Project management | `ProjectExplorerTopComponent`, `WebProject`, wizards |
 | **ui** | Core UI components | `MainWindow`, `WelcomeScreen`, `StartupInitializer`, actions |
 | **branding** | Application identity | Splash screen, icons, custom branding |

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -91,6 +91,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>NMOX-Studio-infra</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>NMOX-Studio-sample</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/infra/pom.xml
+++ b/infra/pom.xml
@@ -9,20 +9,23 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>NMOX-Studio-rack</artifactId>
+    <artifactId>NMOX-Studio-infra</artifactId>
     <packaging>nbm</packaging>
-    <name>NMOX Studio Rack</name>
-    <description>Reason-style virtual rack: drag-and-drop wiring of web development task devices with hardware control surfaces</description>
+    <name>NMOX Studio Infra</name>
+    <description>Node-RED-style infrastructure designer wired to the DigitalOcean API</description>
 
     <dependencies>
-        <!-- NMOX Studio modules -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>NMOX-Studio-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>NMOX-Studio-rack</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
-        <!-- NetBeans Platform APIs -->
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-api-annotations-common</artifactId>
@@ -55,17 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
-            <artifactId>org-openide-filesystems</artifactId>
-            <version>${netbeans.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-dialogs</artifactId>
-            <version>${netbeans.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
-            <artifactId>org-openide-io</artifactId>
             <version>${netbeans.version}</version>
         </dependency>
         <dependency>
@@ -73,35 +66,13 @@
             <artifactId>org-netbeans-modules-settings</artifactId>
             <version>${netbeans.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
-            <artifactId>org-netbeans-modules-projectapi</artifactId>
-            <version>${netbeans.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
-            <artifactId>org-netbeans-modules-projectuiapi-base</artifactId>
-            <version>${netbeans.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
-            <artifactId>org-openide-loaders</artifactId>
-            <version>${netbeans.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
-            <artifactId>org-openide-nodes</artifactId>
-            <version>${netbeans.version}</version>
-        </dependency>
 
-        <!-- JSON for patch persistence -->
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20231013</version>
         </dependency>
 
-        <!-- Testing dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -123,10 +94,8 @@
                 <artifactId>nbm-maven-plugin</artifactId>
                 <configuration>
                     <publicPackages>
-                        <publicPackage>org.nmox.studio.rack.model</publicPackage>
-                        <publicPackage>org.nmox.studio.rack.devices</publicPackage>
-                        <publicPackage>org.nmox.studio.rack.service</publicPackage>
-                        <publicPackage>org.nmox.studio.rack.engine</publicPackage>
+                        <publicPackage>org.nmox.studio.infra.model</publicPackage>
+                        <publicPackage>org.nmox.studio.infra.api</publicPackage>
                     </publicPackages>
                 </configuration>
             </plugin>

--- a/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
+++ b/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
@@ -1,0 +1,325 @@
+package org.nmox.studio.infra;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Point;
+import java.io.File;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JPasswordField;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import org.netbeans.api.settings.ConvertAsProperties;
+import org.nmox.studio.infra.api.DeployPlanner;
+import org.nmox.studio.infra.api.DigitalOceanClient;
+import org.nmox.studio.infra.api.DoRequest;
+import org.nmox.studio.infra.model.GraphIO;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.InfraGraph.InfraNode;
+import org.nmox.studio.infra.ui.FlowCanvas;
+import org.nmox.studio.infra.ui.InfraPalette;
+import org.nmox.studio.infra.ui.PropertyPanel;
+import org.nmox.studio.rack.service.RackService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.util.NbBundle.Messages;
+import org.openide.windows.TopComponent;
+
+/**
+ * The Infra Designer: DigitalOcean's catalog as a Node-RED-style flow.
+ * Drag offerings from the palette, wire relationships, watch the cost
+ * meter, then hit DEPLOY - dry-run plan without a token, real API
+ * calls with one. The design persists with the project, exactly like
+ * the rack patch.
+ */
+@ConvertAsProperties(dtd = "-//org.nmox.studio.infra//InfraDesigner//EN", autostore = false)
+@TopComponent.Description(preferredID = "InfraDesignerTopComponent",
+        persistenceType = TopComponent.PERSISTENCE_ALWAYS)
+@TopComponent.Registration(mode = "editor", openAtStartup = false)
+@ActionID(category = "Window", id = "org.nmox.studio.infra.InfraDesignerTopComponent")
+@ActionReference(path = "Menu/Window", position = 260)
+@TopComponent.OpenActionRegistration(displayName = "#CTL_InfraAction",
+        preferredID = "InfraDesignerTopComponent")
+@Messages({
+    "CTL_InfraAction=Infra Designer",
+    "CTL_InfraTopComponent=Infra Designer",
+    "HINT_InfraTopComponent=Drag-and-drop DigitalOcean infrastructure designer"
+})
+public final class InfraDesignerTopComponent extends TopComponent {
+
+    private final InfraGraph graph = new InfraGraph();
+    private final DigitalOceanClient client = new DigitalOceanClient();
+    private final FlowCanvas canvas;
+    private final PropertyPanel properties;
+    private final JLabel tokenLabel = new JLabel();
+    private final JLabel costLabel = new JLabel();
+    private final Timer saveDebounce;
+    private boolean loading;
+
+    public InfraDesignerTopComponent() {
+        setName(org.openide.util.NbBundle.getMessage(InfraDesignerTopComponent.class, "CTL_InfraTopComponent"));
+        setToolTipText(org.openide.util.NbBundle.getMessage(InfraDesignerTopComponent.class, "HINT_InfraTopComponent"));
+        setLayout(new BorderLayout());
+
+        properties = new PropertyPanel(graph);
+        canvas = new FlowCanvas(graph, new FlowCanvas.Callbacks() {
+            @Override
+            public void nodeDoubleClicked(InfraNode node) {
+                properties.show(node);
+            }
+
+            @Override
+            public void nodeContextMenu(InfraNode node, Point screenPoint) {
+                showNodeMenu(node, screenPoint);
+            }
+
+            @Override
+            public void selectionChanged(InfraNode node) {
+                properties.show(node);
+            }
+        });
+
+        add(new InfraPalette(graph), BorderLayout.WEST);
+        add(canvas, BorderLayout.CENTER);
+        add(properties, BorderLayout.EAST);
+        add(buildToolbar(), BorderLayout.NORTH);
+
+        saveDebounce = new Timer(1000, e -> save());
+        saveDebounce.setRepeats(false);
+        graph.addListener(new InfraGraph.Listener() {
+            @Override
+            public void graphChanged() {
+                SwingUtilities.invokeLater(() -> {
+                    refreshCost();
+                    if (!loading) {
+                        saveDebounce.restart();
+                    }
+                });
+            }
+        });
+
+        RackService.getDefault().getRack().addListener(new org.nmox.studio.rack.model.Rack.Listener() {
+            @Override
+            public void projectChanged() {
+                SwingUtilities.invokeLater(InfraDesignerTopComponent.this::load);
+            }
+        });
+        load();
+        refreshToken();
+        refreshCost();
+    }
+
+    private JToolBar buildToolbar() {
+        JToolBar bar = new JToolBar();
+        bar.setFloatable(false);
+
+        JButton token = new JButton("Token…");
+        token.setToolTipText("Set the DigitalOcean API token (or export DIGITALOCEAN_TOKEN)");
+        token.addActionListener(e -> {
+            JPasswordField field = new JPasswordField(32);
+            int ok = JOptionPane.showConfirmDialog(this, field,
+                    "DigitalOcean API token (stored in IDE settings)",
+                    JOptionPane.OK_CANCEL_OPTION);
+            if (ok == JOptionPane.OK_OPTION) {
+                DigitalOceanClient.storeToken(new String(field.getPassword()).trim());
+                refreshToken();
+            }
+        });
+        bar.add(token);
+        tokenLabel.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 12));
+        bar.add(tokenLabel);
+
+        JButton sync = new JButton("Sync from cloud");
+        sync.setToolTipText("Import existing DigitalOcean resources as live nodes");
+        sync.addActionListener(e -> syncFromCloud());
+        bar.add(sync);
+
+        JButton fit = new JButton("Fit");
+        fit.addActionListener(e -> canvas.fit());
+        bar.add(fit);
+
+        bar.add(javax.swing.Box.createHorizontalGlue());
+
+        costLabel.setFont(new Font(Font.MONOSPACED, Font.BOLD, 12));
+        costLabel.setForeground(new Color(0x4E, 0xC9, 0x8B));
+        costLabel.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 12));
+        bar.add(costLabel);
+
+        // THE button, Node-RED red
+        JButton deploy = new JButton("DEPLOY");
+        deploy.setBackground(new Color(0xC6, 0x2B, 0x2B));
+        deploy.setForeground(Color.WHITE);
+        deploy.setOpaque(true);
+        deploy.setBorderPainted(false);
+        deploy.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 12));
+        deploy.setToolTipText("Create everything in this design via the DigitalOcean API");
+        deploy.addActionListener(e -> deploy());
+        bar.add(deploy);
+        return bar;
+    }
+
+    // ---- deploy ----
+
+    private void deploy() {
+        List<DoRequest> plan = DeployPlanner.plan(graph);
+        if (plan.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Nothing to deploy - the design is empty or all live.",
+                    "Infra Designer", JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+        StringBuilder text = new StringBuilder();
+        int step = 1;
+        for (DoRequest request : plan) {
+            text.append(String.format("%2d. %s %s%n      %s%n", step++,
+                    request.skipped() ? "SKIP" : request.method(),
+                    request.skipped() ? "" : request.path(),
+                    request.description()));
+        }
+        text.append(String.format("%nEstimated monthly cost: $%.2f", graph.totalMonthlyUsd()));
+
+        JTextArea area = new JTextArea(text.toString(), 18, 64);
+        area.setEditable(false);
+        area.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+
+        boolean live = DigitalOceanClient.hasToken();
+        String title = live ? "Deploy to DigitalOcean?" : "Dry run (no API token set)";
+        Object[] options = live ? new Object[]{"Deploy", "Cancel"} : new Object[]{"Close"};
+        int choice = JOptionPane.showOptionDialog(this, new JScrollPane(area), title,
+                JOptionPane.DEFAULT_OPTION, live ? JOptionPane.WARNING_MESSAGE : JOptionPane.INFORMATION_MESSAGE,
+                null, options, options[0]);
+        if (!live || choice != 0) {
+            return;
+        }
+        Thread worker = new Thread(() -> {
+            boolean ok = client.execute(plan, graph, (node, message) -> {
+                if (node != null) {
+                    graph.setStatus(node, message);
+                }
+            });
+            SwingUtilities.invokeLater(() -> {
+                save();
+                JOptionPane.showMessageDialog(this,
+                        ok ? "Deploy complete - nodes are live." : "Deploy stopped on a failure; see node status.",
+                        "Infra Designer", ok ? JOptionPane.INFORMATION_MESSAGE : JOptionPane.ERROR_MESSAGE);
+            });
+        }, "nmox-infra-deploy");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private void syncFromCloud() {
+        if (!DigitalOceanClient.hasToken()) {
+            JOptionPane.showMessageDialog(this, "Set an API token first.", "Infra Designer",
+                    JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+        Thread worker = new Thread(() -> {
+            try {
+                int imported = client.sync(graph);
+                SwingUtilities.invokeLater(() -> {
+                    canvas.fit();
+                    save();
+                    JOptionPane.showMessageDialog(this, "Imported " + imported + " live resources.",
+                            "Infra Designer", JOptionPane.INFORMATION_MESSAGE);
+                });
+            } catch (Exception ex) {
+                SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this,
+                        "Sync failed: " + ex.getMessage(), "Infra Designer", JOptionPane.ERROR_MESSAGE));
+            }
+        }, "nmox-infra-sync");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private void showNodeMenu(InfraNode node, Point screenPoint) {
+        JPopupMenu menu = new JPopupMenu();
+        if (node.doId != null) {
+            JMenuItem destroy = new JMenuItem("Destroy in cloud (" + node.doId + ")");
+            destroy.addActionListener(e -> {
+                if (JOptionPane.showConfirmDialog(this,
+                        "Really destroy " + node.kind.getDisplayName() + " " + node.label + " on DigitalOcean?",
+                        "Destroy resource", JOptionPane.YES_NO_OPTION,
+                        JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+                    Thread worker = new Thread(() -> {
+                        try {
+                            client.destroy(node);
+                            graph.setStatus(node, "destroyed");
+                            SwingUtilities.invokeLater(this::save);
+                        } catch (Exception ex) {
+                            graph.setStatus(node, "destroy failed: " + ex.getMessage());
+                        }
+                    }, "nmox-infra-destroy");
+                    worker.setDaemon(true);
+                    worker.start();
+                }
+            });
+            menu.add(destroy);
+            menu.addSeparator();
+        }
+        JMenuItem remove = new JMenuItem("Remove from design");
+        remove.addActionListener(e -> graph.removeNode(node));
+        menu.add(remove);
+        Point local = new Point(screenPoint);
+        SwingUtilities.convertPointFromScreen(local, canvas);
+        menu.show(canvas, local.x, local.y);
+    }
+
+    // ---- persistence & labels ----
+
+    private File designFile() {
+        return new File(RackService.getDefault().getRack().getProjectDir(), GraphIO.DEFAULT_FILENAME);
+    }
+
+    private void load() {
+        loading = true;
+        try {
+            File file = designFile();
+            if (file.isFile()) {
+                GraphIO.load(graph, file);
+            } else {
+                graph.clear();
+            }
+            canvas.fit();
+        } catch (Exception ex) {
+            // unreadable design: start clean rather than block the window
+            graph.clear();
+        } finally {
+            loading = false;
+            refreshCost();
+        }
+    }
+
+    private void save() {
+        try {
+            GraphIO.save(graph, designFile());
+        } catch (Exception ex) {
+            // disk hiccup; the next change retries
+        }
+    }
+
+    private void refreshToken() {
+        boolean has = DigitalOceanClient.hasToken();
+        tokenLabel.setText(has ? "● connected" : "○ no token (dry-run)");
+        tokenLabel.setForeground(has ? new Color(0x4E, 0xC9, 0x8B) : new Color(0xE8, 0xC4, 0x4A));
+    }
+
+    private void refreshCost() {
+        costLabel.setText(String.format("≈ $%.2f/mo", graph.totalMonthlyUsd()));
+    }
+
+    void writeProperties(java.util.Properties p) {
+        p.setProperty("version", "1.0");
+    }
+
+    void readProperties(java.util.Properties p) {
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/api/DeployPlanner.java
+++ b/infra/src/main/java/org/nmox/studio/infra/api/DeployPlanner.java
@@ -1,0 +1,377 @@
+package org.nmox.studio.infra.api;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.InfraGraph.InfraNode;
+import org.nmox.studio.infra.model.InfraGraph.Wire;
+import org.nmox.studio.infra.model.NodeKind;
+
+/**
+ * Turns a design into an ordered list of API calls: a topological sort
+ * over creation dependencies (a droplet needs its VPC's id at create
+ * time), followed by post-create attachments (a volume attaches to a
+ * droplet only after both exist). Pure function of the graph - the
+ * dry-run plan and the live deploy run the identical list.
+ */
+public final class DeployPlanner {
+
+    private DeployPlanner() {
+    }
+
+    public static List<DoRequest> plan(InfraGraph graph) {
+        List<InfraNode> ordered = topologicalOrder(graph);
+        List<DoRequest> requests = new ArrayList<>();
+        for (InfraNode node : ordered) {
+            if (node.doId != null) {
+                continue; // already live in the cloud
+            }
+            requests.add(creationRequest(graph, node));
+        }
+        // attachments after every creation
+        for (Wire wire : graph.getWires()) {
+            InfraNode from = graph.node(wire.fromId());
+            InfraNode to = graph.node(wire.toId());
+            if (from != null && to != null && from.kind.attachesTo(to.kind)) {
+                requests.add(attachmentRequest(from, to));
+            }
+        }
+        return requests;
+    }
+
+    /** Kahn's algorithm over creation-dependency edges (stable order). */
+    private static List<InfraNode> topologicalOrder(InfraGraph graph) {
+        List<InfraNode> nodes = graph.getNodes();
+        Map<String, Integer> indegree = new LinkedHashMap<>();
+        Map<String, List<String>> consumers = new HashMap<>();
+        for (InfraNode n : nodes) {
+            indegree.put(n.id, 0);
+        }
+        for (Wire w : graph.getWires()) {
+            InfraNode from = graph.node(w.fromId());
+            InfraNode to = graph.node(w.toId());
+            if (from == null || to == null || from.kind.attachesTo(to.kind)) {
+                continue; // attachments don't constrain creation order
+            }
+            indegree.merge(w.toId(), 1, Integer::sum);
+            consumers.computeIfAbsent(w.fromId(), k -> new ArrayList<>()).add(w.toId());
+        }
+        Deque<String> ready = new ArrayDeque<>();
+        indegree.forEach((id, deg) -> {
+            if (deg == 0) {
+                ready.add(id);
+            }
+        });
+        List<InfraNode> ordered = new ArrayList<>();
+        while (!ready.isEmpty()) {
+            String id = ready.poll();
+            ordered.add(graph.node(id));
+            for (String next : consumers.getOrDefault(id, List.of())) {
+                if (indegree.merge(next, -1, Integer::sum) == 0) {
+                    ready.add(next);
+                }
+            }
+        }
+        // cycles are impossible by construction (rules are a DAG), but
+        // append any stragglers rather than silently dropping them
+        for (InfraNode n : nodes) {
+            if (!ordered.contains(n)) {
+                ordered.add(n);
+            }
+        }
+        return ordered;
+    }
+
+    private static String idOf(InfraNode node) {
+        return node.doId != null ? node.doId : "${id-of:" + node.id + "}";
+    }
+
+    private static DoRequest creationRequest(InfraGraph graph, InfraNode node) {
+        Map<String, String> p = node.props;
+        List<InfraNode> providers = graph.providersOf(node);
+        JSONObject body = new JSONObject();
+        return switch (node.kind) {
+            case VPC -> {
+                body.put("name", node.label).put("region", p.get("region"))
+                        .put("ip_range", p.get("ipRange"));
+                yield DoRequest.post("/v2/vpcs", body, node.id, "Create VPC " + node.label);
+            }
+            case DROPLET, GPU_DROPLET -> {
+                body.put("name", node.label)
+                        .put("region", p.get("region"))
+                        .put("size", p.get("size"))
+                        .put("image", p.get("image"));
+                if (node.kind == NodeKind.DROPLET) {
+                    body.put("backups", Boolean.parseBoolean(p.getOrDefault("backups", "false")))
+                            .put("monitoring", Boolean.parseBoolean(p.getOrDefault("monitoring", "true")));
+                }
+                JSONArray keys = new JSONArray();
+                for (InfraNode prov : providers) {
+                    if (prov.kind == NodeKind.VPC) {
+                        body.put("vpc_uuid", idOf(prov));
+                    } else if (prov.kind == NodeKind.SSH_KEY) {
+                        keys.put(idOf(prov));
+                    }
+                }
+                if (!keys.isEmpty()) {
+                    body.put("ssh_keys", keys);
+                }
+                yield DoRequest.post("/v2/droplets", body, node.id,
+                        "Create " + node.kind.getDisplayName() + " " + node.label
+                        + " (" + p.get("size") + ", " + p.get("region") + ")");
+            }
+            case KUBERNETES -> {
+                JSONObject pool = new JSONObject()
+                        .put("size", p.get("nodeSize"))
+                        .put("name", node.label + "-pool")
+                        .put("count", Integer.parseInt(p.getOrDefault("nodeCount", "3")))
+                        .put("auto_scale", Boolean.parseBoolean(p.getOrDefault("autoscale", "false")));
+                body.put("name", node.label).put("region", p.get("region"))
+                        .put("version", "latest")
+                        .put("ha", Boolean.parseBoolean(p.getOrDefault("ha", "false")))
+                        .put("node_pools", new JSONArray().put(pool));
+                for (InfraNode prov : providers) {
+                    if (prov.kind == NodeKind.VPC) {
+                        body.put("vpc_uuid", idOf(prov));
+                    }
+                }
+                yield DoRequest.post("/v2/kubernetes/clusters", body, node.id,
+                        "Create Kubernetes cluster " + node.label);
+            }
+            case LOAD_BALANCER -> {
+                String[] rule = p.getOrDefault("forwardingRule", "http-80").split("-");
+                JSONObject forwarding = new JSONObject()
+                        .put("entry_protocol", rule[0]).put("entry_port", Integer.parseInt(rule[1]))
+                        .put("target_protocol", "http").put("target_port", 80);
+                body.put("name", node.label).put("region", p.get("region"))
+                        .put("size_unit", 1)
+                        .put("forwarding_rules", new JSONArray().put(forwarding))
+                        .put("health_check", new JSONObject()
+                                .put("protocol", "http").put("port", 80)
+                                .put("path", p.getOrDefault("healthPath", "/")));
+                JSONArray dropletIds = new JSONArray();
+                for (InfraNode prov : providers) {
+                    switch (prov.kind) {
+                        case DROPLET, GPU_DROPLET -> dropletIds.put(idOf(prov));
+                        case VPC -> body.put("vpc_uuid", idOf(prov));
+                        case CERTIFICATE -> forwarding
+                                .put("certificate_id", idOf(prov))
+                                .put("entry_protocol", "https").put("entry_port", 443);
+                        default -> {
+                        }
+                    }
+                }
+                if (!dropletIds.isEmpty()) {
+                    body.put("droplet_ids", dropletIds);
+                }
+                yield DoRequest.post("/v2/load_balancers", body, node.id,
+                        "Create load balancer " + node.label);
+            }
+            case FIREWALL -> {
+                body.put("name", node.label)
+                        .put("inbound_rules", rules(p.getOrDefault("inbound", ""), "sources"))
+                        .put("outbound_rules", rules(p.getOrDefault("outbound", "all/0.0.0.0/0"), "destinations"));
+                yield DoRequest.post("/v2/firewalls", body, node.id,
+                        "Create firewall " + node.label);
+            }
+            case VOLUME -> {
+                body.put("name", node.label).put("region", p.get("region"))
+                        .put("size_gigabytes", Integer.parseInt(p.getOrDefault("sizeGb", "100")))
+                        .put("filesystem_type", p.getOrDefault("fs", "ext4"));
+                yield DoRequest.post("/v2/volumes", body, node.id,
+                        "Create " + p.get("sizeGb") + "GiB volume " + node.label);
+            }
+            case RESERVED_IP -> {
+                body.put("region", p.get("region"));
+                yield DoRequest.post("/v2/reserved_ips", body, node.id, "Reserve IP");
+            }
+            case DOMAIN -> {
+                String target = "192.0.2.1";
+                for (InfraNode prov : providers) {
+                    target = prov.kind == NodeKind.LOAD_BALANCER ? "${ip-of:" + prov.id + "}"
+                            : "${ip-of:" + prov.id + "}";
+                }
+                body.put("name", p.get("name")).put("ip_address", target);
+                yield DoRequest.post("/v2/domains", body, node.id,
+                        "Create domain " + p.get("name") + " -> " + target);
+            }
+            case CDN -> {
+                String origin = node.label + ".nyc3.digitaloceanspaces.com";
+                for (InfraNode prov : providers) {
+                    if (prov.kind == NodeKind.SPACES) {
+                        origin = prov.props.getOrDefault("bucket", "bucket")
+                                + "." + prov.props.getOrDefault("region", "nyc3")
+                                + ".digitaloceanspaces.com";
+                    }
+                }
+                body.put("origin", origin).put("ttl", Integer.parseInt(p.getOrDefault("ttl", "3600")));
+                for (InfraNode prov : providers) {
+                    if (prov.kind == NodeKind.CERTIFICATE) {
+                        body.put("certificate_id", idOf(prov));
+                    }
+                }
+                yield DoRequest.post("/v2/cdn/endpoints", body, node.id,
+                        "Create CDN endpoint for " + origin);
+            }
+            case SPACES -> DoRequest.skip(node.id,
+                    "Spaces bucket '" + p.get("bucket") + "' uses the S3 protocol - create via "
+                    + "s3cmd/aws-cli against " + p.get("region") + ".digitaloceanspaces.com");
+            case CONTAINER_REGISTRY -> {
+                body.put("name", node.label)
+                        .put("subscription_tier_slug", p.getOrDefault("tier", "basic"))
+                        .put("region", p.get("region"));
+                yield DoRequest.post("/v2/registry", body, node.id,
+                        "Create container registry " + node.label);
+            }
+            case DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY, DB_KAFKA, DB_OPENSEARCH -> {
+                body.put("name", node.label)
+                        .put("engine", engineSlug(node.kind))
+                        .put("version", p.get("version"))
+                        .put("region", p.get("region"))
+                        .put("size", p.get("size"))
+                        .put("num_nodes", Integer.parseInt(p.getOrDefault("nodes", "1")));
+                for (InfraNode prov : providers) {
+                    if (prov.kind == NodeKind.VPC) {
+                        body.put("private_network_uuid", idOf(prov));
+                    }
+                }
+                yield DoRequest.post("/v2/databases", body, node.id,
+                        "Create managed " + node.kind.getDisplayName() + " " + node.label);
+            }
+            case APP_PLATFORM -> {
+                JSONObject service = new JSONObject()
+                        .put("name", "web")
+                        .put("github", new JSONObject()
+                                .put("repo", p.getOrDefault("repo", "owner/app"))
+                                .put("branch", "main").put("deploy_on_push", true))
+                        .put("instance_size_slug", p.getOrDefault("instance", "basic-xxs"))
+                        .put("instance_count", Integer.parseInt(p.getOrDefault("instances", "1")));
+                JSONObject spec = new JSONObject()
+                        .put("name", node.label)
+                        .put("region", p.getOrDefault("region", "nyc"))
+                        .put("services", new JSONArray().put(service));
+                JSONArray databases = new JSONArray();
+                for (InfraNode prov : providers) {
+                    if (prov.kind.name().startsWith("DB_")) {
+                        databases.put(new JSONObject()
+                                .put("name", prov.label)
+                                .put("engine", engineSlug(prov.kind).toUpperCase())
+                                .put("production", true)
+                                .put("cluster_name", prov.label));
+                    }
+                }
+                if (!databases.isEmpty()) {
+                    spec.put("databases", databases);
+                }
+                body.put("spec", spec);
+                yield DoRequest.post("/v2/apps", body, node.id,
+                        "Create App Platform app " + node.label);
+            }
+            case FUNCTIONS -> {
+                body.put("label", p.getOrDefault("namespaceLabel", node.label))
+                        .put("region", p.get("region"));
+                yield DoRequest.post("/v2/functions/namespaces", body, node.id,
+                        "Create Functions namespace " + node.label);
+            }
+            case GRADIENT_AI -> {
+                body.put("name", p.getOrDefault("agentName", node.label))
+                        .put("model_uuid", p.getOrDefault("model", "llama3.3-70b-instruct"))
+                        .put("region", p.getOrDefault("region", "tor1"))
+                        .put("instruction", "You are a helpful assistant.");
+                yield DoRequest.post("/v2/gen-ai/agents", body, node.id,
+                        "Create Gradient AI agent " + node.label);
+            }
+            case SSH_KEY -> {
+                body.put("name", p.getOrDefault("name", node.label))
+                        .put("public_key", p.getOrDefault("publicKey", ""));
+                yield DoRequest.post("/v2/account/keys", body, node.id,
+                        "Register SSH key " + p.get("name"));
+            }
+            case CERTIFICATE -> {
+                body.put("name", p.getOrDefault("name", node.label))
+                        .put("type", p.getOrDefault("certType", "lets_encrypt"))
+                        .put("dns_names", new JSONArray(p.getOrDefault("dnsNames", "").split(",\\s*")));
+                yield DoRequest.post("/v2/certificates", body, node.id,
+                        "Create certificate " + p.get("name"));
+            }
+            case MONITOR_ALERT -> {
+                JSONArray entities = new JSONArray();
+                for (InfraNode prov : providers) {
+                    if (prov.kind == NodeKind.DROPLET || prov.kind == NodeKind.GPU_DROPLET) {
+                        entities.put(idOf(prov));
+                    }
+                }
+                body.put("type", p.get("metric"))
+                        .put("compare", "GreaterThan")
+                        .put("value", Integer.parseInt(p.getOrDefault("threshold", "80")))
+                        .put("window", "5m")
+                        .put("entities", entities)
+                        .put("alerts", new JSONObject()
+                                .put("email", new JSONArray().put(p.getOrDefault("email", ""))))
+                        .put("enabled", true)
+                        .put("description", node.label);
+                yield DoRequest.post("/v2/monitoring/alerts", body, node.id,
+                        "Create alert " + node.label);
+            }
+        };
+    }
+
+    private static DoRequest attachmentRequest(InfraNode from, InfraNode to) {
+        return switch (from.kind) {
+            case VOLUME -> DoRequest.post(
+                    "/v2/volumes/" + idOf(from) + "/actions",
+                    new JSONObject().put("type", "attach")
+                            .put("droplet_id", idOf(to))
+                            .put("region", from.props.get("region")),
+                    from.id, "Attach volume " + from.label + " to " + to.label);
+            case RESERVED_IP -> DoRequest.post(
+                    "/v2/reserved_ips/" + idOf(from) + "/actions",
+                    new JSONObject().put("type", "assign").put("droplet_id", idOf(to)),
+                    from.id, "Assign reserved IP to " + to.label);
+            case FIREWALL -> DoRequest.post(
+                    "/v2/firewalls/" + idOf(from) + "/droplets",
+                    new JSONObject().put("droplet_ids",
+                            new JSONArray().put(idOf(to))),
+                    from.id, "Apply firewall " + from.label + " to " + to.label);
+            default -> DoRequest.skip(from.id, "No attachment for " + from.kind);
+        };
+    }
+
+    private static String engineSlug(NodeKind kind) {
+        return switch (kind) {
+            case DB_POSTGRES -> "pg";
+            case DB_MYSQL -> "mysql";
+            case DB_MONGODB -> "mongodb";
+            case DB_VALKEY -> "valkey";
+            case DB_KAFKA -> "kafka";
+            case DB_OPENSEARCH -> "opensearch";
+            default -> "pg";
+        };
+    }
+
+    /** "22/0.0.0.0/0, 80/0.0.0.0/0" -> firewall rule objects. */
+    private static JSONArray rules(String spec, String peerField) {
+        JSONArray rules = new JSONArray();
+        for (String part : spec.split(",")) {
+            String[] bits = part.trim().split("/", 2);
+            if (bits.length < 2) {
+                continue;
+            }
+            String ports = bits[0].trim();
+            JSONObject rule = new JSONObject()
+                    .put("protocol", "all".equals(ports) ? "tcp" : "tcp")
+                    .put("ports", "all".equals(ports) ? "all" : ports)
+                    .put(peerField, new JSONObject()
+                            .put("addresses", new JSONArray().put(bits[1].trim())));
+            rules.put(rule);
+        }
+        return rules;
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/api/DigitalOceanClient.java
+++ b/infra/src/main/java/org/nmox/studio/infra/api/DigitalOceanClient.java
@@ -1,0 +1,291 @@
+package org.nmox.studio.infra.api;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.InfraGraph.InfraNode;
+import org.nmox.studio.infra.model.NodeKind;
+import org.openide.util.NbPreferences;
+
+/**
+ * The live wire to DigitalOcean's v2 REST API. Executes deploy plans
+ * (resolving cross-step id/ip placeholders as resources come up),
+ * imports existing resources, and destroys per node. Without a token
+ * everything stays in dry-run; with one, DEPLOY is real.
+ */
+public final class DigitalOceanClient {
+
+    public static final String API = "https://api.digitalocean.com";
+    private static final String PREF_TOKEN = "doToken";
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{(id|ip)-of:([^}]+)}");
+
+    private final HttpClient http = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(15))
+            .build();
+
+    // ---- token ----
+
+    public static String token() {
+        String env = System.getenv("DIGITALOCEAN_TOKEN");
+        if (env != null && !env.isBlank()) {
+            return env;
+        }
+        String pref = NbPreferences.forModule(DigitalOceanClient.class).get(PREF_TOKEN, "");
+        return pref.isBlank() ? null : pref;
+    }
+
+    public static void storeToken(String token) {
+        NbPreferences.forModule(DigitalOceanClient.class).put(PREF_TOKEN, token == null ? "" : token);
+    }
+
+    public static boolean hasToken() {
+        return token() != null;
+    }
+
+    // ---- plan execution ----
+
+    /**
+     * Runs a plan against the API. Per-node ids land back on the graph
+     * nodes; progress flows through the callback (worker thread).
+     *
+     * @param onStep (node, message) per state change
+     * @return true when every step succeeded
+     */
+    public boolean execute(List<DoRequest> plan, InfraGraph graph,
+            BiConsumer<InfraNode, String> onStep) {
+        Map<String, String> ids = new ConcurrentHashMap<>();
+        Map<String, String> ips = new ConcurrentHashMap<>();
+        for (InfraNode node : graph.getNodes()) {
+            if (node.doId != null) {
+                ids.put(node.id, node.doId);
+            }
+        }
+        for (DoRequest step : plan) {
+            InfraNode node = graph.node(step.nodeId());
+            if (step.skipped()) {
+                onStep.accept(node, "skipped: " + step.description());
+                continue;
+            }
+            onStep.accept(node, "creating…");
+            try {
+                String bodyText = step.body() == null ? "" : step.body().toString();
+                bodyText = resolvePlaceholders(bodyText, ids, ips, onStep, node);
+                String path = resolvePlaceholders(step.path(), ids, ips, onStep, node);
+                JSONObject response = send(step.method(), path, bodyText);
+                String doId = extractId(node == null ? null : node.kind, response);
+                if (node != null && doId != null && node.doId == null) {
+                    node.doId = doId;
+                    ids.put(node.id, doId);
+                }
+                onStep.accept(node, "created");
+            } catch (Exception ex) {
+                onStep.accept(node, "FAILED: " + compact(ex.getMessage()));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String resolvePlaceholders(String text, Map<String, String> ids,
+            Map<String, String> ips, BiConsumer<InfraNode, String> onStep,
+            InfraNode forNode) throws IOException, InterruptedException {
+        Matcher m = PLACEHOLDER.matcher(text);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String want = m.group(1);
+            String nodeId = m.group(2);
+            String value;
+            if ("id".equals(want)) {
+                value = ids.get(nodeId);
+                if (value == null) {
+                    throw new IOException("dependency " + nodeId + " has no id yet");
+                }
+            } else {
+                value = ips.computeIfAbsent(nodeId, k -> null);
+                if (value == null) {
+                    onStep.accept(forNode, "waiting for IP of " + nodeId + "…");
+                    value = waitForDropletIp(ids.get(nodeId));
+                    ips.put(nodeId, value);
+                }
+            }
+            m.appendReplacement(sb, Matcher.quoteReplacement(value));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    /** Polls a droplet until it has a public IPv4 (max ~90s). */
+    private String waitForDropletIp(String dropletId) throws IOException, InterruptedException {
+        for (int i = 0; i < 30; i++) {
+            JSONObject response = send("GET", "/v2/droplets/" + dropletId, "");
+            JSONArray v4 = response.getJSONObject("droplet")
+                    .getJSONObject("networks").optJSONArray("v4");
+            if (v4 != null) {
+                for (int j = 0; j < v4.length(); j++) {
+                    JSONObject net = v4.getJSONObject(j);
+                    if ("public".equals(net.optString("type"))) {
+                        return net.getString("ip_address");
+                    }
+                }
+            }
+            Thread.sleep(3000);
+        }
+        throw new IOException("droplet " + dropletId + " got no public IP in time");
+    }
+
+    // ---- raw API ----
+
+    private JSONObject send(String method, String path, String body)
+            throws IOException, InterruptedException {
+        String tok = token();
+        if (tok == null) {
+            throw new IOException("no API token configured");
+        }
+        HttpRequest.Builder rb = HttpRequest.newBuilder(URI.create(API + path))
+                .header("Authorization", "Bearer " + tok)
+                .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(60));
+        switch (method) {
+            case "POST" -> rb.POST(HttpRequest.BodyPublishers.ofString(body));
+            case "DELETE" -> rb.DELETE();
+            default -> rb.GET();
+        }
+        HttpResponse<String> response = http.send(rb.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 300) {
+            throw new IOException("HTTP " + response.statusCode() + ": " + compact(response.body()));
+        }
+        String text = response.body();
+        return text == null || text.isBlank() ? new JSONObject() : new JSONObject(text);
+    }
+
+    /** Pulls the new resource's id out of a creation response, per kind. */
+    static String extractId(NodeKind kind, JSONObject response) {
+        if (kind == null) {
+            return null;
+        }
+        try {
+            return switch (kind) {
+                case DROPLET, GPU_DROPLET -> String.valueOf(response.getJSONObject("droplet").getLong("id"));
+                case VPC -> response.getJSONObject("vpc").getString("id");
+                case LOAD_BALANCER -> response.getJSONObject("load_balancer").getString("id");
+                case FIREWALL -> response.getJSONObject("firewall").getString("id");
+                case VOLUME -> response.getJSONObject("volume").getString("id");
+                case RESERVED_IP -> response.getJSONObject("reserved_ip").getString("ip");
+                case DOMAIN -> response.getJSONObject("domain").getString("name");
+                case CDN -> response.getJSONObject("endpoint").getString("id");
+                case KUBERNETES -> response.getJSONObject("kubernetes_cluster").getString("id");
+                case APP_PLATFORM -> response.getJSONObject("app").getString("id");
+                case FUNCTIONS -> response.getJSONObject("namespace").getString("namespace");
+                case CONTAINER_REGISTRY -> response.getJSONObject("registry").getString("name");
+                case SSH_KEY -> String.valueOf(response.getJSONObject("ssh_key").getLong("id"));
+                case CERTIFICATE -> response.getJSONObject("certificate").getString("id");
+                case MONITOR_ALERT -> response.getJSONObject("policy").getString("uuid");
+                case GRADIENT_AI -> response.getJSONObject("agent").optString("uuid", null);
+                case DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY, DB_KAFKA, DB_OPENSEARCH ->
+                    response.getJSONObject("database").getString("id");
+                default -> null;
+            };
+        } catch (RuntimeException ex) {
+            return null; // unexpected response shape; node stays design-only
+        }
+    }
+
+    // ---- sync & destroy ----
+
+    /** Imports live resources as nodes laid out in a grid, marked live. */
+    public int sync(InfraGraph graph) throws IOException, InterruptedException {
+        record Source(String path, String listKey, NodeKind kind, String idKey, String nameKey) {
+        }
+        List<Source> sources = List.of(
+                new Source("/v2/vpcs", "vpcs", NodeKind.VPC, "id", "name"),
+                new Source("/v2/droplets", "droplets", NodeKind.DROPLET, "id", "name"),
+                new Source("/v2/load_balancers", "load_balancers", NodeKind.LOAD_BALANCER, "id", "name"),
+                new Source("/v2/volumes", "volumes", NodeKind.VOLUME, "id", "name"),
+                new Source("/v2/domains", "domains", NodeKind.DOMAIN, "name", "name"),
+                new Source("/v2/databases", "databases", NodeKind.DB_POSTGRES, "id", "name"));
+        int imported = 0;
+        int x = 80, y = 60;
+        for (Source source : sources) {
+            JSONObject response = send("GET", source.path() + "?per_page=100", "");
+            JSONArray items = response.optJSONArray(source.listKey());
+            if (items == null) {
+                continue;
+            }
+            for (int i = 0; i < items.length(); i++) {
+                JSONObject item = items.getJSONObject(i);
+                String doId = String.valueOf(item.get(source.idKey()));
+                boolean known = graph.getNodes().stream().anyMatch(n -> doId.equals(n.doId));
+                if (known) {
+                    continue;
+                }
+                InfraNode node = graph.addNode(source.kind(), x, y);
+                node.label = item.optString(source.nameKey(), node.label);
+                node.doId = doId;
+                graph.setStatus(node, "live");
+                imported++;
+                x += 190;
+                if (x > 900) {
+                    x = 80;
+                    y += 90;
+                }
+            }
+            if (imported > 0) {
+                x = 80;
+                y += 90;
+            }
+        }
+        return imported;
+    }
+
+    /** Destroys the cloud resource behind a node (the node stays designed). */
+    public void destroy(InfraNode node) throws IOException, InterruptedException {
+        if (node.doId == null) {
+            return;
+        }
+        String path = switch (node.kind) {
+            case DROPLET, GPU_DROPLET -> "/v2/droplets/" + node.doId;
+            case VPC -> "/v2/vpcs/" + node.doId;
+            case LOAD_BALANCER -> "/v2/load_balancers/" + node.doId;
+            case FIREWALL -> "/v2/firewalls/" + node.doId;
+            case VOLUME -> "/v2/volumes/" + node.doId;
+            case RESERVED_IP -> "/v2/reserved_ips/" + node.doId;
+            case DOMAIN -> "/v2/domains/" + node.doId;
+            case CDN -> "/v2/cdn/endpoints/" + node.doId;
+            case KUBERNETES -> "/v2/kubernetes/clusters/" + node.doId;
+            case APP_PLATFORM -> "/v2/apps/" + node.doId;
+            case FUNCTIONS -> "/v2/functions/namespaces/" + node.doId;
+            case CONTAINER_REGISTRY -> "/v2/registry";
+            case SSH_KEY -> "/v2/account/keys/" + node.doId;
+            case CERTIFICATE -> "/v2/certificates/" + node.doId;
+            case MONITOR_ALERT -> "/v2/monitoring/alerts/" + node.doId;
+            case GRADIENT_AI -> "/v2/gen-ai/agents/" + node.doId;
+            case DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY, DB_KAFKA, DB_OPENSEARCH ->
+                "/v2/databases/" + node.doId;
+            default -> null;
+        };
+        if (path != null) {
+            send("DELETE", path, "");
+            node.doId = null;
+        }
+    }
+
+    private static String compact(String text) {
+        if (text == null) {
+            return "unknown error";
+        }
+        String oneLine = text.replaceAll("\\s+", " ").trim();
+        return oneLine.length() > 160 ? oneLine.substring(0, 160) + "…" : oneLine;
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/api/DoRequest.java
+++ b/infra/src/main/java/org/nmox/studio/infra/api/DoRequest.java
@@ -1,0 +1,30 @@
+package org.nmox.studio.infra.api;
+
+import org.json.JSONObject;
+
+/**
+ * One planned DigitalOcean API call. Bodies may carry placeholders -
+ * <code>${id-of:nodeId}</code> and <code>${ip-of:nodeId}</code> -
+ * resolved at execution time from earlier steps' results, which is
+ * what lets a single plan create a VPC, place a droplet inside it and
+ * point DNS at the droplet's not-yet-known IP.
+ *
+ * @param method      HTTP method (POST, DELETE)
+ * @param path        API path, e.g. /v2/droplets
+ * @param body        request body, or null
+ * @param nodeId      the designer node this call realizes
+ * @param description human line for the dry-run plan
+ * @param skipped     true for resources outside the v2 REST API (Spaces
+ *                    buckets are S3-protocol); shown in the plan, never sent
+ */
+public record DoRequest(String method, String path, JSONObject body,
+        String nodeId, String description, boolean skipped) {
+
+    public static DoRequest post(String path, JSONObject body, String nodeId, String description) {
+        return new DoRequest("POST", path, body, nodeId, description, false);
+    }
+
+    public static DoRequest skip(String nodeId, String description) {
+        return new DoRequest("SKIP", "", null, nodeId, description, true);
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/model/GraphIO.java
+++ b/infra/src/main/java/org/nmox/studio/infra/model/GraphIO.java
@@ -1,0 +1,93 @@
+package org.nmox.studio.infra.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Persists an infrastructure design as JSON in the project directory -
+ * the design travels with the repo, exactly like the rack patch.
+ */
+public final class GraphIO {
+
+    public static final String DEFAULT_FILENAME = ".nmoxinfra.json";
+
+    private GraphIO() {
+    }
+
+    public static JSONObject toJson(InfraGraph graph) {
+        JSONObject root = new JSONObject();
+        root.put("version", 1);
+        JSONArray nodeArr = new JSONArray();
+        for (InfraGraph.InfraNode node : graph.getNodes()) {
+            JSONObject nj = new JSONObject();
+            nj.put("id", node.id);
+            nj.put("kind", node.kind.name());
+            nj.put("x", node.x);
+            nj.put("y", node.y);
+            nj.put("label", node.label);
+            nj.put("props", new JSONObject(node.props));
+            if (node.doId != null) {
+                nj.put("doId", node.doId);
+            }
+            nodeArr.put(nj);
+        }
+        root.put("nodes", nodeArr);
+        JSONArray wireArr = new JSONArray();
+        for (InfraGraph.Wire wire : graph.getWires()) {
+            wireArr.put(new JSONObject().put("from", wire.fromId()).put("to", wire.toId()));
+        }
+        root.put("wires", wireArr);
+        return root;
+    }
+
+    public static void fromJson(InfraGraph graph, JSONObject root) {
+        graph.clear();
+        JSONArray nodeArr = root.optJSONArray("nodes");
+        if (nodeArr == null) {
+            return;
+        }
+        for (int i = 0; i < nodeArr.length(); i++) {
+            JSONObject nj = nodeArr.getJSONObject(i);
+            NodeKind kind;
+            try {
+                kind = NodeKind.valueOf(nj.getString("kind"));
+            } catch (IllegalArgumentException ex) {
+                continue; // kind from a future version; skip rather than fail
+            }
+            InfraGraph.InfraNode node = graph.restoreNode(
+                    nj.getString("id"), kind, nj.getInt("x"), nj.getInt("y"));
+            node.label = nj.optString("label", node.label);
+            node.doId = nj.has("doId") ? nj.getString("doId") : null;
+            JSONObject props = nj.optJSONObject("props");
+            if (props != null) {
+                for (String key : props.keySet()) {
+                    node.props.put(key, props.getString(key));
+                }
+            }
+        }
+        JSONArray wireArr = root.optJSONArray("wires");
+        if (wireArr != null) {
+            for (int i = 0; i < wireArr.length(); i++) {
+                JSONObject wj = wireArr.getJSONObject(i);
+                InfraGraph.InfraNode from = graph.node(wj.getString("from"));
+                InfraGraph.InfraNode to = graph.node(wj.getString("to"));
+                if (from != null && to != null) {
+                    graph.connect(from, to);
+                }
+            }
+        }
+        graph.fireChanged();
+    }
+
+    public static void save(InfraGraph graph, File file) throws IOException {
+        Files.writeString(file.toPath(), toJson(graph).toString(2), StandardCharsets.UTF_8);
+    }
+
+    public static void load(InfraGraph graph, File file) throws IOException {
+        fromJson(graph, new JSONObject(Files.readString(file.toPath(), StandardCharsets.UTF_8)));
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/model/InfraGraph.java
+++ b/infra/src/main/java/org/nmox/studio/infra/model/InfraGraph.java
@@ -1,0 +1,182 @@
+package org.nmox.studio.infra.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The design: nodes placed on the canvas and the wires between them.
+ * Wires are validated against the catalog's relationship rules, so an
+ * impossible topology can't be drawn in the first place.
+ */
+public final class InfraGraph {
+
+    /** One placed resource. */
+    public static final class InfraNode {
+
+        public final String id;
+        public final NodeKind kind;
+        public int x;
+        public int y;
+        public String label;
+        public final Map<String, String> props = new LinkedHashMap<>();
+        /** DigitalOcean resource id once deployed; null while design-only. */
+        public String doId;
+        public String status = "";
+
+        InfraNode(String id, NodeKind kind, int x, int y) {
+            this.id = id;
+            this.kind = kind;
+            this.x = x;
+            this.y = y;
+            this.label = kind.getDisplayName().toLowerCase().replace(" ", "-");
+            for (NodeKind.Prop p : kind.getProps()) {
+                props.put(p.key(), p.defaultValue());
+            }
+        }
+
+        public double monthlyUsd() {
+            return kind.estimateMonthlyUsd(props);
+        }
+    }
+
+    /** A relationship wire from one node's output to another's input. */
+    public record Wire(String fromId, String toId) {
+    }
+
+    public interface Listener {
+        default void graphChanged() { }
+        default void nodeStatusChanged(InfraNode node) { }
+    }
+
+    private final Map<String, InfraNode> nodes = new LinkedHashMap<>();
+    private final List<Wire> wires = new ArrayList<>();
+    private final List<Listener> listeners = new CopyOnWriteArrayList<>();
+    private final AtomicLong sequence = new AtomicLong();
+
+    public synchronized InfraNode addNode(NodeKind kind, int x, int y) {
+        String id = kind.name().toLowerCase() + "-" + sequence.incrementAndGet();
+        InfraNode node = new InfraNode(id, kind, x, y);
+        nodes.put(id, node);
+        fireChanged();
+        return node;
+    }
+
+    /** Restores a node with a known id (persistence/sync). */
+    public synchronized InfraNode restoreNode(String id, NodeKind kind, int x, int y) {
+        InfraNode node = new InfraNode(id, kind, x, y);
+        nodes.put(id, node);
+        long numeric = extractSequence(id);
+        sequence.updateAndGet(current -> Math.max(current, numeric));
+        return node;
+    }
+
+    private static long extractSequence(String id) {
+        int dash = id.lastIndexOf('-');
+        try {
+            return Long.parseLong(id.substring(dash + 1));
+        } catch (RuntimeException ex) {
+            return 0;
+        }
+    }
+
+    public synchronized void removeNode(InfraNode node) {
+        if (nodes.remove(node.id) != null) {
+            wires.removeIf(w -> w.fromId().equals(node.id) || w.toId().equals(node.id));
+            fireChanged();
+        }
+    }
+
+    public synchronized InfraNode node(String id) {
+        return nodes.get(id);
+    }
+
+    public synchronized List<InfraNode> getNodes() {
+        return Collections.unmodifiableList(new ArrayList<>(nodes.values()));
+    }
+
+    public synchronized List<Wire> getWires() {
+        return Collections.unmodifiableList(new ArrayList<>(wires));
+    }
+
+    /** Whether a wire from -> to is allowed by the catalog rules. */
+    public boolean canConnect(InfraNode from, InfraNode to) {
+        return from != null && to != null && from != to
+                && from.kind.wiresInto().contains(to.kind);
+    }
+
+    /** Adds the wire if valid and not a duplicate; returns success. */
+    public synchronized boolean connect(InfraNode from, InfraNode to) {
+        if (!canConnect(from, to)) {
+            return false;
+        }
+        Wire wire = new Wire(from.id, to.id);
+        if (wires.contains(wire)) {
+            return false;
+        }
+        wires.add(wire);
+        fireChanged();
+        return true;
+    }
+
+    public synchronized void disconnect(Wire wire) {
+        if (wires.remove(wire)) {
+            fireChanged();
+        }
+    }
+
+    /** Wires arriving at this node (its providers). */
+    public synchronized List<InfraNode> providersOf(InfraNode node) {
+        List<InfraNode> result = new ArrayList<>();
+        for (Wire w : wires) {
+            if (w.toId().equals(node.id)) {
+                InfraNode from = nodes.get(w.fromId());
+                if (from != null) {
+                    result.add(from);
+                }
+            }
+        }
+        return result;
+    }
+
+    public synchronized void clear() {
+        nodes.clear();
+        wires.clear();
+        fireChanged();
+    }
+
+    /** Estimated total monthly cost of the whole design. */
+    public synchronized double totalMonthlyUsd() {
+        return nodes.values().stream().mapToDouble(InfraNode::monthlyUsd).sum();
+    }
+
+    public void setStatus(InfraNode node, String status) {
+        node.status = status;
+        for (Listener l : listeners) {
+            l.nodeStatusChanged(node);
+        }
+    }
+
+    public void addListener(Listener l) {
+        listeners.add(l);
+    }
+
+    public void removeListener(Listener l) {
+        listeners.remove(l);
+    }
+
+    /** Public nudge after direct field edits (node drag, property change). */
+    public void touch() {
+        fireChanged();
+    }
+
+    void fireChanged() {
+        for (Listener l : listeners) {
+            l.graphChanged();
+        }
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/model/NodeKind.java
+++ b/infra/src/main/java/org/nmox/studio/infra/model/NodeKind.java
@@ -1,0 +1,299 @@
+package org.nmox.studio.infra.model;
+
+import java.awt.Color;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The palette: DigitalOcean's offerings, 1:1. Each kind carries its
+ * Node-RED-style category color, its configurable properties with
+ * defaults, an estimated monthly price for the cost meter, and the
+ * relationship rules that decide which wires make sense.
+ */
+public enum NodeKind {
+
+    // ---- Compute ----
+    DROPLET("Droplet", Category.COMPUTE,
+            List.of(
+                Prop.choice("size", "Size", "s-1vcpu-1gb",
+                    "s-1vcpu-512mb-10gb", "s-1vcpu-1gb", "s-1vcpu-2gb", "s-2vcpu-2gb",
+                    "s-2vcpu-4gb", "s-4vcpu-8gb", "s-8vcpu-16gb", "c-2", "c-4", "g-2vcpu-8gb"),
+                Prop.choice("region", "Region", "nyc3", regions()),
+                Prop.choice("image", "Image", "ubuntu-24-04-x64",
+                    "ubuntu-24-04-x64", "ubuntu-22-04-x64", "debian-12-x64", "fedora-40-x64",
+                    "rockylinux-9-x64", "docker-20-04"),
+                Prop.bool("backups", "Backups", false),
+                Prop.bool("monitoring", "Monitoring agent", true)),
+            6.0),
+    GPU_DROPLET("GPU Droplet", Category.COMPUTE,
+            List.of(
+                Prop.choice("size", "GPU size", "gpu-h100x1-80gb",
+                    "gpu-h100x1-80gb", "gpu-h100x8-640gb", "gpu-l40sx1-48gb", "gpu-6000adax1-48gb"),
+                Prop.choice("region", "Region", "nyc2", "nyc2", "tor1", "atl1"),
+                Prop.choice("image", "Image", "gpu-h100x1-base", "gpu-h100x1-base", "ubuntu-24-04-x64")),
+            1830.0),
+    KUBERNETES("Kubernetes", Category.COMPUTE,
+            List.of(
+                Prop.choice("region", "Region", "nyc3", regions()),
+                Prop.choice("nodeSize", "Node size", "s-2vcpu-4gb",
+                    "s-2vcpu-2gb", "s-2vcpu-4gb", "s-4vcpu-8gb", "s-8vcpu-16gb"),
+                Prop.number("nodeCount", "Node count", 3),
+                Prop.bool("ha", "HA control plane", false),
+                Prop.bool("autoscale", "Autoscale pool", false)),
+            72.0),
+    APP_PLATFORM("App Platform", Category.COMPUTE,
+            List.of(
+                Prop.text("repo", "GitHub repo", "owner/app"),
+                Prop.choice("instance", "Instance", "basic-xxs",
+                    "basic-xxs", "basic-xs", "basic-s", "professional-xs", "professional-s"),
+                Prop.number("instances", "Instance count", 1),
+                Prop.choice("region", "Region", "nyc", "nyc", "ams", "fra", "lon", "sfo", "sgp", "syd", "tor", "blr")),
+            5.0),
+    FUNCTIONS("Functions", Category.COMPUTE,
+            List.of(
+                Prop.text("namespaceLabel", "Namespace label", "fn-namespace"),
+                Prop.choice("region", "Region", "nyc1", "nyc1", "ams3", "fra1", "lon1", "sfo3", "sgp1", "syd1", "tor1", "blr1")),
+            0.0),
+    GRADIENT_AI("Gradient AI", Category.COMPUTE,
+            List.of(
+                Prop.text("agentName", "Agent name", "assistant"),
+                Prop.choice("model", "Model", "llama3.3-70b-instruct",
+                    "llama3.3-70b-instruct", "anthropic-claude-3.5-sonnet", "openai-gpt-4o",
+                    "deepseek-r1-distill-llama-70b"),
+                Prop.choice("region", "Region", "tor1", "tor1", "nyc2")),
+            0.0),
+
+    // ---- Networking ----
+    VPC("VPC", Category.NETWORKING,
+            List.of(
+                Prop.text("ipRange", "IP range", "10.10.0.0/20"),
+                Prop.choice("region", "Region", "nyc3", regions())),
+            0.0),
+    LOAD_BALANCER("Load Balancer", Category.NETWORKING,
+            List.of(
+                Prop.choice("size", "Size", "lb-small", "lb-small", "lb-medium", "lb-large"),
+                Prop.choice("region", "Region", "nyc3", regions()),
+                Prop.choice("forwardingRule", "Forwarding", "http-80",
+                    "http-80", "https-443", "tcp-22", "http2-443"),
+                Prop.text("healthPath", "Health check path", "/")),
+            12.0),
+    FIREWALL("Firewall", Category.NETWORKING,
+            List.of(
+                Prop.text("inbound", "Inbound (port/cidr)", "22/0.0.0.0/0, 80/0.0.0.0/0, 443/0.0.0.0/0"),
+                Prop.text("outbound", "Outbound", "all/0.0.0.0/0")),
+            0.0),
+    RESERVED_IP("Reserved IP", Category.NETWORKING,
+            List.of(Prop.choice("region", "Region", "nyc3", regions())),
+            0.0),
+    DOMAIN("Domain / DNS", Category.NETWORKING,
+            List.of(
+                Prop.text("name", "Domain name", "example.com"),
+                Prop.choice("recordType", "Record type", "A", "A", "AAAA", "CNAME", "MX", "TXT"),
+                Prop.text("recordName", "Record name", "@")),
+            0.0),
+    CDN("CDN", Category.NETWORKING,
+            List.of(Prop.number("ttl", "Cache TTL (s)", 3600)),
+            0.0),
+
+    // ---- Storage ----
+    VOLUME("Volume", Category.STORAGE,
+            List.of(
+                Prop.number("sizeGb", "Size (GiB)", 100),
+                Prop.choice("region", "Region", "nyc3", regions()),
+                Prop.choice("fs", "Filesystem", "ext4", "ext4", "xfs")),
+            10.0),
+    SPACES("Spaces Bucket", Category.STORAGE,
+            List.of(
+                Prop.text("bucket", "Bucket name", "my-bucket"),
+                Prop.choice("region", "Region", "nyc3", "nyc3", "ams3", "fra1", "sfo3", "sgp1", "syd1"),
+                Prop.bool("publicRead", "Public read", false)),
+            5.0),
+    CONTAINER_REGISTRY("Container Registry", Category.STORAGE,
+            List.of(
+                Prop.choice("tier", "Tier", "basic", "starter", "basic", "professional"),
+                Prop.choice("region", "Region", "nyc3", "nyc3", "ams3", "fra1", "sfo3", "sgp1", "syd1")),
+            5.0),
+
+    // ---- Databases ----
+    DB_POSTGRES("PostgreSQL", Category.DATABASES, dbProps("16"), 15.0),
+    DB_MYSQL("MySQL", Category.DATABASES, dbProps("8"), 15.0),
+    DB_MONGODB("MongoDB", Category.DATABASES, dbProps("7"), 15.0),
+    DB_VALKEY("Valkey (Redis)", Category.DATABASES, dbProps("8"), 15.0),
+    DB_KAFKA("Kafka", Category.DATABASES, dbProps("3.8"), 147.0),
+    DB_OPENSEARCH("OpenSearch", Category.DATABASES, dbProps("2"), 49.0),
+
+    // ---- Security & Ops ----
+    SSH_KEY("SSH Key", Category.OPS,
+            List.of(
+                Prop.text("name", "Key name", "workstation"),
+                Prop.text("publicKey", "Public key", "ssh-ed25519 AAAA...")),
+            0.0),
+    CERTIFICATE("Certificate", Category.OPS,
+            List.of(
+                Prop.text("name", "Name", "site-cert"),
+                Prop.choice("certType", "Type", "lets_encrypt", "lets_encrypt", "custom"),
+                Prop.text("dnsNames", "DNS names", "example.com")),
+            0.0),
+    MONITOR_ALERT("Monitor Alert", Category.OPS,
+            List.of(
+                Prop.choice("metric", "Metric", "v1/insights/droplet/cpu",
+                    "v1/insights/droplet/cpu", "v1/insights/droplet/memory_utilization_percent",
+                    "v1/insights/droplet/disk_utilization_percent"),
+                Prop.number("threshold", "Threshold %", 80),
+                Prop.text("email", "Alert email", "ops@example.com")),
+            0.0);
+
+    /** Node-RED-ish category palette. */
+    public enum Category {
+        COMPUTE(new Color(0x53, 0x9E, 0xF6)),
+        NETWORKING(new Color(0xE8, 0x9A, 0x3C)),
+        STORAGE(new Color(0x8F, 0x6B, 0xD6)),
+        DATABASES(new Color(0x4E, 0xC9, 0x8B)),
+        OPS(new Color(0xD6, 0x5C, 0x6E));
+
+        public final Color color;
+
+        Category(Color color) {
+            this.color = color;
+        }
+    }
+
+    /** A configurable property with a default and optional choices. */
+    public record Prop(String key, String label, String type, String defaultValue, List<String> choices) {
+
+        static Prop text(String key, String label, String dflt) {
+            return new Prop(key, label, "text", dflt, List.of());
+        }
+
+        static Prop number(String key, String label, int dflt) {
+            return new Prop(key, label, "number", String.valueOf(dflt), List.of());
+        }
+
+        static Prop bool(String key, String label, boolean dflt) {
+            return new Prop(key, label, "bool", String.valueOf(dflt), List.of());
+        }
+
+        static Prop choice(String key, String label, String dflt, String... choices) {
+            return new Prop(key, label, "choice", dflt, List.of(choices));
+        }
+    }
+
+    private static String[] regions() {
+        return new String[]{
+            "nyc1", "nyc3", "sfo3", "ams3", "fra1", "lon1", "sgp1", "blr1", "syd1", "tor1"};
+    }
+
+    private static List<Prop> dbProps(String version) {
+        return List.of(
+                Prop.choice("size", "Size", "db-s-1vcpu-1gb",
+                    "db-s-1vcpu-1gb", "db-s-1vcpu-2gb", "db-s-2vcpu-4gb", "db-s-4vcpu-8gb"),
+                Prop.choice("region", "Region", "nyc3", regions()),
+                Prop.number("nodes", "Standby nodes + primary", 1),
+                Prop.text("version", "Engine version", version));
+    }
+
+    /**
+     * Wire rules: each entry lists the kinds this kind may wire INTO.
+     * A wire A->B reads "A serves B": VPC->Droplet places it, Droplet->LB
+     * joins the backend pool, Spaces->CDN sets the origin.
+     */
+    public Set<NodeKind> wiresInto() {
+        return switch (this) {
+            case VPC -> Set.of(DROPLET, GPU_DROPLET, KUBERNETES, LOAD_BALANCER,
+                    DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY, DB_KAFKA, DB_OPENSEARCH);
+            case SSH_KEY -> Set.of(DROPLET, GPU_DROPLET);
+            case FIREWALL -> Set.of(DROPLET, GPU_DROPLET);
+            case VOLUME -> Set.of(DROPLET, GPU_DROPLET);
+            case RESERVED_IP -> Set.of(DROPLET, GPU_DROPLET);
+            case DROPLET, GPU_DROPLET -> Set.of(LOAD_BALANCER, DOMAIN, MONITOR_ALERT);
+            case KUBERNETES -> Set.of(MONITOR_ALERT);
+            case LOAD_BALANCER -> Set.of(DOMAIN);
+            case APP_PLATFORM, FUNCTIONS -> Set.of(DOMAIN);
+            case SPACES -> Set.of(CDN);
+            case CERTIFICATE -> Set.of(LOAD_BALANCER, CDN);
+            case CONTAINER_REGISTRY -> Set.of(KUBERNETES, APP_PLATFORM);
+            case DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY, DB_KAFKA, DB_OPENSEARCH ->
+                Set.of(APP_PLATFORM, KUBERNETES);
+            case GRADIENT_AI -> Set.of(APP_PLATFORM, FUNCTIONS);
+            case CDN, DOMAIN, MONITOR_ALERT -> Set.of();
+        };
+    }
+
+    /**
+     * Relations that are post-create attachments (both ends must exist
+     * before an action call) rather than creation-time references.
+     */
+    public boolean attachesTo(NodeKind target) {
+        return (this == VOLUME || this == RESERVED_IP || this == FIREWALL)
+                && (target == DROPLET || target == GPU_DROPLET);
+    }
+
+    private final String displayName;
+    private final Category category;
+    private final List<Prop> props;
+    private final double monthlyUsd;
+
+    NodeKind(String displayName, Category category, List<Prop> props, double monthlyUsd) {
+        this.displayName = displayName;
+        this.category = category;
+        this.props = props;
+        this.monthlyUsd = monthlyUsd;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public List<Prop> getProps() {
+        return props;
+    }
+
+    /** Estimated monthly price with the node's current property values. */
+    public double estimateMonthlyUsd(java.util.Map<String, String> values) {
+        double base = monthlyUsd;
+        return switch (this) {
+            case DROPLET -> DROPLET_PRICES.getOrDefault(values.getOrDefault("size", "s-1vcpu-1gb"), base);
+            case VOLUME -> 0.10 * parseInt(values.get("sizeGb"), 100);
+            case KUBERNETES -> {
+                double node = DROPLET_PRICES.getOrDefault(values.getOrDefault("nodeSize", "s-2vcpu-4gb"), 24.0);
+                double ha = Boolean.parseBoolean(values.getOrDefault("ha", "false")) ? 40.0 : 0.0;
+                yield node * parseInt(values.get("nodeCount"), 3) + ha;
+            }
+            case DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY -> {
+                double size = DB_PRICES.getOrDefault(values.getOrDefault("size", "db-s-1vcpu-1gb"), 15.0);
+                yield size * Math.max(1, parseInt(values.get("nodes"), 1));
+            }
+            default -> base;
+        };
+    }
+
+    private static final java.util.Map<String, Double> DROPLET_PRICES = java.util.Map.ofEntries(
+            java.util.Map.entry("s-1vcpu-512mb-10gb", 4.0),
+            java.util.Map.entry("s-1vcpu-1gb", 6.0),
+            java.util.Map.entry("s-1vcpu-2gb", 12.0),
+            java.util.Map.entry("s-2vcpu-2gb", 18.0),
+            java.util.Map.entry("s-2vcpu-4gb", 24.0),
+            java.util.Map.entry("s-4vcpu-8gb", 48.0),
+            java.util.Map.entry("s-8vcpu-16gb", 96.0),
+            java.util.Map.entry("c-2", 42.0),
+            java.util.Map.entry("c-4", 84.0),
+            java.util.Map.entry("g-2vcpu-8gb", 63.0));
+
+    private static final java.util.Map<String, Double> DB_PRICES = java.util.Map.of(
+            "db-s-1vcpu-1gb", 15.0,
+            "db-s-1vcpu-2gb", 30.0,
+            "db-s-2vcpu-4gb", 60.0,
+            "db-s-4vcpu-8gb", 120.0);
+
+    private static int parseInt(String value, int dflt) {
+        try {
+            return Integer.parseInt(value);
+        } catch (RuntimeException ex) {
+            return dflt;
+        }
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/ui/FlowCanvas.java
+++ b/infra/src/main/java/org/nmox/studio/infra/ui/FlowCanvas.java
@@ -1,0 +1,470 @@
+package org.nmox.studio.infra.ui;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.RenderingHints;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
+import java.awt.geom.CubicCurve2D;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Point2D;
+import java.awt.geom.RoundRectangle2D;
+import javax.swing.JPanel;
+import javax.swing.TransferHandler;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.InfraGraph.InfraNode;
+import org.nmox.studio.infra.model.InfraGraph.Wire;
+import org.nmox.studio.infra.model.NodeKind;
+
+/**
+ * The flow canvas, Node-RED style: a dotted dark grid, rounded nodes
+ * in category colors with port nubs on their left/right edges, and
+ * horizontal bezier wires. Drag nodes to arrange, drag from an output
+ * nub to wire, drag empty space to pan, scroll to zoom, Delete to
+ * remove, double-click to configure.
+ */
+public class FlowCanvas extends JPanel {
+
+    /** What the host window wants to know about. */
+    public interface Callbacks {
+        void nodeDoubleClicked(InfraNode node);
+
+        void nodeContextMenu(InfraNode node, Point screenPoint);
+
+        void selectionChanged(InfraNode node);
+    }
+
+    public static final int NODE_W = 150;
+    public static final int NODE_H = 36;
+
+    private static final Color CANVAS_BG = new Color(0x1B, 0x1B, 0x1F);
+    private static final Color GRID_DOT = new Color(0x2E, 0x2E, 0x34);
+    private static final Color WIRE = new Color(0x8A, 0x8D, 0x94);
+    private static final Color WIRE_SELECTED = new Color(0xE8, 0x74, 0x22);
+    private static final Color NUB = new Color(0xD6, 0xD7, 0xDB);
+    private static final Color LIVE_DOT = new Color(0x4E, 0xC9, 0x8B);
+
+    private final InfraGraph graph;
+    private final Callbacks callbacks;
+
+    private double zoom = 1.0;
+    private double panX = 0;
+    private double panY = 0;
+
+    private InfraNode selectedNode;
+    private Wire selectedWire;
+    private InfraNode draggingNode;
+    private Point dragOffset;
+    private InfraNode wireFrom;
+    private Point2D wireGhost;
+    private Point panStart;
+
+    public FlowCanvas(InfraGraph graph, Callbacks callbacks) {
+        this.graph = graph;
+        this.callbacks = callbacks;
+        setBackground(CANVAS_BG);
+        setFocusable(true);
+        graph.addListener(new InfraGraph.Listener() {
+            @Override
+            public void graphChanged() {
+                javax.swing.SwingUtilities.invokeLater(FlowCanvas.this::repaint);
+            }
+
+            @Override
+            public void nodeStatusChanged(InfraNode node) {
+                javax.swing.SwingUtilities.invokeLater(FlowCanvas.this::repaint);
+            }
+        });
+        Mouse mouse = new Mouse();
+        addMouseListener(mouse);
+        addMouseMotionListener(mouse);
+        addMouseWheelListener(mouse);
+        addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyCode() == KeyEvent.VK_DELETE || e.getKeyCode() == KeyEvent.VK_BACK_SPACE) {
+                    deleteSelection();
+                }
+            }
+        });
+        setTransferHandler(new PaletteDrop());
+        setToolTipText("");
+    }
+
+    // ---- coordinate transforms ----
+
+    private Point2D toWorld(Point screen) {
+        return new Point2D.Double((screen.x - panX) / zoom, (screen.y - panY) / zoom);
+    }
+
+    private Point toScreen(double wx, double wy) {
+        return new Point((int) (wx * zoom + panX), (int) (wy * zoom + panY));
+    }
+
+    // ---- selection & editing ----
+
+    public InfraNode getSelectedNode() {
+        return selectedNode;
+    }
+
+    private void select(InfraNode node, Wire wire) {
+        selectedNode = node;
+        selectedWire = wire;
+        callbacks.selectionChanged(node);
+        repaint();
+    }
+
+    private void deleteSelection() {
+        if (selectedNode != null) {
+            graph.removeNode(selectedNode);
+            select(null, null);
+        } else if (selectedWire != null) {
+            graph.disconnect(selectedWire);
+            select(null, null);
+        }
+    }
+
+    /** Centers the view on the design. */
+    public void fit() {
+        var nodes = graph.getNodes();
+        if (nodes.isEmpty()) {
+            zoom = 1.0;
+            panX = panY = 0;
+        } else {
+            int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE;
+            int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE;
+            for (InfraNode n : nodes) {
+                minX = Math.min(minX, n.x);
+                minY = Math.min(minY, n.y);
+                maxX = Math.max(maxX, n.x + NODE_W);
+                maxY = Math.max(maxY, n.y + NODE_H + 18);
+            }
+            double zx = getWidth() / (double) Math.max(200, maxX - minX + 120);
+            double zy = getHeight() / (double) Math.max(160, maxY - minY + 120);
+            zoom = Math.max(0.4, Math.min(1.5, Math.min(zx, zy)));
+            panX = -minX * zoom + 60;
+            panY = -minY * zoom + 60;
+        }
+        repaint();
+    }
+
+    // ---- hit testing ----
+
+    private InfraNode nodeAt(Point2D world) {
+        var nodes = graph.getNodes();
+        for (int i = nodes.size() - 1; i >= 0; i--) {
+            InfraNode n = nodes.get(i);
+            if (world.getX() >= n.x && world.getX() <= n.x + NODE_W
+                    && world.getY() >= n.y && world.getY() <= n.y + NODE_H) {
+                return n;
+            }
+        }
+        return null;
+    }
+
+    private boolean onOutputNub(InfraNode node, Point2D world) {
+        return node != null
+                && Math.abs(world.getX() - (node.x + NODE_W)) < 9 / zoom + 4
+                && Math.abs(world.getY() - (node.y + NODE_H / 2.0)) < 12;
+    }
+
+    private Wire wireAt(Point2D world) {
+        for (Wire wire : graph.getWires()) {
+            InfraNode from = graph.node(wire.fromId());
+            InfraNode to = graph.node(wire.toId());
+            if (from == null || to == null) {
+                continue;
+            }
+            CubicCurve2D curve = wireCurve(from, to);
+            // sample the curve; close enough beats exact
+            for (double t = 0; t <= 1.0; t += 0.05) {
+                Point2D pt = pointOn(curve, t);
+                if (pt.distance(world) < 6 / zoom + 3) {
+                    return wire;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Point2D pointOn(CubicCurve2D c, double t) {
+        double mt = 1 - t;
+        double x = mt * mt * mt * c.getX1() + 3 * mt * mt * t * c.getCtrlX1()
+                + 3 * mt * t * t * c.getCtrlX2() + t * t * t * c.getX2();
+        double y = mt * mt * mt * c.getY1() + 3 * mt * mt * t * c.getCtrlY1()
+                + 3 * mt * t * t * c.getCtrlY2() + t * t * t * c.getY2();
+        return new Point2D.Double(x, y);
+    }
+
+    private static CubicCurve2D wireCurve(InfraNode from, InfraNode to) {
+        double x1 = from.x + NODE_W, y1 = from.y + NODE_H / 2.0;
+        double x2 = to.x, y2 = to.y + NODE_H / 2.0;
+        double dx = Math.max(40, Math.abs(x2 - x1) / 2);
+        return new CubicCurve2D.Double(x1, y1, x1 + dx, y1, x2 - dx, y2, x2, y2);
+    }
+
+    // ---- painting ----
+
+    @Override
+    protected void paintComponent(Graphics gr) {
+        super.paintComponent(gr);
+        Graphics2D g = (Graphics2D) gr.create();
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+        paintGrid(g);
+        g.translate(panX, panY);
+        g.scale(zoom, zoom);
+
+        for (Wire wire : graph.getWires()) {
+            InfraNode from = graph.node(wire.fromId());
+            InfraNode to = graph.node(wire.toId());
+            if (from == null || to == null) {
+                continue;
+            }
+            boolean selected = wire.equals(selectedWire);
+            g.setColor(selected ? WIRE_SELECTED : WIRE);
+            g.setStroke(new BasicStroke(selected ? 3.4f : 2.6f,
+                    BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+            g.draw(wireCurve(from, to));
+        }
+
+        if (wireFrom != null && wireGhost != null) {
+            g.setColor(new Color(0xE8, 0x74, 0x22, 180));
+            g.setStroke(new BasicStroke(2.6f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND,
+                    0, new float[]{8, 6}, 0));
+            double x1 = wireFrom.x + NODE_W, y1 = wireFrom.y + NODE_H / 2.0;
+            double dx = Math.max(40, Math.abs(wireGhost.getX() - x1) / 2);
+            g.draw(new CubicCurve2D.Double(x1, y1, x1 + dx, y1,
+                    wireGhost.getX() - dx, wireGhost.getY(), wireGhost.getX(), wireGhost.getY()));
+        }
+
+        for (InfraNode node : graph.getNodes()) {
+            paintNode(g, node);
+        }
+        g.dispose();
+    }
+
+    private void paintGrid(Graphics2D g) {
+        double step = 20 * zoom;
+        if (step < 6) {
+            return;
+        }
+        g.setColor(GRID_DOT);
+        double startX = panX % step;
+        double startY = panY % step;
+        for (double x = startX; x < getWidth(); x += step) {
+            for (double y = startY; y < getHeight(); y += step) {
+                g.fillRect((int) x, (int) y, 1, 1);
+            }
+        }
+    }
+
+    private void paintNode(Graphics2D g, InfraNode node) {
+        Color base = node.kind.getCategory().color;
+        boolean selected = node == selectedNode;
+
+        RoundRectangle2D body = new RoundRectangle2D.Double(node.x, node.y, NODE_W, NODE_H, 10, 10);
+        // soft drop shadow
+        g.setColor(new Color(0, 0, 0, 90));
+        g.fill(new RoundRectangle2D.Double(node.x + 2, node.y + 3, NODE_W, NODE_H, 10, 10));
+        g.setColor(base);
+        g.fill(body);
+        // darker left icon-band, Node-RED style
+        g.setColor(base.darker());
+        g.fill(new RoundRectangle2D.Double(node.x, node.y, 28, NODE_H, 10, 10));
+        g.fillRect(node.x + 14, node.y, 14, NODE_H);
+        g.setColor(new Color(255, 255, 255, 200));
+        g.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 13));
+        g.drawString(glyphFor(node.kind), node.x + 8, node.y + NODE_H / 2 + 5);
+
+        g.setColor(selected ? WIRE_SELECTED : new Color(0, 0, 0, 140));
+        g.setStroke(new BasicStroke(selected ? 2.4f : 1.2f));
+        g.draw(body);
+
+        g.setColor(Color.WHITE);
+        g.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+        FontMetrics fm = g.getFontMetrics();
+        String label = node.label;
+        while (label.length() > 1 && fm.stringWidth(label) > NODE_W - 40) {
+            label = label.substring(0, label.length() - 1);
+        }
+        g.drawString(label, node.x + 34, node.y + NODE_H / 2 + 4);
+
+        // port nubs: input left (when anything can wire in), output right
+        g.setColor(NUB);
+        g.fill(new RoundRectangle2D.Double(node.x - 5, node.y + NODE_H / 2.0 - 5, 10, 10, 3, 3));
+        if (!node.kind.wiresInto().isEmpty()) {
+            g.fill(new RoundRectangle2D.Double(node.x + NODE_W - 5, node.y + NODE_H / 2.0 - 5, 10, 10, 3, 3));
+        }
+        g.setColor(new Color(0, 0, 0, 120));
+        g.draw(new RoundRectangle2D.Double(node.x - 5, node.y + NODE_H / 2.0 - 5, 10, 10, 3, 3));
+
+        // status: live dot + text under the node
+        if (node.doId != null || !node.status.isEmpty()) {
+            g.setColor(node.doId != null ? LIVE_DOT : new Color(0xE8, 0xC4, 0x4A));
+            g.fill(new Ellipse2D.Double(node.x + 4, node.y + NODE_H + 5, 7, 7));
+            g.setColor(new Color(0x9A, 0x9D, 0xA4));
+            g.setFont(new Font(Font.SANS_SERIF, Font.ITALIC, 10));
+            String status = node.doId != null && node.status.isEmpty() ? "live" : node.status;
+            g.drawString(status, node.x + 15, node.y + NODE_H + 12);
+        }
+    }
+
+    private static String glyphFor(NodeKind kind) {
+        return switch (kind.getCategory()) {
+            case COMPUTE -> "▣";
+            case NETWORKING -> "⇄";
+            case STORAGE -> "▤";
+            case DATABASES -> "◫";
+            case OPS -> "✚";
+        };
+    }
+
+    @Override
+    public String getToolTipText(MouseEvent e) {
+        InfraNode node = nodeAt(toWorld(e.getPoint()));
+        if (node == null) {
+            return null;
+        }
+        return "<html><b>" + node.kind.getDisplayName() + "</b> " + node.label
+                + "<br>$" + String.format("%.2f", node.monthlyUsd()) + "/mo"
+                + (node.doId != null ? "<br>live: " + node.doId : "<br>design only")
+                + "</html>";
+    }
+
+    // ---- interaction ----
+
+    private final class Mouse extends MouseAdapter {
+
+        @Override
+        public void mousePressed(MouseEvent e) {
+            requestFocusInWindow();
+            Point2D world = toWorld(e.getPoint());
+            InfraNode node = nodeAt(world);
+            if (e.isPopupTrigger()) {
+                if (node != null) {
+                    callbacks.nodeContextMenu(node, e.getLocationOnScreen());
+                }
+                return;
+            }
+            if (node != null && onOutputNub(node, world)) {
+                wireFrom = node;
+                wireGhost = world;
+            } else if (node != null) {
+                draggingNode = node;
+                dragOffset = new Point((int) (world.getX() - node.x), (int) (world.getY() - node.y));
+                select(node, null);
+            } else {
+                Wire wire = wireAt(world);
+                if (wire != null) {
+                    select(null, wire);
+                } else {
+                    select(null, null);
+                    panStart = e.getPoint();
+                }
+            }
+        }
+
+        @Override
+        public void mouseDragged(MouseEvent e) {
+            Point2D world = toWorld(e.getPoint());
+            if (wireFrom != null) {
+                wireGhost = world;
+                repaint();
+            } else if (draggingNode != null) {
+                draggingNode.x = (int) Math.round((world.getX() - dragOffset.x) / 10) * 10;
+                draggingNode.y = (int) Math.round((world.getY() - dragOffset.y) / 10) * 10;
+                repaint();
+            } else if (panStart != null) {
+                panX += e.getX() - panStart.x;
+                panY += e.getY() - panStart.y;
+                panStart = e.getPoint();
+                repaint();
+            }
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                InfraNode node = nodeAt(toWorld(e.getPoint()));
+                if (node != null) {
+                    callbacks.nodeContextMenu(node, e.getLocationOnScreen());
+                }
+            }
+            if (wireFrom != null) {
+                InfraNode target = nodeAt(toWorld(e.getPoint()));
+                if (target != null) {
+                    graph.connect(wireFrom, target);
+                }
+                wireFrom = null;
+                wireGhost = null;
+                repaint();
+            }
+            if (draggingNode != null) {
+                graph.touch();
+                draggingNode = null;
+            }
+            panStart = null;
+        }
+
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            if (e.getClickCount() == 2) {
+                InfraNode node = nodeAt(toWorld(e.getPoint()));
+                if (node != null) {
+                    callbacks.nodeDoubleClicked(node);
+                }
+            }
+        }
+
+        @Override
+        public void mouseWheelMoved(MouseWheelEvent e) {
+            double factor = e.getWheelRotation() < 0 ? 1.1 : 1 / 1.1;
+            double newZoom = Math.max(0.35, Math.min(2.5, zoom * factor));
+            // zoom around the cursor
+            Point2D before = toWorld(e.getPoint());
+            zoom = newZoom;
+            Point after = toScreen(before.getX(), before.getY());
+            panX += e.getX() - after.x;
+            panY += e.getY() - after.y;
+            repaint();
+        }
+    }
+
+    /** Drop target for the palette: a NodeKind name lands as a new node. */
+    private final class PaletteDrop extends TransferHandler {
+
+        @Override
+        public boolean canImport(TransferSupport support) {
+            return support.isDataFlavorSupported(DataFlavor.stringFlavor);
+        }
+
+        @Override
+        public boolean importData(TransferSupport support) {
+            try {
+                String name = (String) support.getTransferable().getTransferData(DataFlavor.stringFlavor);
+                NodeKind kind = NodeKind.valueOf(name);
+                Point drop = support.isDrop() ? support.getDropLocation().getDropPoint()
+                        : new Point(getWidth() / 2, getHeight() / 2);
+                Point2D world = toWorld(drop);
+                InfraNode node = graph.addNode(kind,
+                        (int) Math.round(world.getX() / 10) * 10,
+                        (int) Math.round(world.getY() / 10) * 10);
+                select(node, null);
+                return true;
+            } catch (Exception ex) {
+                return false;
+            }
+        }
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/ui/InfraPalette.java
+++ b/infra/src/main/java/org/nmox/studio/infra/ui/InfraPalette.java
@@ -1,0 +1,130 @@
+package org.nmox.studio.infra.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.BorderFactory;
+import javax.swing.DefaultListModel;
+import javax.swing.JComponent;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListCellRenderer;
+import javax.swing.TransferHandler;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.NodeKind;
+
+/**
+ * The node palette, Node-RED style: category-grouped entries shaped
+ * like miniature nodes. Drag onto the canvas to place (or double-click).
+ */
+public class InfraPalette extends JPanel {
+
+    /** List entries: a header (null kind) or a draggable node kind. */
+    private record Entry(NodeKind kind, String header) {
+    }
+
+    public InfraPalette(InfraGraph graph) {
+        super(new BorderLayout());
+        setBackground(new Color(0x17, 0x17, 0x1B));
+        setPreferredSize(new Dimension(190, 400));
+
+        DefaultListModel<Entry> model = new DefaultListModel<>();
+        NodeKind.Category last = null;
+        for (NodeKind kind : NodeKind.values()) {
+            if (kind.getCategory() != last) {
+                last = kind.getCategory();
+                model.addElement(new Entry(null, last.name()));
+            }
+            model.addElement(new Entry(kind, null));
+        }
+
+        JList<Entry> list = new JList<>(model);
+        list.setBackground(getBackground());
+        list.setCellRenderer(new Renderer());
+        list.setDragEnabled(true);
+        list.setTransferHandler(new TransferHandler() {
+            @Override
+            public int getSourceActions(JComponent c) {
+                return COPY;
+            }
+
+            @Override
+            protected Transferable createTransferable(JComponent c) {
+                Entry entry = list.getSelectedValue();
+                return entry == null || entry.kind() == null ? null
+                        : new StringSelection(entry.kind().name());
+            }
+        });
+        list.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                Entry entry = list.getSelectedValue();
+                if (e.getClickCount() == 2 && entry != null && entry.kind() != null) {
+                    graph.addNode(entry.kind(), 120 + (int) (Math.random() * 80),
+                            80 + (int) (Math.random() * 120));
+                }
+            }
+        });
+
+        JScrollPane scroll = new JScrollPane(list);
+        scroll.setBorder(BorderFactory.createEmptyBorder());
+        scroll.getViewport().setBackground(getBackground());
+        add(scroll, BorderLayout.CENTER);
+    }
+
+    private static final class Renderer extends JPanel implements ListCellRenderer<Entry> {
+
+        private Entry entry;
+        private boolean selected;
+
+        @Override
+        public Component getListCellRendererComponent(JList<? extends Entry> list, Entry value,
+                int index, boolean isSelected, boolean cellHasFocus) {
+            this.entry = value;
+            this.selected = isSelected;
+            setPreferredSize(new Dimension(180, value.kind() == null ? 26 : 34));
+            setToolTipText(value.kind() == null ? null
+                    : value.kind().getDisplayName() + " — drag onto the canvas");
+            return this;
+        }
+
+        @Override
+        protected void paintComponent(Graphics gr) {
+            Graphics2D g = (Graphics2D) gr.create();
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.setColor(selected ? new Color(0x26, 0x26, 0x2D) : new Color(0x17, 0x17, 0x1B));
+            g.fillRect(0, 0, getWidth(), getHeight());
+            if (entry.kind() == null) {
+                g.setColor(new Color(0x7A, 0x7D, 0x85));
+                g.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 10));
+                g.drawString(entry.header(), 10, getHeight() - 9);
+            } else {
+                Color base = entry.kind().getCategory().color;
+                g.setColor(base);
+                g.fillRoundRect(10, 4, getWidth() - 24, getHeight() - 9, 8, 8);
+                g.setColor(base.darker());
+                g.fillRoundRect(10, 4, 20, getHeight() - 9, 8, 8);
+                g.setColor(new Color(0, 0, 0, 130));
+                g.drawRoundRect(10, 4, getWidth() - 24, getHeight() - 9, 8, 8);
+                g.setColor(Color.WHITE);
+                g.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 11));
+                g.drawString(entry.kind().getDisplayName(), 36, getHeight() / 2 + 4);
+                // port nubs make it read as a node
+                g.setColor(new Color(0xD6, 0xD7, 0xDB));
+                g.fillRoundRect(6, getHeight() / 2 - 4, 7, 7, 2, 2);
+                g.fillRoundRect(getWidth() - 13, getHeight() / 2 - 4, 7, 7, 2, 2);
+            }
+            g.dispose();
+        }
+    }
+}

--- a/infra/src/main/java/org/nmox/studio/infra/ui/PropertyPanel.java
+++ b/infra/src/main/java/org/nmox/studio/infra/ui/PropertyPanel.java
@@ -1,0 +1,178 @@
+package org.nmox.studio.infra.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.InfraGraph.InfraNode;
+import org.nmox.studio.infra.model.NodeKind;
+
+/**
+ * The right-hand inspector: edit the selected node's label and
+ * properties, see its monthly price and live id. Edits apply
+ * immediately and nudge the graph so persistence and the cost total
+ * follow along.
+ */
+public class PropertyPanel extends JPanel {
+
+    private final InfraGraph graph;
+    private final JPanel form = new JPanel(new GridBagLayout());
+    private final JLabel header = new JLabel("No selection");
+    private final JLabel costLabel = new JLabel(" ");
+    private InfraNode current;
+
+    public PropertyPanel(InfraGraph graph) {
+        super(new BorderLayout());
+        this.graph = graph;
+        setPreferredSize(new Dimension(250, 400));
+        setBackground(new Color(0x17, 0x17, 0x1B));
+
+        header.setForeground(new Color(0xE6, 0xE7, 0xEB));
+        header.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 13));
+        header.setBorder(BorderFactory.createEmptyBorder(10, 12, 6, 12));
+        add(header, BorderLayout.NORTH);
+
+        form.setBackground(getBackground());
+        JScrollPane scroll = new JScrollPane(form);
+        scroll.setBorder(BorderFactory.createEmptyBorder());
+        scroll.getViewport().setBackground(getBackground());
+        add(scroll, BorderLayout.CENTER);
+
+        costLabel.setForeground(new Color(0x4E, 0xC9, 0x8B));
+        costLabel.setFont(new Font(Font.MONOSPACED, Font.BOLD, 12));
+        costLabel.setBorder(BorderFactory.createEmptyBorder(8, 12, 10, 12));
+        add(costLabel, BorderLayout.SOUTH);
+
+        show(null);
+    }
+
+    public final void show(InfraNode node) {
+        this.current = node;
+        form.removeAll();
+        if (node == null) {
+            header.setText("No selection");
+            costLabel.setText(" ");
+        } else {
+            header.setText(node.kind.getDisplayName());
+            GridBagConstraints gc = new GridBagConstraints();
+            gc.gridx = 0;
+            gc.gridy = 0;
+            gc.anchor = GridBagConstraints.WEST;
+            gc.fill = GridBagConstraints.HORIZONTAL;
+            gc.insets = new Insets(3, 12, 3, 12);
+
+            addRow(gc, "Name", labelField(node));
+            for (NodeKind.Prop prop : node.kind.getProps()) {
+                addRow(gc, prop.label(), editorFor(node, prop));
+            }
+            if (node.doId != null) {
+                JLabel live = new JLabel("live: " + node.doId);
+                live.setForeground(new Color(0x4E, 0xC9, 0x8B));
+                gc.gridwidth = 2;
+                form.add(live, gc);
+            }
+            refreshCost();
+        }
+        form.revalidate();
+        form.repaint();
+    }
+
+    private void addRow(GridBagConstraints gc, String label, javax.swing.JComponent editor) {
+        JLabel l = new JLabel(label);
+        l.setForeground(new Color(0x9A, 0x9D, 0xA4));
+        gc.gridx = 0;
+        gc.weightx = 0;
+        form.add(l, gc);
+        gc.gridx = 1;
+        gc.weightx = 1;
+        form.add(editor, gc);
+        gc.gridy++;
+    }
+
+    private JTextField labelField(InfraNode node) {
+        JTextField field = new JTextField(node.label);
+        field.getDocument().addDocumentListener(new SimpleDocListener(() -> {
+            node.label = field.getText().trim();
+            graph.touch();
+        }));
+        return field;
+    }
+
+    private javax.swing.JComponent editorFor(InfraNode node, NodeKind.Prop prop) {
+        String value = node.props.getOrDefault(prop.key(), prop.defaultValue());
+        switch (prop.type()) {
+            case "choice" -> {
+                JComboBox<String> combo = new JComboBox<>(prop.choices().toArray(new String[0]));
+                combo.setSelectedItem(value);
+                combo.addActionListener(e -> {
+                    node.props.put(prop.key(), String.valueOf(combo.getSelectedItem()));
+                    graph.touch();
+                    refreshCost();
+                });
+                return combo;
+            }
+            case "bool" -> {
+                JCheckBox box = new JCheckBox("", Boolean.parseBoolean(value));
+                box.setBackground(getBackground());
+                box.addActionListener(e -> {
+                    node.props.put(prop.key(), String.valueOf(box.isSelected()));
+                    graph.touch();
+                    refreshCost();
+                });
+                return box;
+            }
+            default -> {
+                JTextField field = new JTextField(value);
+                field.getDocument().addDocumentListener(new SimpleDocListener(() -> {
+                    node.props.put(prop.key(), field.getText());
+                    graph.touch();
+                    refreshCost();
+                }));
+                return field;
+            }
+        }
+    }
+
+    private void refreshCost() {
+        if (current != null) {
+            costLabel.setText(String.format("≈ $%.2f/mo   (design: $%.2f/mo)",
+                    current.monthlyUsd(), graph.totalMonthlyUsd()));
+        }
+    }
+
+    /** A document listener that just runs a callback on any change. */
+    private static final class SimpleDocListener implements javax.swing.event.DocumentListener {
+
+        private final Runnable onChange;
+
+        SimpleDocListener(Runnable onChange) {
+            this.onChange = onChange;
+        }
+
+        @Override
+        public void insertUpdate(javax.swing.event.DocumentEvent e) {
+            onChange.run();
+        }
+
+        @Override
+        public void removeUpdate(javax.swing.event.DocumentEvent e) {
+            onChange.run();
+        }
+
+        @Override
+        public void changedUpdate(javax.swing.event.DocumentEvent e) {
+            onChange.run();
+        }
+    }
+}

--- a/infra/src/test/java/org/nmox/studio/infra/api/DeployPlannerTest.java
+++ b/infra/src/test/java/org/nmox/studio/infra/api/DeployPlannerTest.java
@@ -1,0 +1,117 @@
+package org.nmox.studio.infra.api;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.NodeKind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeployPlannerTest {
+
+    @Test
+    @DisplayName("Plan orders providers before consumers: VPC -> droplet -> LB -> domain")
+    void planRespectsDependencies() {
+        InfraGraph graph = new InfraGraph();
+        var domain = graph.addNode(NodeKind.DOMAIN, 600, 0); // deliberately added first
+        var lb = graph.addNode(NodeKind.LOAD_BALANCER, 400, 0);
+        var droplet = graph.addNode(NodeKind.DROPLET, 200, 0);
+        var vpc = graph.addNode(NodeKind.VPC, 0, 0);
+        graph.connect(vpc, droplet);
+        graph.connect(droplet, lb);
+        graph.connect(lb, domain);
+
+        List<DoRequest> plan = DeployPlanner.plan(graph);
+        List<String> order = plan.stream().map(DoRequest::nodeId).toList();
+
+        assertThat(order.indexOf(vpc.id)).isLessThan(order.indexOf(droplet.id));
+        assertThat(order.indexOf(droplet.id)).isLessThan(order.indexOf(lb.id));
+        assertThat(order.indexOf(lb.id)).isLessThan(order.indexOf(domain.id));
+    }
+
+    @Test
+    @DisplayName("Creation requests embed provider references as placeholders")
+    void placeholdersEmbedded() {
+        InfraGraph graph = new InfraGraph();
+        var vpc = graph.addNode(NodeKind.VPC, 0, 0);
+        var key = graph.addNode(NodeKind.SSH_KEY, 0, 100);
+        var droplet = graph.addNode(NodeKind.DROPLET, 200, 0);
+        graph.connect(vpc, droplet);
+        graph.connect(key, droplet);
+
+        DoRequest dropletReq = DeployPlanner.plan(graph).stream()
+                .filter(r -> r.nodeId().equals(droplet.id)).findFirst().orElseThrow();
+
+        String body = dropletReq.body().toString();
+        assertThat(body).contains("${id-of:" + vpc.id + "}");
+        assertThat(body).contains("${id-of:" + key.id + "}");
+        assertThat(dropletReq.path()).isEqualTo("/v2/droplets");
+    }
+
+    @Test
+    @DisplayName("Volume/firewall/reserved-IP wires become post-create attachment actions")
+    void attachmentsComeLast() {
+        InfraGraph graph = new InfraGraph();
+        var droplet = graph.addNode(NodeKind.DROPLET, 0, 0);
+        var volume = graph.addNode(NodeKind.VOLUME, 0, 100);
+        var firewall = graph.addNode(NodeKind.FIREWALL, 0, 200);
+        graph.connect(volume, droplet);
+        graph.connect(firewall, droplet);
+
+        List<DoRequest> plan = DeployPlanner.plan(graph);
+
+        // three creations + two attachments
+        assertThat(plan).hasSize(5);
+        assertThat(plan.get(3).path()).contains("/actions");
+        assertThat(plan.get(3).body().getString("type")).isEqualTo("attach");
+        assertThat(plan.get(4).path()).contains("/droplets");
+        // attachments reference both endpoints
+        assertThat(plan.get(3).path()).contains("${id-of:" + volume.id + "}");
+        assertThat(plan.get(3).body().toString()).contains("${id-of:" + droplet.id + "}");
+    }
+
+    @Test
+    @DisplayName("Spaces buckets are planned as explicit skips (S3 protocol)")
+    void spacesSkipped() {
+        InfraGraph graph = new InfraGraph();
+        graph.addNode(NodeKind.SPACES, 0, 0);
+
+        List<DoRequest> plan = DeployPlanner.plan(graph);
+
+        assertThat(plan).hasSize(1);
+        assertThat(plan.get(0).skipped()).isTrue();
+        assertThat(plan.get(0).description()).contains("S3");
+    }
+
+    @Test
+    @DisplayName("Already-live nodes are not re-created")
+    void liveNodesSkipCreation() {
+        InfraGraph graph = new InfraGraph();
+        var vpc = graph.addNode(NodeKind.VPC, 0, 0);
+        vpc.doId = "existing-vpc-uuid";
+        var droplet = graph.addNode(NodeKind.DROPLET, 200, 0);
+        graph.connect(vpc, droplet);
+
+        List<DoRequest> plan = DeployPlanner.plan(graph);
+
+        assertThat(plan).hasSize(1);
+        assertThat(plan.get(0).nodeId()).isEqualTo(droplet.id);
+        // and the droplet references the REAL id, not a placeholder
+        assertThat(plan.get(0).body().getString("vpc_uuid")).isEqualTo("existing-vpc-uuid");
+    }
+
+    @Test
+    @DisplayName("Database creation carries engine, version and size")
+    void databasePayload() {
+        InfraGraph graph = new InfraGraph();
+        var db = graph.addNode(NodeKind.DB_POSTGRES, 0, 0);
+
+        DoRequest request = DeployPlanner.plan(graph).get(0);
+
+        assertThat(request.path()).isEqualTo("/v2/databases");
+        assertThat(request.body().getString("engine")).isEqualTo("pg");
+        assertThat(request.body().getString("version")).isEqualTo("16");
+        assertThat(request.body().getString("size")).isEqualTo("db-s-1vcpu-1gb");
+    }
+}

--- a/infra/src/test/java/org/nmox/studio/infra/model/InfraModelTest.java
+++ b/infra/src/test/java/org/nmox/studio/infra/model/InfraModelTest.java
@@ -1,0 +1,115 @@
+package org.nmox.studio.infra.model;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InfraModelTest {
+
+    @ParameterizedTest
+    @EnumSource(NodeKind.class)
+    @DisplayName("Catalog contract: display name, category, unique prop keys, sane cost")
+    void catalogContract(NodeKind kind) {
+        assertThat(kind.getDisplayName()).isNotBlank();
+        assertThat(kind.getCategory()).isNotNull();
+        Set<String> keys = new HashSet<>();
+        for (NodeKind.Prop prop : kind.getProps()) {
+            assertThat(keys.add(prop.key())).as(kind + " duplicate prop " + prop.key()).isTrue();
+            assertThat(prop.defaultValue()).as(kind + "." + prop.key() + " default").isNotNull();
+            if ("choice".equals(prop.type())) {
+                assertThat(prop.choices()).as(kind + "." + prop.key() + " choices")
+                        .contains(prop.defaultValue());
+            }
+        }
+        assertThat(kind.estimateMonthlyUsd(java.util.Map.of()))
+                .as(kind + " cost").isGreaterThanOrEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("Wire rules form a DAG - no relationship cycles are possible")
+    void wireRulesAreAcyclic() {
+        // DFS over kind->kind creation edges
+        for (NodeKind start : NodeKind.values()) {
+            assertThat(reachable(start, start, new HashSet<>()))
+                    .as(start + " participates in a relationship cycle").isFalse();
+        }
+    }
+
+    private boolean reachable(NodeKind from, NodeKind target, Set<NodeKind> seen) {
+        for (NodeKind next : from.wiresInto()) {
+            if (next == target) {
+                return true;
+            }
+            if (seen.add(next) && reachable(next, target, seen)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    @DisplayName("Graph enforces wire rules and cleans up on node removal")
+    void graphRules() {
+        InfraGraph graph = new InfraGraph();
+        var vpc = graph.addNode(NodeKind.VPC, 0, 0);
+        var droplet = graph.addNode(NodeKind.DROPLET, 100, 0);
+        var domain = graph.addNode(NodeKind.DOMAIN, 200, 0);
+
+        assertThat(graph.connect(vpc, droplet)).isTrue();
+        assertThat(graph.connect(vpc, droplet)).as("duplicate").isFalse();
+        assertThat(graph.connect(droplet, vpc)).as("reverse not allowed").isFalse();
+        assertThat(graph.connect(vpc, domain)).as("vpc->domain invalid").isFalse();
+        assertThat(graph.connect(droplet, domain)).isTrue();
+
+        graph.removeNode(droplet);
+        assertThat(graph.getWires()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Cost: droplet size and k8s node count drive the estimate")
+    void costEstimates() {
+        InfraGraph graph = new InfraGraph();
+        var droplet = graph.addNode(NodeKind.DROPLET, 0, 0);
+        assertThat(droplet.monthlyUsd()).isEqualTo(6.0);
+        droplet.props.put("size", "s-4vcpu-8gb");
+        assertThat(droplet.monthlyUsd()).isEqualTo(48.0);
+
+        var k8s = graph.addNode(NodeKind.KUBERNETES, 0, 0);
+        k8s.props.put("nodeCount", "5");
+        k8s.props.put("ha", "true");
+        assertThat(k8s.monthlyUsd()).isEqualTo(24.0 * 5 + 40.0);
+
+        assertThat(graph.totalMonthlyUsd()).isEqualTo(48.0 + 160.0);
+    }
+
+    @Test
+    @DisplayName("Designs round-trip through JSON with props, positions and live ids")
+    void jsonRoundTrip() {
+        InfraGraph graph = new InfraGraph();
+        var vpc = graph.addNode(NodeKind.VPC, 40, 60);
+        var droplet = graph.addNode(NodeKind.DROPLET, 240, 60);
+        droplet.label = "web-1";
+        droplet.props.put("size", "s-2vcpu-4gb");
+        droplet.doId = "12345";
+        graph.connect(vpc, droplet);
+
+        JSONObject json = GraphIO.toJson(graph);
+        InfraGraph restored = new InfraGraph();
+        GraphIO.fromJson(restored, json);
+
+        assertThat(restored.getNodes()).hasSize(2);
+        var restoredDroplet = restored.getNodes().stream()
+                .filter(n -> n.kind == NodeKind.DROPLET).findFirst().orElseThrow();
+        assertThat(restoredDroplet.label).isEqualTo("web-1");
+        assertThat(restoredDroplet.props).containsEntry("size", "s-2vcpu-4gb");
+        assertThat(restoredDroplet.doId).isEqualTo("12345");
+        assertThat(restoredDroplet.x).isEqualTo(240);
+        assertThat(restored.getWires()).hasSize(1);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <module>project</module>
         <module>tools</module>
         <module>rack</module>
+        <module>infra</module>
         <!-- Temporarily disabled for initial build
         <module>cloud</module>
         <module>deployment</module>


### PR DESCRIPTION
## Summary

A new `infra` module: **DigitalOcean's catalog as a drag-and-drop flow**, visually modeled on Node-RED, wired to the live v2 API.

### The palette — 1:1 with DigitalOcean
22 node kinds across Compute (Droplet/GPU/DOKS/App Platform/Functions/Gradient AI), Networking (VPC/LB/Firewall/Reserved IP/DNS/CDN), Storage (Volume/Spaces/Registry), Databases (PG/MySQL/Mongo/Valkey/Kafka/OpenSearch), Ops (SSH Key/Cert/Alerts) — each with real property defaults (sizes/regions/images), a monthly price model, and **relationship rules that make invalid wires undrawable** (`VPC→Droplet` placement, `Droplet→LB` backend, `Spaces→CDN` origin, `Cert→LB` TLS...).

### The canvas — Node-RED, dark
Dotted grid, rounded category-colored nodes with icon bands and port nubs, horizontal bezier wires, grid-snap node drag, output-nub wire dragging, pan + cursor-zoom, Delete, double-click-to-configure, per-node cost tooltips, and status dots that go green when a node is live in the cloud.

### The red DEPLOY button
- **No token** → full dry-run: the exact ordered API call list with bodies summarized + total monthly cost
- **Token set** (`DIGITALOCEAN_TOKEN` or the Token… dialog) → the same plan executes live: topological creation order, `${id-of:…}` placeholders resolved as resources come up, droplets polled for public IPs before DNS records point at them, volumes/firewalls/reserved IPs attached post-create, per-node status streamed onto the canvas
- **Sync from cloud** imports existing droplets/VPCs/LBs/volumes/domains/databases as live nodes; right-click destroys individual resources with confirmation
- Designs persist to `.nmoxinfra.json` in the project — infra topology travels with the repo

## Test plan
- 12 new tests: catalog contract per kind, wire-rule DAG proof, graph validity rules, cost math, JSON round-trip, plan ordering, placeholder embedding, attachment sequencing, Spaces skip, live-node short-circuit
- Full reactor green; IDE relaunched with the designer open under Window → Infra Designer

🤖 Generated with [Claude Code](https://claude.com/claude-code)