### PR TITLE
World-class Angular: HALO console device, v22 template, snippets

### DIFF
--- a/editor/src/main/java/org/nmox/studio/editor/completion/JavaScriptCompletionProvider.java
+++ b/editor/src/main/java/org/nmox/studio/editor/completion/JavaScriptCompletionProvider.java
@@ -161,6 +161,10 @@ public class JavaScriptCompletionProvider implements CompletionProvider {
         SNIPPETS.add(new JavaScriptSnippet("try", "try {\n    ${1}\n} catch (${2:error}) {\n    ${3}\n}", "Try-catch block"));
         SNIPPETS.add(new JavaScriptSnippet("promise", "new Promise((resolve, reject) => {\n    ${1}\n})", "Promise"));
         SNIPPETS.add(new JavaScriptSnippet("async", "async function ${1:name}(${2:params}) {\n    ${3}\n}", "Async function"));
+        SNIPPETS.add(new JavaScriptSnippet("signal", "const ${1:value} = signal(${2:initial});", "Angular signal"));
+        SNIPPETS.add(new JavaScriptSnippet("computed", "const ${1:value} = computed(() => ${2});", "Angular computed"));
+        SNIPPETS.add(new JavaScriptSnippet("inject", "private readonly ${1:dep} = inject(${2:Type});", "Angular inject"));
+        SNIPPETS.add(new JavaScriptSnippet("bootstrap", "bootstrapApplication(${1:App}, ${2:appConfig});", "Angular bootstrap"));
         SNIPPETS.add(new JavaScriptSnippet("fetch", "fetch('${1:url}')\n    .then(response => response.json())\n    .then(data => {\n        ${2}\n    })\n    .catch(error => console.error(error));", "Fetch API"));
     }
     

--- a/editor/src/main/resources/org/nmox/studio/editor/javascript/codetemplates.xml
+++ b/editor/src/main/resources/org/nmox/studio/editor/javascript/codetemplates.xml
@@ -105,4 +105,61 @@ ${cursor}</code>
  */</code>
         <description>JSDoc block</description>
     </codetemplate>
+    <codetemplate abbreviation="ngc">
+        <code>import { Component, signal } from '@angular/core';
+
+@Component({
+  selector: 'app-${name}',
+  template: `&lt;div&gt;${name} works&lt;/div&gt;`,
+})
+export class ${Name} {
+}</code>
+        <description>Angular standalone component</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngs">
+        <code>import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ${Name}Service {
+}</code>
+        <description>Angular service</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngsig">
+        <code>readonly ${name} = signal(${initial});</code>
+        <description>Angular signal</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngcomp">
+        <code>readonly ${name} = computed(() =&gt; ${cursor});</code>
+        <description>Angular computed</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngeff">
+        <code>effect(() =&gt; {
+  ${cursor}
+});</code>
+        <description>Angular effect</description>
+    </codetemplate>
+    <codetemplate abbreviation="nginj">
+        <code>private readonly ${name} = inject(${Type});</code>
+        <description>Angular inject()</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngin">
+        <code>readonly ${name} = input&lt;${Type}&gt;();</code>
+        <description>Angular signal input</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngout">
+        <code>readonly ${name} = output&lt;${Type}&gt;();</code>
+        <description>Angular signal output</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngif">
+        <code>@if (${condition}) {
+  ${cursor}
+}</code>
+        <description>Angular @if block</description>
+    </codetemplate>
+    <codetemplate abbreviation="ngfor">
+        <code>@for (${item} of ${items}(); track ${item}) {
+  ${cursor}
+}</code>
+        <description>Angular @for block</description>
+    </codetemplate>
 </codetemplates>

--- a/rack/src/main/java/org/nmox/studio/rack/devices/AngularDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/AngularDevice.java
@@ -1,0 +1,197 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.ui.controls.Knob;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.Led;
+import org.nmox.studio.rack.ui.controls.RackButton;
+import org.nmox.studio.rack.ui.controls.RackStyle;
+import org.nmox.studio.rack.ui.controls.ToggleSwitch;
+
+/**
+ * HALO Angular Console: first-class Angular operations in one rack
+ * unit. SERVE runs the dev server (URL out feeds SCOPE), BUILD and
+ * TEST drive the ng builders, the GENERATE row scaffolds schematics,
+ * and the version cluster tracks the installed @angular/core against
+ * the registry's latest - the OUTDATED LED is the "stay current"
+ * nudge, and UPDATE runs `ng update` to chase it.
+ */
+public class AngularDevice extends CommandDevice {
+
+    private static final String[] SCHEMATICS = {
+        "component", "service", "directive", "pipe", "guard", "interceptor", "resolver", "class"};
+    private static final java.util.regex.Pattern LOCAL_URL =
+            java.util.regex.Pattern.compile("(https?://(?:localhost|127\\.0\\.0\\.1):\\d+[^\\s\"']*)");
+
+    private final LcdDisplay versionLcd;
+    private final Led currentLed;
+    private final Led outdatedLed;
+    private final ToggleSwitch prodSwitch;
+    private final Knob schematicKnob;
+    private final LcdDisplay nameLcd;
+    private final AtomicBoolean readyFired = new AtomicBoolean();
+    private volatile String installedVersion;
+    private volatile String latestVersion;
+    private volatile String announcedUrl;
+
+    public AngularDevice() {
+        super("angular", "HALO", "ANGULAR CONSOLE", new Color(0xDD, 0x00, 0x31), 3);
+
+        // ---- row 1: version currency ----
+        versionLcd = place(new LcdDisplay(210, 1), 44, 40);
+        versionLcd.setText("v? → ?");
+        versionLcd.setToolTipText("installed @angular/core → latest on the registry");
+        currentLed = place(new Led("CURRENT", new Color(80, 235, 100)), 262, 46);
+        outdatedLed = place(new Led("OUTDATED", new Color(255, 190, 60)), 318, 46);
+        RackButton check = place(new RackButton("CHECK", new Color(70, 170, 235)), 382, 40);
+        RackButton update = place(new RackButton("UPDATE", new Color(255, 190, 60)), 446, 40);
+
+        // ---- row 2: run/build/test + schematics ----
+        RackButton serve = place(new RackButton("SERVE", new Color(80, 235, 100)), 44, 96);
+        RackButton stop = place(new RackButton("STOP", new Color(255, 70, 60)), 108, 96);
+        prodSwitch = place(new ToggleSwitch("BUILD AS", true, "PROD", "DEV"), 174, 88);
+        RackButton build = place(new RackButton("BUILD", new Color(232, 166, 35)), 240, 96);
+        RackButton test = place(new RackButton("TEST", new Color(99, 197, 70)), 304, 96);
+        schematicKnob = place(new Knob("SCHEMATIC", SCHEMATICS, 0), 380, 84);
+        nameLcd = place(new LcdDisplay(130, 1), 452, 96);
+        nameLcd.setText("widget");
+        nameLcd.setEditable("Name for ng generate");
+        RackButton generate = place(new RackButton("GEN", new Color(0xDD, 0x00, 0x31)), 592, 96);
+
+        check.addActionListener(e -> refreshVersions());
+        update.addActionListener(e -> launch(List.of("npx", "ng", "update",
+                "@angular/cli", "@angular/core", "--allow-dirty")));
+        serve.addActionListener(e -> serve());
+        stop.addActionListener(e -> stopProcess());
+        build.addActionListener(e -> primaryAction());
+        test.addActionListener(e -> launch(List.of("npx", "ng", "test", "--watch=false")));
+        generate.addActionListener(e -> {
+            String name = nameLcd.getText().trim();
+            if (!name.isEmpty()) {
+                launch(List.of("npx", "ng", "generate",
+                        SCHEMATICS[schematicKnob.getSelectedIndex()], name));
+            }
+        });
+
+        addInPort("serve", "SERVE", SignalType.TRIGGER);
+        addInPort("stop", "STOP", SignalType.TRIGGER);
+        addOutPort("url", "URL", SignalType.DATA);
+        addOutPort("ready", "READY", SignalType.TRIGGER);
+        addOutPort("serving", "SERVING", SignalType.GATE);
+
+        param("prod", prodSwitch);
+        param("schematic", schematicKnob);
+        param("genName", nameLcd);
+    }
+
+    /** ng always runs beside package.json, even in mixed monorepos. */
+    @Override
+    protected ProjectInspector.ProjectKind effectiveKind() {
+        return ProjectInspector.ProjectKind.NODE;
+    }
+
+    @Override
+    protected void onAttached() {
+        refreshVersions();
+    }
+
+    @Override
+    public void projectChanged(File dir) {
+        refreshVersions();
+    }
+
+    /** Installed version from package.json; latest from the registry, async. */
+    private void refreshVersions() {
+        installedVersion = AngularVersions.installed(projectDir());
+        showVersions();
+        if (installedVersion == null) {
+            onEdt(() -> statusLcd.setText(ProjectInspector.hasAngular(projectDir())
+                    ? "ANGULAR WORKSPACE — DEPS NOT INSTALLED?"
+                    : "NO ANGULAR.JSON IN PROJECT"));
+            return;
+        }
+        StringBuilder out = new StringBuilder();
+        CommandProbe.run(projectDir(),
+                List.of(org.nmox.studio.rack.engine.ToolLocator.resolve("npm"),
+                        "view", "@angular/core", "version"),
+                out::append, code -> {
+                    if (code == 0 && !out.isEmpty()) {
+                        latestVersion = out.toString().trim();
+                        showVersions();
+                    }
+                });
+    }
+
+    private void showVersions() {
+        String installed = installedVersion;
+        String latest = latestVersion;
+        boolean outdated = AngularVersions.isOutdated(installed, latest);
+        boolean majorBehind = AngularVersions.isMajorBehind(installed, latest);
+        onEdt(() -> {
+            versionLcd.setTextColor(outdated ? RackStyle.LCD_AMBER : RackStyle.LCD_TEXT);
+            versionLcd.setText("v" + (installed == null ? "?" : installed)
+                    + " → " + (latest == null ? "checking…" : latest)
+                    + (latest == null ? "" : outdated ? (majorBehind ? "  MAJOR!" : "") : "  ✓"));
+            currentLed.setOn(latest != null && !outdated);
+            outdatedLed.setOn(outdated);
+            if (outdated) {
+                outdatedLed.setBlinking(majorBehind);
+            }
+        });
+    }
+
+    private void serve() {
+        readyFired.set(false);
+        emit("serving", Signal.gate(true));
+        launch(List.of("npx", "ng", "serve"));
+    }
+
+    @Override
+    protected List<String> buildCommand() {
+        List<String> cmd = new ArrayList<>(List.of("npx", "ng", "build"));
+        if (!prodSwitch.isOn()) {
+            cmd.add("--configuration=development");
+        }
+        return cmd;
+    }
+
+    @Override
+    protected void onLine(String line) {
+        java.util.regex.Matcher m = LOCAL_URL.matcher(line);
+        if (m.find()) {
+            String url = m.group(1);
+            if (readyFired.compareAndSet(false, true)) {
+                emit("ready", Signal.trigger());
+            }
+            if (!url.equals(announcedUrl)) {
+                announcedUrl = url;
+                onEdt(() -> statusLcd.setText("SERVING  " + url));
+                emit("url", Signal.data(url));
+            }
+        }
+    }
+
+    @Override
+    protected void onFinished(int exitCode) {
+        emit("serving", Signal.gate(false));
+        announcedUrl = null;
+        // a finished `ng update` may have bumped package.json
+        refreshVersions();
+    }
+
+    @Override
+    public void receive(Port in, Signal signal) {
+        switch (in.getId()) {
+            case "serve" -> serve();
+            case "stop" -> stopProcess();
+            default -> super.receive(in, signal);
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/devices/AngularVersions.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/AngularVersions.java
@@ -1,0 +1,64 @@
+package org.nmox.studio.rack.devices;
+
+import java.io.File;
+
+/**
+ * Version arithmetic for the HALO Angular console: reads the installed
+ * @angular/core constraint from package.json and compares against the
+ * registry's latest, so the OUTDATED LED tells the truth.
+ */
+public final class AngularVersions {
+
+    private AngularVersions() {
+    }
+
+    /** The @angular/core constraint from package.json, cleaned: "22.0.1", or null. */
+    public static String installed(File projectDir) {
+        String raw = ProjectInspector.dependencyVersion(projectDir, "@angular/core");
+        return raw == null ? null : clean(raw);
+    }
+
+    /** Strips range operators: "^22.0.1" -> "22.0.1". */
+    public static String clean(String constraint) {
+        return constraint.replaceAll("[~^>=<\\s]", "");
+    }
+
+    /**
+     * True when latest is a newer release than installed. Compares
+     * numeric segments; non-numeric segments compare as zero.
+     */
+    public static boolean isOutdated(String installed, String latest) {
+        if (installed == null || latest == null) {
+            return false;
+        }
+        String[] a = clean(installed).split("\\.");
+        String[] b = clean(latest).split("\\.");
+        for (int i = 0; i < Math.max(a.length, b.length); i++) {
+            int x = segment(a, i);
+            int y = segment(b, i);
+            if (x != y) {
+                return x < y;
+            }
+        }
+        return false;
+    }
+
+    /** Majors differ: an `ng update` is a real migration, not a patch. */
+    public static boolean isMajorBehind(String installed, String latest) {
+        if (installed == null || latest == null) {
+            return false;
+        }
+        return segment(clean(installed).split("\\."), 0) < segment(clean(latest).split("\\."), 0);
+    }
+
+    private static int segment(String[] parts, int index) {
+        if (index >= parts.length) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(parts[index].replaceAll("\\D.*$", ""));
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
@@ -15,6 +15,7 @@ public enum DeviceType {
     ROSETTA("rosetta", "ROSETTA", "Language Selector — steer AUTO knobs in mixed repos", new Color(64, 224, 178), RosettaDevice::new),
     RUN("run", "IGNITION", "Polyglot Runtime — run anything: node/go/rust/py/rb/php", new Color(255, 94, 58), RunDevice::new),
     DEBUG("debug", "INSPECTOR", "Debug Launcher — debug servers with attach endpoints", new Color(186, 85, 255), DebugDevice::new),
+    ANGULAR("angular", "HALO", "Angular Console — serve/generate/update, stays current", new Color(0xDD, 0x00, 0x31), AngularDevice::new),
     NPM_SCRIPT("npm-script", "NPM-9000", "Script Sequencer — run package.json scripts", new Color(203, 56, 55), NpmScriptDevice::new),
     PACKAGE_MANAGER("package-manager", "CRATE", "Package Manager — install & update deps", new Color(214, 121, 41), PackageManagerDevice::new),
     BUILD("build", "FORGE", "Build Engine — vite/webpack/rollup & co", new Color(232, 166, 35), BuildDevice::new),

--- a/rack/src/main/java/org/nmox/studio/rack/devices/ProjectInspector.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/ProjectInspector.java
@@ -153,6 +153,29 @@ public final class ProjectInspector {
         };
     }
 
+    /** True when the project (or its Node subproject) is an Angular workspace. */
+    public static boolean hasAngular(File projectDir) {
+        return new File(projectDir, "angular.json").isFile()
+                || new File(kindDir(projectDir, ProjectKind.NODE), "angular.json").isFile();
+    }
+
+    /** The declared version constraint of a dependency, or null. */
+    public static String dependencyVersion(File projectDir, String name) {
+        JSONObject json = read(projectDir);
+        if (json == null) {
+            return null;
+        }
+        JSONObject deps = json.optJSONObject("dependencies");
+        if (deps != null && deps.has(name)) {
+            return deps.getString(name);
+        }
+        JSONObject devDeps = json.optJSONObject("devDependencies");
+        if (devDeps != null && devDeps.has(name)) {
+            return devDeps.getString(name);
+        }
+        return null;
+    }
+
     /**
      * The first of the candidate packages found in dependencies or
      * devDependencies, or null. Order expresses preference.

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/ProjectTemplates.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/ProjectTemplates.java
@@ -721,6 +721,253 @@ public enum ProjectTemplates {
                 - arm REFLEX's WATCH switch for a save-driven test loop
                 """;
         }
+    },
+
+    ANGULAR("Angular (standalone)", "Angular 22, zoneless, signals + control flow, HALO-wired") {
+        @Override
+        void writeFiles(Path dir, String name) throws IOException {
+            write(dir, "package.json", """
+                {
+                  "name": "%s",
+                  "version": "0.1.0",
+                  "private": true,
+                  "scripts": {
+                    "ng": "ng",
+                    "start": "ng serve",
+                    "build": "ng build",
+                    "test": "ng test"
+                  },
+                  "dependencies": {
+                    "@angular/common": "^22.0.0",
+                    "@angular/compiler": "^22.0.0",
+                    "@angular/core": "^22.0.0",
+                    "@angular/platform-browser": "^22.0.0",
+                    "@angular/router": "^22.0.0",
+                    "rxjs": "~7.8.0",
+                    "tslib": "^2.8.0"
+                  },
+                  "devDependencies": {
+                    "@angular/build": "^22.0.0",
+                    "@angular/cli": "^22.0.0",
+                    "@angular/compiler-cli": "^22.0.0",
+                    "typescript": "~5.9.0"
+                  }
+                }
+                """.formatted(name));
+            write(dir, "angular.json", """
+                {
+                  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+                  "version": 1,
+                  "projects": {
+                    "%s": {
+                      "projectType": "application",
+                      "root": "",
+                      "sourceRoot": "src",
+                      "prefix": "app",
+                      "architect": {
+                        "build": {
+                          "builder": "@angular/build:application",
+                          "options": {
+                            "outputPath": "dist/%s",
+                            "index": "src/index.html",
+                            "browser": "src/main.ts",
+                            "tsConfig": "tsconfig.app.json",
+                            "styles": ["src/styles.css"]
+                          },
+                          "configurations": {
+                            "production": {"outputHashing": "all"},
+                            "development": {"optimization": false, "sourceMap": true}
+                          },
+                          "defaultConfiguration": "production"
+                        },
+                        "serve": {
+                          "builder": "@angular/build:dev-server",
+                          "configurations": {
+                            "production": {"buildTarget": "%s:build:production"},
+                            "development": {"buildTarget": "%s:build:development"}
+                          },
+                          "defaultConfiguration": "development"
+                        },
+                        "test": {
+                          "builder": "@angular/build:unit-test"
+                        }
+                      }
+                    }
+                  }
+                }
+                """.formatted(name, name, name, name));
+            write(dir, "tsconfig.json", """
+                {
+                  "compileOnSave": false,
+                  "compilerOptions": {
+                    "strict": true,
+                    "noImplicitOverride": true,
+                    "noPropertyAccessFromIndexSignature": true,
+                    "noImplicitReturns": true,
+                    "noFallthroughCasesInSwitch": true,
+                    "skipLibCheck": true,
+                    "isolatedModules": true,
+                    "experimentalDecorators": false,
+                    "moduleResolution": "bundler",
+                    "importHelpers": true,
+                    "target": "ES2022",
+                    "module": "preserve"
+                  },
+                  "angularCompilerOptions": {
+                    "enableI18nLegacyMessageIdFormat": false,
+                    "strictInjectionParameters": true,
+                    "strictInputAccessModifiers": true,
+                    "typeCheckHostBindings": true,
+                    "strictTemplates": true
+                  }
+                }
+                """);
+            write(dir, "tsconfig.app.json", """
+                {
+                  "extends": "./tsconfig.json",
+                  "compilerOptions": {"outDir": "./out-tsc/app", "types": []},
+                  "files": ["src/main.ts"],
+                  "include": ["src/**/*.d.ts"]
+                }
+                """);
+            write(dir, "src/index.html", """
+                <!doctype html>
+                <html lang="en">
+                <head>
+                  <meta charset="utf-8">
+                  <title>%s</title>
+                  <meta name="viewport" content="width=device-width, initial-scale=1">
+                </head>
+                <body>
+                  <app-root></app-root>
+                </body>
+                </html>
+                """.formatted(name));
+            write(dir, "src/styles.css", """
+                :root { color-scheme: dark; }
+                body {
+                  margin: 0;
+                  font-family: system-ui, sans-serif;
+                  background: #1b1b1f;
+                  color: #e6e7eb;
+                  display: grid;
+                  place-items: center;
+                  min-height: 100vh;
+                }
+                """);
+            write(dir, "src/main.ts", """
+                import { bootstrapApplication } from '@angular/platform-browser';
+                import { appConfig } from './app/app.config';
+                import { App } from './app/app';
+
+                bootstrapApplication(App, appConfig).catch(err => console.error(err));
+                """);
+            write(dir, "src/app/app.config.ts", """
+                import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+                import { provideRouter } from '@angular/router';
+                import { routes } from './app.routes';
+
+                export const appConfig: ApplicationConfig = {
+                  providers: [provideZonelessChangeDetection(), provideRouter(routes)],
+                };
+                """);
+            write(dir, "src/app/app.routes.ts", """
+                import { Routes } from '@angular/router';
+
+                export const routes: Routes = [];
+                """);
+            write(dir, "src/app/app.ts", """
+                import { Component, computed, signal } from '@angular/core';
+
+                @Component({
+                  selector: 'app-root',
+                  templateUrl: './app.html',
+                  styleUrl: './app.css',
+                })
+                export class App {
+                  readonly count = signal(0);
+                  readonly doubled = computed(() => this.count() * 2);
+                  readonly features = signal(['signals', 'zoneless', 'control flow']);
+
+                  increment(): void {
+                    this.count.update(v => v + 1);
+                  }
+                }
+                """);
+            write(dir, "src/app/app.html", """
+                <main>
+                  <h1>%s</h1>
+                  <button (click)="increment()">count: {{ count() }}</button>
+                  <p>doubled: {{ doubled() }}</p>
+                  @if (count() > 4) {
+                    <p>that's plenty.</p>
+                  }
+                  <ul>
+                    @for (feature of features(); track feature) {
+                      <li>{{ feature }}</li>
+                    }
+                  </ul>
+                </main>
+                """.formatted(name));
+            write(dir, "src/app/app.css", """
+                main { text-align: center; }
+                button { font-size: 1.25rem; padding: 0.5rem 1.5rem; cursor: pointer; }
+                """);
+            write(dir, "src/app/app.spec.ts", """
+                import { TestBed } from '@angular/core/testing';
+                import { provideZonelessChangeDetection } from '@angular/core';
+                import { App } from './app';
+
+                describe('App', () => {
+                  beforeEach(async () => {
+                    await TestBed.configureTestingModule({
+                      imports: [App],
+                      providers: [provideZonelessChangeDetection()],
+                    }).compileComponents();
+                  });
+
+                  it('creates and counts', () => {
+                    const fixture = TestBed.createComponent(App);
+                    const app = fixture.componentInstance;
+                    expect(app).toBeTruthy();
+                    app.increment();
+                    expect(app.count()).toBe(1);
+                  });
+                });
+                """);
+        }
+
+        @Override
+        JSONObject buildPatch() {
+            return buildPatchFrom(rack -> {
+                RackDevice halo = add(rack, DeviceType.ANGULAR, Map.of("prod", "true"));
+                RackDevice deps = add(rack, DeviceType.PACKAGE_MANAGER, null);
+                RackDevice reflex = add(rack, DeviceType.REFLEX, Map.of("armed", "false", "filter", "1"));
+                RackDevice test = add(rack, DeviceType.TEST, null);
+                RackDevice browser = add(rack, DeviceType.BROWSER, null);
+                RackDevice console = add(rack, DeviceType.CONSOLE, null);
+                rack.connect(halo.getPort("url"), browser.getPort("url"));
+                rack.connect(halo.getPort("ready"), browser.getPort("open"));
+                rack.connect(reflex.getPort("changed"), test.getPort("run"));
+                rack.connect(test.getPort("out"), console.getPort("in"));
+                rack.connect(halo.getPort("out"), console.getPort("in"));
+            });
+        }
+
+        @Override
+        boolean lintable() {
+            return false; // angular-eslint arrives via `ng add angular-eslint`
+        }
+
+        @Override
+        String readmeHints() {
+            return """
+                - press INSTALL on CRATE (or run `npm install`) once
+                - SERVE on HALO runs ng serve and opens the browser via SCOPE
+                - HALO's version cluster tracks the latest Angular; UPDATE runs `ng update`
+                - GEN scaffolds components/services with the SCHEMATIC knob
+                """;
+        }
     };
 
     private final String displayName;

--- a/rack/src/test/java/org/nmox/studio/rack/devices/AngularVersionsTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/AngularVersionsTest.java
@@ -1,0 +1,49 @@
+package org.nmox.studio.rack.devices;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AngularVersionsTest {
+
+    @TempDir
+    Path projectDir;
+
+    @Test
+    @DisplayName("Cleans range operators and reads the installed constraint")
+    void readsInstalledVersion() throws Exception {
+        Files.writeString(projectDir.resolve("package.json"), """
+            {"dependencies": {"@angular/core": "^21.2.3"}}
+            """);
+        assertThat(AngularVersions.installed(projectDir.toFile())).isEqualTo("21.2.3");
+        assertThat(AngularVersions.clean("~22.0.1")).isEqualTo("22.0.1");
+        assertThat(AngularVersions.installed(new File(projectDir.toFile(), "missing"))).isNull();
+    }
+
+    @Test
+    @DisplayName("Outdated and major-behind comparisons tell the truth")
+    void comparesVersions() {
+        assertThat(AngularVersions.isOutdated("22.0.0", "22.0.1")).isTrue();
+        assertThat(AngularVersions.isOutdated("22.0.1", "22.0.1")).isFalse();
+        assertThat(AngularVersions.isOutdated("22.1.0", "22.0.9")).isFalse();
+        assertThat(AngularVersions.isOutdated("^21.0.0", "22.0.1")).isTrue();
+        assertThat(AngularVersions.isOutdated(null, "22.0.1")).isFalse();
+
+        assertThat(AngularVersions.isMajorBehind("21.9.9", "22.0.0")).isTrue();
+        assertThat(AngularVersions.isMajorBehind("22.0.0", "22.9.0")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Angular workspace detection finds angular.json at root and in Node subdirs")
+    void detectsAngularWorkspace() throws Exception {
+        assertThat(ProjectInspector.hasAngular(projectDir.toFile())).isFalse();
+
+        Files.writeString(projectDir.resolve("angular.json"), "{}");
+        assertThat(ProjectInspector.hasAngular(projectDir.toFile())).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

First-class Angular support across every layer of NMOX Studio, targeting **Angular 22** (verified latest on the registry at build time: 22.0.1).

### HALO Angular Console — the rack unit
A 3U device in Angular red with two rows:
- **Version currency cluster**: LCD shows installed `@angular/core` → registry latest (`npm view`, async, offline-safe); CURRENT/OUTDATED LEDs, blinking when a **major** behind; **UPDATE** runs `ng update @angular/cli @angular/core --allow-dirty`. This is the "stay up to date on the latest Angular tooling" mechanic — the rack literally tells you when Angular moved.
- **Operations row**: SERVE (scrapes the real dev-server URL, feeds SCOPE via cable, READY trigger + SERVING gate), STOP, BUILD with PROD/DEV switch, TEST (`ng test --watch=false`), and a GENERATE row — schematic knob (component/service/directive/pipe/guard/interceptor/resolver/class) + name LCD + GEN.
- Monorepo-aware: always operates beside package.json via the ROSETTA-era per-kind directory machinery.

### Angular 22 standalone template
`New Project → Angular (standalone)`: zoneless (`provideZonelessChangeDetection`), signals/computed demo, `@if`/`@for` control flow, `@angular/build` builders including the vitest-backed `unit-test` builder, strict tsconfig, a passing spec — and a pre-wired rack patch (HALO→SCOPE auto-open, REFLEX→VERITAS save loop, console trail). Works out of the box: INSTALL on CRATE, SERVE on HALO, browser opens.

### Editor
Ten `ng*` Tab snippets (component, service, signal, computed, effect, inject, input, output, @if, @for) + Angular completion snippets in TS.

## Test plan
- `AngularVersionsTest`: constraint cleaning, outdated/major comparisons, workspace detection
- HALO automatically under the 4-invariant device-contract suite; template under the all-templates generation/patch-load loop
- Full reactor green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)