### PR TITLE
LSP servers for every language

### DIFF
--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServers.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServers.java
@@ -2,6 +2,7 @@ package org.nmox.studio.editor.lsp;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.editor.mimelookup.MimeRegistrations;
@@ -16,8 +17,12 @@ import org.openide.util.Lookup;
  * own server over stdio and hands it to the platform's LSP client -
  * definitions, hover, semantic completion, rename and live
  * diagnostics arrive wholesale. Servers are found through ToolLocator
- * (Homebrew, npm, cargo, go installs); a missing server degrades
- * silently to the TextMate-level experience.
+ * (Homebrew, npm, cargo, go, dotnet tool, coursier, gem installs); a
+ * missing server degrades silently to the TextMate-level experience.
+ *
+ * Where an ecosystem has competing servers the provider tries them in
+ * preference order (ruby-lsp before solargraph, csharp-ls before
+ * OmniSharp) so whichever one the developer actually installed wins.
  */
 public final class LanguageServers {
 
@@ -47,6 +52,42 @@ public final class LanguageServers {
         }
     }
 
+    /** The first candidate that launches wins; null when none can. */
+    @SafeVarargs
+    static LanguageServerProvider.LanguageServerDescription launchFirst(
+            Lookup lookup, List<String>... candidates) {
+        for (List<String> candidate : candidates) {
+            LanguageServerProvider.LanguageServerDescription server = launch(lookup, candidate);
+            if (server != null) {
+                return server;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * For npm-distributed servers: prefer the project's own
+     * node_modules/.bin install over the global binary, so the server
+     * version matches what the project pinned.
+     */
+    static LanguageServerProvider.LanguageServerDescription launchNpm(
+            Lookup lookup, String bin, String... args) {
+        File dir = projectDir(lookup);
+        if (dir != null) {
+            File local = new File(dir, "node_modules/.bin/" + bin);
+            if (local.canExecute()) {
+                List<String> cmd = new ArrayList<>();
+                cmd.add(local.getAbsolutePath());
+                cmd.addAll(List.of(args));
+                return launch(lookup, cmd);
+            }
+        }
+        List<String> cmd = new ArrayList<>();
+        cmd.add(bin);
+        cmd.addAll(List.of(args));
+        return launch(lookup, cmd);
+    }
+
     private static boolean onPath(String name) {
         for (String dir : ToolLocator.augmentedPath().split(File.pathSeparator)) {
             if (new File(dir, name).canExecute()) {
@@ -69,15 +110,7 @@ public final class LanguageServers {
     public static final class TypeScriptServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            File dir = projectDir(lookup);
-            // prefer the project's own install, then the global binary
-            if (dir != null) {
-                File local = new File(dir, "node_modules/.bin/typescript-language-server");
-                if (local.canExecute()) {
-                    return launch(lookup, List.of(local.getAbsolutePath(), "--stdio"));
-                }
-            }
-            return launch(lookup, List.of("typescript-language-server", "--stdio"));
+            return launchNpm(lookup, "typescript-language-server", "--stdio");
         }
     }
 
@@ -108,12 +141,242 @@ public final class LanguageServers {
         }
     }
 
-    /** Elixir via elixir-ls (when installed as language_server.sh on PATH). */
+    /** Elixir via elixir-ls (brew wrapper or language_server.sh on PATH). */
     @MimeRegistration(mimeType = "text/x-elixir", service = LanguageServerProvider.class)
     public static final class ElixirServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("elixir-ls"));
+            return launchFirst(lookup,
+                    List.of("elixir-ls"),
+                    List.of("language_server.sh"));
+        }
+    }
+
+    /** C and C++ via clangd (ships with Xcode CLT and every LLVM install). */
+    @MimeRegistrations({
+        @MimeRegistration(mimeType = "text/x-c", service = LanguageServerProvider.class),
+        @MimeRegistration(mimeType = "text/x-cpp", service = LanguageServerProvider.class)
+    })
+    public static final class ClangdServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("clangd", "--background-index"));
+        }
+    }
+
+    /** Java via Eclipse JDT Language Server. */
+    @MimeRegistration(mimeType = "text/x-java", service = LanguageServerProvider.class)
+    public static final class JavaServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("jdtls"));
+        }
+    }
+
+    /** C# via csharp-ls, falling back to OmniSharp. */
+    @MimeRegistration(mimeType = "text/x-csharp", service = LanguageServerProvider.class)
+    public static final class CSharpServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchFirst(lookup,
+                    List.of("csharp-ls"),
+                    List.of("OmniSharp", "-lsp"));
+        }
+    }
+
+    /** F# via fsautocomplete (dotnet tool install -g fsautocomplete). */
+    @MimeRegistration(mimeType = "text/x-fsharp", service = LanguageServerProvider.class)
+    public static final class FSharpServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("fsautocomplete"));
+        }
+    }
+
+    /** PHP via intelephense (project-local first), falling back to phpactor. */
+    @MimeRegistration(mimeType = "text/x-php5", service = LanguageServerProvider.class)
+    public static final class PhpServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            LanguageServerDescription server = launchNpm(lookup, "intelephense", "--stdio");
+            return server != null ? server
+                    : launch(lookup, List.of("phpactor", "language-server"));
+        }
+    }
+
+    /** Ruby via ruby-lsp, falling back to solargraph. */
+    @MimeRegistration(mimeType = "text/x-ruby", service = LanguageServerProvider.class)
+    public static final class RubyServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchFirst(lookup,
+                    List.of("ruby-lsp"),
+                    List.of("solargraph", "stdio"));
+        }
+    }
+
+    /** Dart via the SDK's built-in language server. */
+    @MimeRegistration(mimeType = "text/x-dart", service = LanguageServerProvider.class)
+    public static final class DartServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("dart", "language-server", "--protocol=lsp"));
+        }
+    }
+
+    /** Scala via Metals (coursier install metals). */
+    @MimeRegistration(mimeType = "text/x-scala", service = LanguageServerProvider.class)
+    public static final class ScalaServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("metals"));
+        }
+    }
+
+    /** Kotlin via kotlin-language-server. */
+    @MimeRegistration(mimeType = "text/x-kotlin", service = LanguageServerProvider.class)
+    public static final class KotlinServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("kotlin-language-server"));
+        }
+    }
+
+    /** Swift via sourcekit-lsp (ships with the Swift toolchain and Xcode). */
+    @MimeRegistration(mimeType = "text/x-swift", service = LanguageServerProvider.class)
+    public static final class SwiftServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("sourcekit-lsp"));
+        }
+    }
+
+    /** Haskell via haskell-language-server (ghcup install hls). */
+    @MimeRegistration(mimeType = "text/x-haskell", service = LanguageServerProvider.class)
+    public static final class HaskellServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("haskell-language-server-wrapper", "--lsp"));
+        }
+    }
+
+    /** Zig via zls. */
+    @MimeRegistration(mimeType = "text/x-zig", service = LanguageServerProvider.class)
+    public static final class ZigServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("zls"));
+        }
+    }
+
+    /** Erlang via erlang_ls. */
+    @MimeRegistration(mimeType = "text/x-erlang", service = LanguageServerProvider.class)
+    public static final class ErlangServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("erlang_ls", "--transport", "stdio"));
+        }
+    }
+
+    /** Clojure via clojure-lsp. */
+    @MimeRegistration(mimeType = "text/x-clojure", service = LanguageServerProvider.class)
+    public static final class ClojureServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("clojure-lsp"));
+        }
+    }
+
+    /** Common Lisp via cl-lsp, when someone has gone to the trouble. */
+    @MimeRegistration(mimeType = "text/x-lisp", service = LanguageServerProvider.class)
+    public static final class LispServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("cl-lsp"));
+        }
+    }
+
+    /** Lua via lua-language-server. */
+    @MimeRegistration(mimeType = "text/x-lua", service = LanguageServerProvider.class)
+    public static final class LuaServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("lua-language-server"));
+        }
+    }
+
+    /** OCaml via ocamllsp (opam install ocaml-lsp-server). */
+    @MimeRegistration(mimeType = "text/x-ocaml", service = LanguageServerProvider.class)
+    public static final class OCamlServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("ocamllsp"));
+        }
+    }
+
+    /** Crystal via crystalline. */
+    @MimeRegistration(mimeType = "text/x-crystal", service = LanguageServerProvider.class)
+    public static final class CrystalServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("crystalline"));
+        }
+    }
+
+    /** Julia via LanguageServer.jl, falling back fast if it isn't installed. */
+    @MimeRegistration(mimeType = "text/x-julia", service = LanguageServerProvider.class)
+    public static final class JuliaServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("julia", "--startup-file=no", "--history-file=no",
+                    "-e", "using LanguageServer; runserver()"));
+        }
+    }
+
+    /** R via the languageserver package. */
+    @MimeRegistration(mimeType = "text/x-r", service = LanguageServerProvider.class)
+    public static final class RServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("R", "--no-echo", "-e", "languageserver::run()"));
+        }
+    }
+
+    /** Perl via PLS, falling back to Perl::LanguageServer. */
+    @MimeRegistration(mimeType = "text/x-perl", service = LanguageServerProvider.class)
+    public static final class PerlServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchFirst(lookup,
+                    List.of("pls"),
+                    List.of("perl", "-MPerl::LanguageServer", "-e", "Perl::LanguageServer::run"));
+        }
+    }
+
+    /** Groovy via groovy-language-server, when installed. */
+    @MimeRegistration(mimeType = "text/x-groovy", service = LanguageServerProvider.class)
+    public static final class GroovyServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("groovy-language-server"));
+        }
+    }
+
+    /** Shell scripts via bash-language-server. */
+    @MimeRegistration(mimeType = "text/sh", service = LanguageServerProvider.class)
+    public static final class ShellServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "bash-language-server", "start");
+        }
+    }
+
+    /** JSON via vscode-json-language-server (vscode-langservers-extracted). */
+    @MimeRegistration(mimeType = "text/x-json", service = LanguageServerProvider.class)
+    public static final class JsonServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "vscode-json-language-server", "--stdio");
         }
     }
 

--- a/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerContractTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerContractTest.java
@@ -1,0 +1,96 @@
+package org.nmox.studio.editor.lsp;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every language we ship a grammar for must also register a language
+ * server provider. The check reads META-INF/generated-layer.xml - the
+ * artifact the annotation processor actually produces and the platform
+ * actually reads - so it fails both when a language is forgotten AND
+ * when annotation processing silently stops running (the JDK 23
+ * -proc:none regression that has bitten this project before).
+ */
+class LanguageServerContractTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "text/javascript", "text/typescript",
+        "text/x-c", "text/x-cpp", "text/x-java", "text/x-csharp", "text/x-fsharp",
+        "text/x-python", "text/x-ruby", "text/x-rust", "text/x-go", "text/x-php5",
+        "text/x-dart", "text/x-scala", "text/x-kotlin", "text/x-swift",
+        "text/x-haskell", "text/x-zig", "text/x-erlang", "text/x-elixir",
+        "text/x-clojure", "text/x-lisp", "text/x-lua", "text/x-ocaml",
+        "text/x-crystal", "text/x-julia", "text/x-r", "text/x-perl",
+        "text/x-groovy", "text/sh", "text/x-json"
+    })
+    @DisplayName("Grammar language has a registered LanguageServerProvider")
+    void languageServerRegistered(String mime) throws Exception {
+        assertThat(mimeHasServerRegistration(mime))
+                .as("generated-layer.xml registers a LanguageServers provider under Editors/" + mime)
+                .isTrue();
+    }
+
+    private static boolean mimeHasServerRegistration(String mime) throws Exception {
+        Enumeration<URL> layers = LanguageServerContractTest.class.getClassLoader()
+                .getResources("META-INF/generated-layer.xml");
+        for (URL url : Collections.list(layers)) {
+            try (InputStream in = url.openStream()) {
+                Element editors = childFolder(parse(in).getDocumentElement(), "Editors");
+                Element mimeFolder = editors;
+                for (String part : mime.split("/")) {
+                    mimeFolder = mimeFolder == null ? null : childFolder(mimeFolder, part);
+                }
+                if (mimeFolder != null && hasServerFile(mimeFolder)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static Document parse(InputStream in) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // the layer references the NetBeans filesystem DTD; never fetch it
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        return factory.newDocumentBuilder().parse(in);
+    }
+
+    private static Element childFolder(Element parent, String name) {
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node instanceof Element el && "folder".equals(el.getTagName())
+                    && name.equals(el.getAttribute("name"))) {
+                return el;
+            }
+        }
+        return null;
+    }
+
+    /** A .instance file naming one of our LanguageServers inner classes. */
+    private static boolean hasServerFile(Element mimeFolder) {
+        NodeList files = mimeFolder.getElementsByTagName("file");
+        for (int i = 0; i < files.getLength(); i++) {
+            Element file = (Element) files.item(i);
+            if (file.getAttribute("name").contains("LanguageServers")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/engine/ToolLocator.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/ToolLocator.java
@@ -107,6 +107,13 @@ public final class ToolLocator {
         dirs.add("/opt/homebrew/opt/dart/libexec/bin");
         dirs.add(home + "/.ghcup/bin");
         dirs.add(home + "/.opam/default/bin");
+        // language-server install homes
+        dirs.add(home + "/.dotnet/tools");                           // csharp-ls, fsautocomplete
+        dirs.add(home + "/Library/Application Support/Coursier/bin"); // metals (macOS)
+        dirs.add(home + "/.local/share/coursier/bin");               // metals (Linux)
+        dirs.add(home + "/.cabal/bin");                              // haskell-language-server
+        dirs.add(home + "/.mix/escripts");                           // elixir escripts
+        dirs.add(home + "/.juliaup/bin");                            // julia
         // polyglot toolchains
         dirs.add(home + "/.cargo/bin");                              // rust
         dirs.add("/usr/local/go/bin");                               // go


### PR DESCRIPTION
## What

Language-server coverage goes from 5 languages (TS/JS, Python, Go, Rust, Elixir) to **all 31 MIMEs we ship editing support for** — definitions, hover, semantic completion, rename, and live diagnostics for every language that can build the web.

## How

- **26 providers** in `LanguageServers`, one per ecosystem's canonical server: clangd, jdtls, csharp-ls→OmniSharp, fsautocomplete, intelephense→phpactor, ruby-lsp→solargraph, `dart language-server`, metals, kotlin-language-server, sourcekit-lsp, haskell-language-server, zls, erlang_ls, clojure-lsp, cl-lsp, lua-language-server, ocamllsp, crystalline, LanguageServer.jl, R languageserver, pls→Perl::LanguageServer, groovy-language-server, bash-language-server, vscode-json-language-server
- **Ordered fallbacks** (`launchFirst`): where an ecosystem has competing servers, whichever the developer installed wins
- **Project-local preference** (`launchNpm`): npm-distributed servers resolve from `node_modules/.bin` before the global binary, so the server version matches the project's pin
- **ToolLocator** learns the server install homes: `~/.dotnet/tools`, coursier bins (macOS + Linux), `~/.cabal/bin`, `~/.mix/escripts`, `~/.juliaup/bin` — Finder launches find them too
- **Contract test**: `LanguageServerContractTest` parses `META-INF/generated-layer.xml` and asserts a provider registration under `Editors/<mime>` for all 31 MIMEs. This guards a forgotten language AND the JDK 23 `-proc:none` annotation-processing regression in a single test.

Missing servers degrade silently to the TextMate-level experience — installing nothing changes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)