### PR TITLE
Rack love: stderr-aware MONITOR starter, drag/sort/remove UX, hardware realism

### DIFF
--- a/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
+++ b/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
@@ -56,7 +56,7 @@ import org.openide.windows.TopComponent;
 public final class RackTopComponent extends TopComponent {
 
     private final Rack rack = org.nmox.studio.rack.service.RackService.getDefault().getRack();
-    private final RackPanel rackPanel;
+    private RackPanel rackPanel;
     private final JLabel projectLabel = new JLabel();
     private JToggleButton flipToggle;
 
@@ -67,11 +67,20 @@ public final class RackTopComponent extends TopComponent {
      * focus manager, exactly while the rack is the activated TopComponent.
      */
     private final java.awt.KeyEventDispatcher tabFlipDispatcher = e -> {
-        if (e.getID() == KeyEvent.KEY_PRESSED
-                && e.getKeyCode() == KeyEvent.VK_TAB
-                && e.getModifiersEx() == 0
-                && TopComponent.getRegistry().getActivated() == RackTopComponent.this) {
+        if (e.getID() != KeyEvent.KEY_PRESSED || e.getModifiersEx() != 0
+                || TopComponent.getRegistry().getActivated() != RackTopComponent.this) {
+            return false;
+        }
+        if (e.getKeyCode() == KeyEvent.VK_TAB) {
             flipToggle.doClick();
+            return true;
+        }
+        if ((e.getKeyCode() == KeyEvent.VK_DELETE || e.getKeyCode() == KeyEvent.VK_BACK_SPACE)
+                && rackPanel.getSelected() != null
+                // never swallow Delete while something editable has focus
+                && !(java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager()
+                        .getFocusOwner() instanceof javax.swing.text.JTextComponent)) {
+            rackPanel.removeSelected();
             return true;
         }
         return false;

--- a/rack/src/main/java/org/nmox/studio/rack/devices/ConsoleDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/ConsoleDevice.java
@@ -1,43 +1,98 @@
 package org.nmox.studio.rack.devices;
 
 import java.awt.Color;
+import org.nmox.studio.rack.engine.RackBus;
 import org.nmox.studio.rack.model.Port;
 import org.nmox.studio.rack.model.RackDevice;
 import org.nmox.studio.rack.model.Signal;
 import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.ui.controls.Knob;
 import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.Led;
 import org.nmox.studio.rack.ui.controls.RackButton;
 import org.nmox.studio.rack.ui.controls.RackStyle;
 import org.nmox.studio.rack.ui.controls.VuMeter;
 
 /**
- * MONITOR Console: a rack-mounted terminal screen. Patch any device's
- * OUT jack into IN and its output scrolls across the green phosphor.
+ * MONITOR Console: a rack-mounted terminal screen. Patched input always
+ * displays; the TAP knob additionally taps the rack's monitor bus the
+ * way a studio monitor section taps the mix - STDERR hears every error
+ * any device prints (the factory position), ALL hears everything.
+ * Bus errors glow red on the phosphor and flash the ERR LED.
  */
 public class ConsoleDevice extends RackDevice {
 
+    private static final String[] TAPS = {"off", "stderr", "all"};
+    private static final Color ERR_TEXT = new Color(255, 110, 95);
+
     private final LcdDisplay screen;
     private final VuMeter meter;
+    private final Knob tapKnob;
+    private final Led errLed;
+    private final javax.swing.Timer errFade;
+    /** EDT-owned knob position mirrored for the pump threads. */
+    private volatile String tapMode = "stderr";
+
+    private final RackBus.Listener tap = (device, line, err) -> {
+        String mode = tapMode;
+        if ("off".equals(mode) || (!err && !"all".equals(mode))) {
+            return;
+        }
+        show("[" + device + "] " + line, err);
+    };
 
     public ConsoleDevice() {
         super("console", "MONITOR", "OUTPUT CONSOLE", new Color(80, 200, 120), 3);
 
-        int screenW = RackStyle.RACK_WIDTH - 2 * RackStyle.EAR_WIDTH - 160;
+        int colW = 150;
+        int colX = RackStyle.RACK_WIDTH - RackStyle.EAR_WIDTH - colW;
+        int screenW = RackStyle.RACK_WIDTH - 2 * RackStyle.EAR_WIDTH - colW - 28;
         screen = place(new LcdDisplay(screenW, 8), RackStyle.EAR_WIDTH + 14, 42);
-        RackButton clear = place(new RackButton("CLEAR", RackStyle.MUTATE),
-                RackStyle.RACK_WIDTH - RackStyle.EAR_WIDTH - 130, 42);
-        meter = place(new VuMeter("FEED", false), RackStyle.RACK_WIDTH - RackStyle.EAR_WIDTH - 130, 92);
+        RackButton clear = place(new RackButton("CLEAR", RackStyle.MUTATE), colX, 42);
+        tapKnob = place(new Knob("TAP", TAPS, 1), colX + 70, 36);
+        errLed = place(new Led("ERR", RackStyle.STOP), colX, 92);
+        meter = place(new VuMeter("FEED", false), colX, 130);
 
+        tapKnob.setToolTipText("<html><b>Monitor bus tap</b><br>"
+                + "off — only what is patched into IN<br>"
+                + "stderr — every device's errors, unpatched<br>"
+                + "all — everything every device prints</html>");
+        errFade = new javax.swing.Timer(600, e -> errLed.setOn(false));
+        errFade.setRepeats(false);
         clear.addActionListener(e -> screen.clear());
+        tapKnob.addChangeListener(() -> tapMode = tapKnob.getSelectedOption());
+
+        param("tap", tapKnob);
 
         addInPort("in", "IN", SignalType.DATA);
+    }
+
+    private void show(String line, boolean err) {
+        screen.appendLine(line, err ? ERR_TEXT : null);
+        meter.pulse(0.4 + Math.min(0.55, line.length() / 140.0));
+        if (err) {
+            onEdt(() -> {
+                errLed.setOn(true);
+                errFade.restart();
+            });
+        }
+    }
+
+    @Override
+    protected void onAttached() {
+        RackBus.subscribe(tap);
+    }
+
+    @Override
+    public void dispose() {
+        RackBus.unsubscribe(tap);
+        super.dispose();
     }
 
     @Override
     public void receive(Port in, Signal signal) {
         if (signal.type() == SignalType.DATA) {
-            screen.appendLine(signal.payload());
-            meter.pulse(0.4 + Math.min(0.55, signal.payload().length() / 140.0));
+            show(signal.payload(), false);
         }
     }
 }

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
@@ -118,7 +118,7 @@ public enum DeviceType {
             case ANGULAR -> "SERVE/BUILD/TEST drive ng; GEN scaffolds with the SCHEMATIC knob.\nThe version cluster nags when Angular moves - UPDATE runs ng update.";
             case PHOENIX -> "SERVER runs mix phx.server; GEN row drives phx.gen.*; MIGRATE runs ecto.\nVersion cluster tracks :phoenix against Hex.";
             case NEXTJS -> "DEV serves with the URL out feeding SCOPE; BUILD then START runs production.\nVersion cluster tracks next against the registry.";
-            case CONSOLE -> "A glanceable 8-line screen. Patch any OUT (data) jack into IN\nand watch your pipeline talk.";
+            case CONSOLE -> "A glanceable 8-line screen. Patch any OUT (data) jack into IN,\nor dial TAP to stderr/all to hear every device unpatched — errors glow red.";
             case TERMINAL -> "5,000 lines of selectable scrollback. FOLLOW tails the output.\nPatch the OUT of anything chatty in here.";
             case BENCH -> "FIRE hammers the URL with autocannon; req/s on the meter.\nPatch SURGE URL → URL and READY → RUN to bench the second it serves.";
             case DEBUG -> "LAUNCH starts your runtime in debug-server mode; the attach\nendpoint (chrome://inspect, debugpy, dlv…) lands on the LCD.";

--- a/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
@@ -14,9 +14,11 @@ import org.openide.windows.InputOutput;
 import org.openide.windows.OutputWriter;
 
 /**
- * Runs external tool processes for rack devices: streams merged
- * stdout/stderr line by line to the device (for meters and LCDs) and
- * mirrors everything into a NetBeans Output window tab per device.
+ * Runs external tool processes for rack devices: streams stdout and
+ * stderr line by line to the device (for meters and LCDs), publishes
+ * every line on the {@link RackBus} tagged with its stream, and mirrors
+ * everything into a NetBeans Output window tab per device - stderr in
+ * the error color, exactly as a terminal would.
  */
 public final class CommandExecutor {
 
@@ -55,7 +57,6 @@ public final class CommandExecutor {
             // IDE has a bare PATH with no node/npm/git on it
             ProcessBuilder pb = new ProcessBuilder(ToolLocator.resolveCommand(command))
                     .directory(dir)
-                    .redirectErrorStream(true)
                     // no terminal is attached: an interactive prompt would
                     // hang forever, so give prompts an empty stdin instead
                     .redirectInput(devNull());
@@ -72,6 +73,7 @@ public final class CommandExecutor {
                 out.println(msg);
             }
             safeAccept(onLine, msg);
+            RackBus.publish(tabName, msg, true);
             onExit.accept(-1);
             return new Handle() {
                 @Override
@@ -85,31 +87,18 @@ public final class CommandExecutor {
             };
         }
 
+        OutputWriter err = io == null ? null : io.getErr();
+        Thread errPump = new Thread(
+                () -> pumpStream(process.getErrorStream(), err, true, tabName, dir, onLine),
+                "nmox-rack-errpump-" + tabName);
+        errPump.setDaemon(true);
+        errPump.start();
+
         Thread pump = new Thread(() -> {
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    String clean = stripAnsi(line);
-                    if (out != null) {
-                        FileLink.Location loc = FileLink.find(clean, dir);
-                        if (loc != null) {
-                            try {
-                                out.println(clean, FileLink.opener(loc));
-                            } catch (IOException ex) {
-                                out.println(clean);
-                            }
-                        } else {
-                            out.println(clean);
-                        }
-                    }
-                    safeAccept(onLine, clean);
-                }
-            } catch (IOException ignored) {
-                // stream closes when the process dies or is killed
-            }
+            pumpStream(process.getInputStream(), out, false, tabName, dir, onLine);
             int code;
             try {
+                errPump.join(5_000);
                 code = process.waitFor();
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
@@ -146,6 +135,40 @@ public final class CommandExecutor {
                 return process.isAlive();
             }
         };
+    }
+
+    /**
+     * Drains one of the process's streams: ANSI-stripped lines go to the
+     * device callback (devices parse markers from either stream - vite
+     * logs to stderr), onto the rack bus tagged with their origin, and
+     * into the Output window, where stderr prints in the error color and
+     * file:line references become clickable links.
+     */
+    private static void pumpStream(java.io.InputStream stream, OutputWriter writer,
+            boolean isErr, String tabName, File dir, Consumer<String> onLine) {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String clean = stripAnsi(line);
+                if (writer != null) {
+                    FileLink.Location loc = FileLink.find(clean, dir);
+                    if (loc != null) {
+                        try {
+                            writer.println(clean, FileLink.opener(loc));
+                        } catch (IOException ex) {
+                            writer.println(clean);
+                        }
+                    } else {
+                        writer.println(clean);
+                    }
+                }
+                safeAccept(onLine, clean);
+                RackBus.publish(tabName, clean, isErr);
+            }
+        } catch (IOException ignored) {
+            // stream closes when the process dies or is killed
+        }
     }
 
     /** ANSI CSI/OSC escape sequences, e.g. color codes from vite/vitest. */

--- a/rack/src/main/java/org/nmox/studio/rack/engine/RackBus.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/RackBus.java
@@ -1,0 +1,43 @@
+package org.nmox.studio.rack.engine;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * The rack's monitor bus: every line any device's process prints travels
+ * over it, tagged with the device that produced it and whether it came
+ * from stderr. A console can tap the bus the way a studio monitor
+ * section taps the mix - hearing everything without being patched to
+ * anything.
+ */
+public final class RackBus {
+
+    /** Receives bus traffic. Called on process pump threads, never the EDT. */
+    public interface Listener {
+
+        void line(String device, String line, boolean err);
+    }
+
+    private static final List<Listener> LISTENERS = new CopyOnWriteArrayList<>();
+
+    private RackBus() {
+    }
+
+    public static void subscribe(Listener l) {
+        LISTENERS.add(l);
+    }
+
+    public static void unsubscribe(Listener l) {
+        LISTENERS.remove(l);
+    }
+
+    public static void publish(String device, String line, boolean err) {
+        for (Listener l : LISTENERS) {
+            try {
+                l.line(device, line, err);
+            } catch (RuntimeException ignored) {
+                // a misbehaving tap must not stall the output pump
+            }
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
@@ -389,6 +389,7 @@ public abstract class RackDevice extends JPanel {
             g.setFont(RackStyle.LABEL_FONT);
             g.setColor(RackStyle.SILKSCREEN_DIM);
             g.drawString(title + "  —  REAR", RackStyle.EAR_WIDTH + 14, 18);
+            paintRearHardware(g, w, h);
             paintJackGroups(g, h);
             for (Port p : ports) {
                 paintJack(g, p);
@@ -409,6 +410,56 @@ public abstract class RackDevice extends JPanel {
         RackStyle.paintScrew(g, RackStyle.EAR_WIDTH / 2, h - 12);
         RackStyle.paintScrew(g, getWidth() - RackStyle.EAR_WIDTH / 2, 12);
         RackStyle.paintScrew(g, getWidth() - RackStyle.EAR_WIDTH / 2, h - 12);
+    }
+
+    /**
+     * The hardware every real unit carries on its back: an IEC power
+     * inlet with its fuse drawer, voltage silkscreen, and a serial
+     * sticker. Pure decoration - but it is what makes the rear of the
+     * rack read as GEAR rather than a diagram. 2U and up only; a 1U
+     * back is all jacks.
+     */
+    private void paintRearHardware(Graphics2D g, int w, int h) {
+        if (h < 2 * RackStyle.UNIT) {
+            return;
+        }
+        int x = w - RackStyle.EAR_WIDTH - 96;
+        int y = 10;
+        // IEC C14 inlet: recessed black trapezoid with three pin slots
+        g.setColor(new Color(16, 16, 18));
+        g.fillRoundRect(x, y, 44, 30, 4, 4);
+        g.setColor(new Color(70, 71, 75));
+        g.drawRoundRect(x, y, 44, 30, 4, 4);
+        g.setColor(new Color(8, 8, 9));
+        g.fillRoundRect(x + 5, y + 5, 34, 20, 6, 6);
+        g.setColor(new Color(170, 172, 176));
+        g.fillRect(x + 11, y + 12, 4, 8);   // L
+        g.fillRect(x + 20, y + 9, 4, 8);    // E
+        g.fillRect(x + 29, y + 12, 4, 8);   // N
+        // fuse drawer beneath the inlet
+        g.setColor(new Color(30, 30, 33));
+        g.fillRoundRect(x + 50, y + 6, 26, 12, 3, 3);
+        g.setColor(new Color(8, 8, 9));
+        g.drawRoundRect(x + 50, y + 6, 26, 12, 3, 3);
+        g.setFont(RackStyle.TINY_FONT);
+        g.setColor(RackStyle.SILKSCREEN_DIM);
+        g.drawString("FUSE T1A", x + 50, y + 30);
+        g.drawString("100-240V~ 50/60Hz", x - 110, y + 12);
+        // serial sticker: pale label, barcode, number from the type id
+        int sx = x - 110, sy = y + 18;
+        g.setColor(new Color(214, 211, 196));
+        g.fillRect(sx, sy, 96, 20);
+        g.setColor(new Color(20, 20, 22));
+        int bar = sx + 4;
+        int seed = typeId.hashCode();
+        while (bar < sx + 64) {
+            int bw = 1 + Math.floorMod(seed >> (bar % 13), 3);
+            g.fillRect(bar, sy + 3, bw, 10);
+            bar += bw + 2;
+        }
+        g.setFont(RackStyle.TINY_FONT);
+        g.drawString("S/N " + String.format("%07d", Math.floorMod(seed, 10_000_000)),
+                sx + 4, sy + 18);
     }
 
     private void paintJackGroups(Graphics2D g, int h) {

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/RackPresets.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/RackPresets.java
@@ -16,6 +16,26 @@ import org.nmox.studio.rack.model.RackIO;
  */
 public enum RackPresets {
 
+    WEB_PIPELINE("Web Pipeline",
+            "MAESTRO fires install → build → test; SURGE pops the browser when serving") {
+        @Override
+        void wire(Rack rack) {
+            RackDevice master = add(rack, DeviceType.MASTER, null);
+            RackDevice deps = add(rack, DeviceType.PACKAGE_MANAGER, null);
+            RackDevice build = add(rack, DeviceType.BUILD, null);
+            RackDevice test = add(rack, DeviceType.TEST, null);
+            RackDevice server = add(rack, DeviceType.DEV_SERVER, null);
+            RackDevice browser = add(rack, DeviceType.BROWSER, null);
+            RackDevice console = add(rack, DeviceType.CONSOLE, null);
+            rack.connect(master.getPort("trig1"), deps.getPort("run"));
+            rack.connect(deps.getPort("ok"), build.getPort("run"));
+            rack.connect(build.getPort("ok"), test.getPort("run"));
+            rack.connect(test.getPort("out"), console.getPort("in"));
+            rack.connect(server.getPort("url"), browser.getPort("url"));
+            rack.connect(server.getPort("ready"), browser.getPort("open"));
+        }
+    },
+
     DEV_LOOP("Dev Loop",
             "Dev server auto-opens the browser; saves run the tests") {
         @Override

--- a/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.prefs.Preferences;
 import org.nmox.studio.rack.devices.DeviceType;
 import org.nmox.studio.rack.model.Rack;
-import org.nmox.studio.rack.model.RackDevice;
 import org.nmox.studio.rack.model.RackIO;
 import org.openide.util.Lookup;
 import org.openide.util.NbPreferences;
@@ -113,33 +112,13 @@ public class RackService {
     }
 
     /**
-     * Starter rack: a working web pipeline. MAESTRO fires install; a
-     * green install builds; a green build tests; test output scrolls on
-     * the console. Independently, starting SURGE hands its URL to SCOPE
-     * and pops the browser the moment the dev server answers.
+     * Starter rack: a single MONITOR with its TAP on stderr - the first
+     * thing a new user sees is one honest unit that shows every error
+     * anything in the rack prints, before a single cable is patched.
+     * The full pipeline lives one click away in Presets ("Web Pipeline").
      */
     private void loadDefaultRack() {
-        RackDevice master = DeviceType.MASTER.create();
-        RackDevice deps = DeviceType.PACKAGE_MANAGER.create();
-        RackDevice build = DeviceType.BUILD.create();
-        RackDevice test = DeviceType.TEST.create();
-        RackDevice server = DeviceType.DEV_SERVER.create();
-        RackDevice browser = DeviceType.BROWSER.create();
-        RackDevice console = DeviceType.CONSOLE.create();
-        rack.addDevice(master);
-        rack.addDevice(deps);
-        rack.addDevice(build);
-        rack.addDevice(test);
-        rack.addDevice(server);
-        rack.addDevice(browser);
-        rack.addDevice(console);
-
-        rack.connect(master.getPort("trig1"), deps.getPort("run"));
-        rack.connect(deps.getPort("ok"), build.getPort("run"));
-        rack.connect(build.getPort("ok"), test.getPort("run"));
-        rack.connect(test.getPort("out"), console.getPort("in"));
-        rack.connect(server.getPort("url"), browser.getPort("url"));
-        rack.connect(server.getPort("ready"), browser.getPort("open"));
+        rack.addDevice(DeviceType.CONSOLE.create());
     }
 
     /**

--- a/rack/src/main/java/org/nmox/studio/rack/ui/RackPanel.java
+++ b/rack/src/main/java/org/nmox/studio/rack/ui/RackPanel.java
@@ -47,6 +47,22 @@ public class RackPanel extends JPanel implements Rack.Listener {
     // device reordering (front view)
     private RackDevice reordering;
 
+    // the selected device (front view): Delete unracks it
+    private RackDevice selected;
+
+    // palette drag-over insertion slot (-1 = no drag in progress)
+    private int dropIndex = -1;
+    private long dropSeenAt;
+    private final Timer dropClearTimer = new Timer(150, e -> {
+        if (dropIndex >= 0 && System.currentTimeMillis() - dropSeenAt > 300) {
+            dropIndex = -1;
+            repaint();
+        }
+        if (dropIndex < 0) {
+            ((Timer) e.getSource()).stop();
+        }
+    });
+
     // recent signal flashes per cable, for the glow animation
     private final Map<Cable, Long> flashes = new HashMap<>();
     private final Timer flashTimer = new Timer(60, e -> {
@@ -66,7 +82,38 @@ public class RackPanel extends JPanel implements Rack.Listener {
         rack.addListener(this);
 
         setTransferHandler(new PaletteDropHandler());
+
+        // clicking the rails or empty rack deselects
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                setSelected(null);
+            }
+        });
         rebuild();
+    }
+
+    // ---- selection ----
+
+    /** The device a Delete keypress would unrack. */
+    public RackDevice getSelected() {
+        return selected;
+    }
+
+    private void setSelected(RackDevice device) {
+        if (selected != device) {
+            selected = device;
+            repaint();
+        }
+    }
+
+    /** Unracks the selected device (the Delete key, routed by the window). */
+    public void removeSelected() {
+        if (selected != null) {
+            RackDevice doomed = selected;
+            selected = null;
+            rack.removeDevice(doomed);
+        }
     }
 
     public Rack getRack() {
@@ -98,6 +145,9 @@ public class RackPanel extends JPanel implements Rack.Listener {
 
     private void rebuild() {
         removeAll();
+        if (selected != null && !rack.getDevices().contains(selected)) {
+            selected = null;
+        }
         for (RackDevice d : rack.getDevices()) {
             d.setAlignmentX(CENTER_ALIGNMENT);
             d.setFront(front);
@@ -165,9 +215,12 @@ public class RackPanel extends JPanel implements Rack.Listener {
                     dragPoint = SwingUtilities.convertPoint(device, e.getPoint(), RackPanel.this);
                     repaint();
                 }
-            } else if (device.isGrip(e.getPoint())) {
-                reordering = device;
-                setCursor(java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.MOVE_CURSOR));
+            } else {
+                setSelected(device);
+                if (device.isGrip(e.getPoint())) {
+                    reordering = device;
+                    setCursor(java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.MOVE_CURSOR));
+                }
             }
         }
 
@@ -243,6 +296,8 @@ public class RackPanel extends JPanel implements Rack.Listener {
                 menu.addSeparator();
             }
             JMenuItem remove = new JMenuItem("Remove " + device.getTitle());
+            remove.setAccelerator(javax.swing.KeyStroke.getKeyStroke(
+                    java.awt.event.KeyEvent.VK_DELETE, 0));
             remove.addActionListener(a -> rack.removeDevice(device));
             menu.add(remove);
             menu.show(device, e.getX(), e.getY());
@@ -316,13 +371,61 @@ public class RackPanel extends JPanel implements Rack.Listener {
         g.setColor(RackStyle.RAIL_EDGE);
         g.drawRect(railX1, -1, 10, getHeight() + 1);
         g.drawRect(railX2 - 10, -1, 10, getHeight() + 1);
+        paintRailHardware(g, railX1, railX2);
+        if (rack.getDevices().isEmpty()) {
+            paintEmptyRack(g, railX1, railX2);
+        }
         g.dispose();
+    }
+
+    /**
+     * Cage-nut holes punched down both rails on the half-unit grid, with
+     * a unit number etched at every unit boundary - the part of a real
+     * rack you line the screws up against.
+     */
+    private void paintRailHardware(Graphics2D g, int railX1, int railX2) {
+        int unit = RackStyle.UNIT;
+        g.setFont(RackStyle.TINY_FONT);
+        for (int y = unit / 4; y < getHeight(); y += unit / 2) {
+            for (int x : new int[]{railX1 + 2, railX2 - 8}) {
+                // square hole, punched dark with a lit bottom edge
+                g.setColor(new Color(8, 8, 10));
+                g.fillRoundRect(x, y - 3, 6, 6, 2, 2);
+                g.setColor(new Color(255, 255, 255, 28));
+                g.drawLine(x, y + 3, x + 6, y + 3);
+            }
+        }
+        g.setColor(new Color(120, 122, 128, 110));
+        for (int u = 0; u * unit < getHeight(); u++) {
+            String n = String.format("%02d", u + 1);
+            g.drawString(n, railX1 - g.getFontMetrics().stringWidth(n) - 3, u * unit + unit / 2 + 3);
+        }
+    }
+
+    /** An empty rack invites: etched silkscreen between bare rails. */
+    private void paintEmptyRack(Graphics2D g, int railX1, int railX2) {
+        int cx = (railX1 + railX2) / 2;
+        int cy = Math.max(70, getHeight() / 3);
+        g.setFont(RackStyle.TITLE_FONT);
+        g.setColor(new Color(255, 255, 255, 40));
+        String big = "RACK EMPTY";
+        g.drawString(big, cx - g.getFontMetrics().stringWidth(big) / 2, cy);
+        g.setFont(RackStyle.LABEL_FONT);
+        g.setColor(new Color(255, 255, 255, 30));
+        String hint = "Drag a device in from the shelf — or load a preset from the toolbar";
+        g.drawString(hint, cx - g.getFontMetrics().stringWidth(hint) / 2, cy + 22);
     }
 
     @Override
     public void paint(Graphics gr) {
         super.paint(gr);
         if (front) {
+            Graphics2D g = (Graphics2D) gr.create();
+            RackStyle.antialias(g);
+            paintSeams(g);
+            paintSelection(g);
+            paintInsertionSlot(g);
+            g.dispose();
             return;
         }
         Graphics2D g = (Graphics2D) gr.create();
@@ -357,6 +460,70 @@ public class RackPanel extends JPanel implements Rack.Listener {
                     hint, 0.6f);
         }
         g.dispose();
+    }
+
+    /**
+     * Ambient occlusion at every device boundary: each unit throws a
+     * sliver of shadow onto the one below, the way stacked hardware does.
+     */
+    private void paintSeams(Graphics2D g) {
+        var devices = rack.getDevices();
+        for (int i = 1; i < devices.size(); i++) {
+            RackDevice d = devices.get(i);
+            int y = d.getY();
+            g.setPaint(new java.awt.GradientPaint(0, y, new Color(0, 0, 0, 90),
+                    0, y + 5, new Color(0, 0, 0, 0)));
+            g.fillRect(d.getX(), y, d.getWidth(), 5);
+        }
+    }
+
+    /** The selected device wears its accent as a halo; lifted = brighter. */
+    private void paintSelection(Graphics2D g) {
+        RackDevice d = reordering != null ? reordering : selected;
+        if (d == null) {
+            return;
+        }
+        Color accent = d.getAccent();
+        boolean lifted = reordering != null;
+        g.setColor(new Color(accent.getRed(), accent.getGreen(), accent.getBlue(),
+                lifted ? 200 : 130));
+        g.setStroke(new BasicStroke(lifted ? 2.5f : 1.6f));
+        g.drawRect(d.getX(), d.getY(), d.getWidth() - 1, d.getHeight() - 1);
+        if (lifted) {
+            // a lifted unit floats: deepen its shadow on the device below
+            g.setPaint(new java.awt.GradientPaint(0, d.getY() + d.getHeight(),
+                    new Color(0, 0, 0, 130),
+                    0, d.getY() + d.getHeight() + 12, new Color(0, 0, 0, 0)));
+            g.fillRect(d.getX(), d.getY() + d.getHeight(), d.getWidth(), 12);
+        }
+    }
+
+    /** The lit slot a palette drag would drop into. */
+    private void paintInsertionSlot(Graphics2D g) {
+        if (dropIndex < 0) {
+            return;
+        }
+        var devices = rack.getDevices();
+        int x = (getWidth() - RackStyle.RACK_WIDTH) / 2;
+        int y = dropIndex < devices.size()
+                ? devices.get(dropIndex).getY()
+                : (devices.isEmpty() ? 8
+                        : devices.get(devices.size() - 1).getY()
+                        + devices.get(devices.size() - 1).getHeight());
+        g.setColor(new Color(RackStyle.GO.getRed(), RackStyle.GO.getGreen(),
+                RackStyle.GO.getBlue(), 70));
+        g.fillRect(x, y - 3, RackStyle.RACK_WIDTH, 6);
+        g.setColor(RackStyle.GO);
+        g.setStroke(new BasicStroke(2f));
+        g.drawLine(x, y, x + RackStyle.RACK_WIDTH, y);
+        // chevrons pointing at the slot from both rails
+        var left = new java.awt.Polygon(
+                new int[]{x - 12, x - 2, x - 12}, new int[]{y - 6, y, y + 6}, 3);
+        var right = new java.awt.Polygon(
+                new int[]{x + RackStyle.RACK_WIDTH + 12, x + RackStyle.RACK_WIDTH + 2,
+                    x + RackStyle.RACK_WIDTH + 12}, new int[]{y - 6, y, y + 6}, 3);
+        g.fill(left);
+        g.fill(right);
     }
 
     private void paintCable(Graphics2D g, Point a, Point b, Color color, float glow) {
@@ -418,21 +585,38 @@ public class RackPanel extends JPanel implements Rack.Listener {
 
         @Override
         public boolean canImport(TransferSupport support) {
-            return support.isDataFlavorSupported(DataFlavor.stringFlavor);
+            boolean ok = support.isDataFlavorSupported(DataFlavor.stringFlavor);
+            if (ok && support.isDrop()) {
+                // light the slot the device would land in
+                int index = indexForY(support.getDropLocation().getDropPoint().y);
+                dropSeenAt = System.currentTimeMillis();
+                if (index != dropIndex) {
+                    dropIndex = index;
+                    repaint();
+                }
+                if (!dropClearTimer.isRunning()) {
+                    dropClearTimer.start();
+                }
+            }
+            return ok;
         }
 
         @Override
         public boolean importData(TransferSupport support) {
+            int index = dropIndex >= 0 && support.isDrop()
+                    ? dropIndex
+                    : rack.getDevices().size();
+            dropIndex = -1;
+            repaint();
             try {
                 String id = (String) support.getTransferable().getTransferData(DataFlavor.stringFlavor);
                 DeviceType type = DeviceType.byId(id);
                 if (type == null) {
                     return false;
                 }
-                int index = support.isDrop()
-                        ? indexForY(support.getDropLocation().getDropPoint().y)
-                        : rack.getDevices().size();
-                rack.addDevice(type.create(), index);
+                RackDevice fresh = type.create();
+                rack.addDevice(fresh, index);
+                setSelected(fresh);
                 return true;
             } catch (Exception ex) {
                 return false;

--- a/rack/src/main/java/org/nmox/studio/rack/ui/controls/LcdDisplay.java
+++ b/rack/src/main/java/org/nmox/studio/rack/ui/controls/LcdDisplay.java
@@ -20,8 +20,12 @@ import javax.swing.SwingUtilities;
  */
 public class LcdDisplay extends JComponent {
 
+    /** One scrolled line and the color it glows in (null = panel default). */
+    private record Entry(String text, Color color) {
+    }
+
     private final int lines;
-    private final LinkedList<String> buffer = new LinkedList<>();
+    private final LinkedList<Entry> buffer = new LinkedList<>();
     private String text = "";
     private Color textColor = RackStyle.LCD_TEXT;
     private boolean editable;
@@ -75,8 +79,13 @@ public class LcdDisplay extends JComponent {
 
     /** Multi-line mode: append a line, scrolling old ones off. */
     public void appendLine(String line) {
+        appendLine(line, null);
+    }
+
+    /** Multi-line mode with a per-line glow color (null = panel default). */
+    public void appendLine(String line, Color color) {
         synchronized (buffer) {
-            buffer.add(line == null ? "" : line);
+            buffer.add(new Entry(line == null ? "" : line, color));
             while (buffer.size() > lines) {
                 buffer.removeFirst();
             }
@@ -131,16 +140,17 @@ public class LcdDisplay extends JComponent {
             }
             g.drawString(t, 7, h / 2 + fm.getAscent() / 2 - 2);
         } else {
-            List<String> snapshot;
+            List<Entry> snapshot;
             synchronized (buffer) {
                 snapshot = new ArrayList<>(buffer);
             }
             int y = 4 + fm.getAscent();
-            for (String line : snapshot) {
-                String t = line;
+            for (Entry entry : snapshot) {
+                String t = entry.text();
                 while (t.length() > 1 && fm.stringWidth(t) > w - 14) {
                     t = t.substring(0, t.length() - 1);
                 }
+                g.setColor(entry.color() != null ? entry.color() : textColor);
                 g.drawString(t, 7, y);
                 y += 15;
             }

--- a/rack/src/test/java/org/nmox/studio/rack/engine/CommandExecutorTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/CommandExecutorTest.java
@@ -40,6 +40,30 @@ class CommandExecutorTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    @DisplayName("stderr keeps its identity: bus lines are tagged by stream, devices see both")
+    void shouldSeparateStderrOnTheBus() throws Exception {
+        List<String> busLines = new java.util.concurrent.CopyOnWriteArrayList<>();
+        RackBus.Listener tap = (device, line, err) -> busLines.add(device + "|" + line + "|" + err);
+        RackBus.subscribe(tap);
+        try {
+            CountDownLatch done = new CountDownLatch(1);
+            List<String> deviceLines = new java.util.concurrent.CopyOnWriteArrayList<>();
+            CommandExecutor.run("streams", new File("."), Map.of(),
+                    List.of("sh", "-c", "echo plain; echo broken 1>&2"),
+                    deviceLines::add, code -> done.countDown());
+
+            assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+            assertThat(busLines).containsExactlyInAnyOrder(
+                    "streams|plain|false", "streams|broken|true");
+            // the device callback still hears both streams (parsers need both)
+            assertThat(deviceLines).containsExactlyInAnyOrder("plain", "broken");
+        } finally {
+            RackBus.unsubscribe(tap);
+        }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
     @DisplayName("A command that reads stdin must finish instantly, not hang")
     void shouldNotHangOnStdinReads() throws Exception {
         CountDownLatch done = new CountDownLatch(1);

--- a/rack/src/test/java/org/nmox/studio/rack/service/StarterRackTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/service/StarterRackTest.java
@@ -1,0 +1,30 @@
+package org.nmox.studio.rack.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.rack.model.Rack;
+import org.nmox.studio.rack.model.RackDevice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The first thing a new user sees: one MONITOR, tapped onto the stderr
+ * bus, so errors are visible before a single cable is patched.
+ */
+class StarterRackTest {
+
+    @Test
+    @DisplayName("Starter rack is a single MONITOR with its TAP on stderr")
+    void starterRackIsOneStderrMonitor() {
+        Rack rack = new RackService().getRack();
+        try {
+            assertThat(rack.getDevices()).hasSize(1);
+            RackDevice monitor = rack.getDevices().get(0);
+            assertThat(monitor.getTypeId()).isEqualTo("console");
+            // TAP options are {off, stderr, all}; index 1 = stderr
+            assertThat(monitor.getState()).containsEntry("tap", "1");
+        } finally {
+            rack.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## What

The rack now opens as **a single MONITOR unit with stderr showing** — one honest screen that displays every error any device prints, before a single cable is patched. Around it, the complete handling experience: drag units into an exact slot, sort them with a lifted-glow grip drag, remove with Delete, and a realism pass that makes this the most convincing rack on the market.

## Highlights

- **True stderr**: the engine no longer merges stderr into stdout. Both streams pump separately, stderr prints red in the Output window, and every line travels a new `RackBus` tagged with device + stream.
- **MONITOR = a real monitor section**: the TAP knob (off / stderr / all) taps the rack bus the way a console's monitor section taps the mix. Bus errors glow red on the phosphor and flash the ERR LED. Patched input always displays.
- **Starter rack**: one MONITOR, TAP on stderr. The old 7-device wall became the "Web Pipeline" preset (first in the Presets menu).
- **Handling**: palette drags light the exact insertion slot (chevroned line on the unit grid); reordering lifts the unit with a glow and a deeper drop shadow; click selects, Delete/Backspace unracks (guarded against focused text fields); right-click menu unchanged.
- **Realism**: cage-nut holes down both rails on the half-unit grid, etched unit numbers, ambient-occlusion seams between stacked units, and rear-panel hardware on 2U+ devices — IEC C14 power inlet, fuse drawer, voltage silkscreen, barcoded serial sticker per device type.
- **Empty rack** invites with etched silkscreen instead of a void.

## Tests

- `CommandExecutorTest`: stderr keeps its identity on the bus; devices still hear both streams (vite logs to stderr — parsers need both).
- `StarterRackTest`: starter rack is exactly one MONITOR with TAP=stderr.
- `DeviceContractTest` (163 checks) covers the new MONITOR surface automatically.
- Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)