### PR TITLE
Rock solid: real-tool gauntlet, synchronous orphan reaper, human failure modes

### DIFF
--- a/editor/src/test/java/org/nmox/studio/editor/javascript/LexerPerformanceTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/javascript/LexerPerformanceTest.java
@@ -1,0 +1,54 @@
+package org.nmox.studio.editor.javascript;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.netbeans.api.lexer.TokenHierarchy;
+import org.netbeans.api.lexer.TokenSequence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real projects open real files: generated bundles, vendored libraries,
+ * megabyte-sized source. The lexer must chew through them without
+ * making the editor breathe heavy.
+ */
+class LexerPerformanceTest {
+
+    @Test
+    @DisplayName("A 1MB JavaScript file lexes fully in under 2 seconds")
+    void megabyteFileLexesFast() {
+        String unit = """
+                // module %d
+                const value%d = { a: 1, b: 'text', c: `tpl ${x}` };
+                function fn%d(arg) {
+                    /* block comment */
+                    if (arg !== null && arg >= 0.5) { return arg * 2; }
+                    return [1, 2, 3].map(n => n + value%d.a);
+                }
+                """;
+        StringBuilder source = new StringBuilder(1_200_000);
+        int i = 0;
+        while (source.length() < 1_000_000) {
+            source.append(unit.formatted(i, i, i, i));
+            i++;
+        }
+
+        long start = System.nanoTime();
+        TokenHierarchy<String> hierarchy =
+                TokenHierarchy.create(source.toString(), JavaScriptTokenId.language());
+        TokenSequence<?> ts = hierarchy.tokenSequence();
+        int tokens = 0;
+        int errors = 0;
+        while (ts.moveNext()) {
+            tokens++;
+            if ("error".equals(ts.token().id().primaryCategory())) {
+                errors++;
+            }
+        }
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertThat(tokens).as("the whole file must tokenize").isGreaterThan(100_000);
+        assertThat(errors).as("clean source must produce no error tokens").isZero();
+        assertThat(elapsedMs).as("1MB lex time (ms)").isLessThan(2_000);
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DevServerDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DevServerDevice.java
@@ -119,6 +119,14 @@ public class DevServerDevice extends CommandDevice {
 
     @Override
     protected void onLine(String line) {
+        // the most common real-world serve failure deserves a real answer
+        if (line.contains("EADDRINUSE") || line.toLowerCase().contains("address already in use")) {
+            onEdt(() -> {
+                statusLcd.setTextColor(new Color(255, 90, 80));
+                statusLcd.setText("PORT " + port() + " IN USE — DIAL ANOTHER OR STOP THE OTHER SERVER");
+            });
+            return;
+        }
         if (readyFired.compareAndSet(false, true)) {
             onEdt(() -> {
                 liveLed.setBlinking(false);

--- a/rack/src/main/java/org/nmox/studio/rack/devices/PackageManagerDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/PackageManagerDevice.java
@@ -195,13 +195,21 @@ public class PackageManagerDevice extends CommandDevice {
     private void refreshDepsLcd() {
         int[] counts = ProjectInspector.dependencyCounts(projectDir());
         var kinds = ProjectInspector.detectKinds(projectDir());
+        // a present-but-unparseable package.json is a fact worth stating,
+        // not a silent shrug - it breaks every AUTO knob downstream
+        boolean broken = counts == null && new File(
+                ProjectInspector.kindDir(projectDir(), ProjectInspector.ProjectKind.NODE),
+                "package.json").isFile();
         onEdt(() -> {
-            depsLcd.setText(counts != null && kinds.size() <= 1
+            depsLcd.setText(broken ? "PACKAGE.JSON UNREADABLE"
+                    : counts != null && kinds.size() <= 1
                     ? counts[0] + "+" + counts[1] + " DEPS"
                     : kinds.size() > 1 ? kinds.size() + " TOOLCHAINS"
                     : !kinds.isEmpty() ? kinds.keySet().iterator().next().manifest()
                     : "NO PROJECT");
-            depsLcd.setToolTipText(counts == null
+            depsLcd.setToolTipText(broken
+                    ? "package.json exists but does not parse — fix the JSON"
+                    : counts == null
                     ? "No package.json in the project"
                     : counts[0] + " dependencies, " + counts[1] + " devDependencies");
         });

--- a/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
@@ -29,6 +29,14 @@ public final class CommandExecutor {
     public interface Handle {
         void kill();
 
+        /**
+         * Kills synchronously: TERM, wait up to the grace period, then
+         * KILL the whole tree and wait again. For shutdown paths (the
+         * JVM exits when the hooks return, so async escalation threads
+         * never get their turn) - guarantees no orphaned dev servers.
+         */
+        void killAndWait(long graceMillis);
+
         boolean isAlive();
     }
 
@@ -68,7 +76,7 @@ public final class CommandExecutor {
             pb.environment().putAll(env);
             process = pb.start();
         } catch (IOException ex) {
-            String msg = "launch failed: " + ex.getMessage();
+            String msg = friendlyLaunchFailure(command, ex);
             if (out != null) {
                 out.println(msg);
             }
@@ -78,6 +86,10 @@ public final class CommandExecutor {
             return new Handle() {
                 @Override
                 public void kill() {
+                }
+
+                @Override
+                public void killAndWait(long graceMillis) {
                 }
 
                 @Override
@@ -131,10 +143,51 @@ public final class CommandExecutor {
             }
 
             @Override
+            public void killAndWait(long graceMillis) {
+                java.util.List<ProcessHandle> tree = new java.util.ArrayList<>();
+                process.descendants().forEach(tree::add);
+                tree.forEach(ProcessHandle::destroy);
+                process.destroy();
+                try {
+                    if (!process.waitFor(graceMillis, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                        tree.forEach(ProcessHandle::destroyForcibly);
+                        process.destroyForcibly();
+                        process.waitFor(1, java.util.concurrent.TimeUnit.SECONDS);
+                    }
+                    // descendants may outlive the parent's exit; sweep them
+                    for (ProcessHandle h : tree) {
+                        if (h.isAlive()) {
+                            h.destroyForcibly();
+                        }
+                    }
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
             public boolean isAlive() {
                 return process.isAlive();
             }
         };
+    }
+
+    /**
+     * Translates launch IOExceptions into something a developer can act
+     * on: the usual cause is simply that the tool is not installed or
+     * not on the PATH the IDE sees.
+     */
+    static String friendlyLaunchFailure(List<String> command, IOException ex) {
+        String tool = command.isEmpty() ? "?" : command.get(0);
+        String raw = String.valueOf(ex.getMessage());
+        if (raw.contains("error=2") || raw.contains("No such file")) {
+            return tool.toUpperCase() + " NOT FOUND — install it, or launch the IDE "
+                    + "from a terminal so your PATH carries it";
+        }
+        if (raw.contains("error=13") || raw.contains("Permission denied")) {
+            return tool.toUpperCase() + " IS NOT EXECUTABLE — check its permissions";
+        }
+        return "launch failed: " + raw;
     }
 
     /**

--- a/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
@@ -272,9 +272,17 @@ public abstract class RackDevice extends JPanel {
         }
     }
 
-    /** Emergency stop, callable from outside (the master section's STOP ALL). */
+    /**
+     * Emergency stop, callable from outside (STOP ALL, and the JVM
+     * shutdown reaper). Kills synchronously with forced escalation:
+     * shutdown hooks get no second chance, so neither do dev servers.
+     */
     public void panic() {
-        stopProcess();
+        CommandExecutor.Handle h = running;
+        if (h != null) {
+            running = null;
+            h.killAndWait(1_500);
+        }
     }
 
     // ---- control placement & persistence ----

--- a/rack/src/test/java/org/nmox/studio/rack/devices/RealPipelineTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/RealPipelineTest.java
@@ -1,0 +1,263 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nmox.studio.rack.engine.ToolLocator;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.Rack;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * The gauntlet: the rack's pipeline run against REAL tools - node and
+ * npm, no mocks, no network. Install readies a project, build produces
+ * artifacts, the test tally counts real output, the dev server
+ * announces a real URL and dies without orphans. If these pass, a web
+ * developer's day-one loop works.
+ */
+class RealPipelineTest {
+
+    @TempDir
+    static Path projectDir;
+
+    private Rack rack;
+
+    @BeforeAll
+    static void requireTools() throws Exception {
+        assumeTrue(toolOnPath("node"), "node not installed; gauntlet skipped");
+        assumeTrue(toolOnPath("npm"), "npm not installed; gauntlet skipped");
+        writeFixtureProject(projectDir);
+    }
+
+    private static boolean toolOnPath(String tool) {
+        for (String dir : ToolLocator.augmentedPath().split(File.pathSeparator)) {
+            if (new File(dir, tool).canExecute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** A zero-dependency npm project: no registry, no network, all real. */
+    private static void writeFixtureProject(Path dir) throws Exception {
+        Files.writeString(dir.resolve("package.json"), """
+                {
+                  "name": "gauntlet-fixture",
+                  "version": "1.0.0",
+                  "scripts": {
+                    "build": "node build.js",
+                    "test": "node test.js",
+                    "dev": "node server.js"
+                  }
+                }
+                """);
+        Files.writeString(dir.resolve("build.js"), """
+                const fs = require('fs');
+                fs.mkdirSync('dist', { recursive: true });
+                fs.writeFileSync('dist/out.txt', 'artifact');
+                console.log('built in 0.1s');
+                """);
+        Files.writeString(dir.resolve("test.js"), """
+                console.log('3 passed');
+                """);
+        Files.writeString(dir.resolve("server.js"), """
+                const http = require('http');
+                const srv = http.createServer((req, res) => res.end('ok'));
+                srv.listen(0, '127.0.0.1', () => {
+                    const port = srv.address().port;
+                    console.log('PID ' + process.pid);
+                    console.log('Local: http://localhost:' + port + '/');
+                });
+                """);
+    }
+
+    @BeforeEach
+    void freshRack() {
+        rack = new Rack();
+        rack.setProjectDir(projectDir.toFile());
+    }
+
+    @AfterEach
+    void tearDown() {
+        rack.shutdown();
+    }
+
+    /** Captures everything patched into it; a cable-level assertion point. */
+    private static final class ProbeDevice extends RackDevice {
+
+        final ConcurrentLinkedQueue<String> received = new ConcurrentLinkedQueue<>();
+        final CountDownLatch hit = new CountDownLatch(1);
+
+        ProbeDevice() {
+            super("probe", "PROBE", "TEST PROBE", new Color(0, 0, 0), 1);
+            addInPort("in", "IN", SignalType.TRIGGER);
+            addInPort("data", "DATA", SignalType.DATA);
+            addInPort("gate", "GATE", SignalType.GATE);
+        }
+
+        @Override
+        public void receive(Port in, Signal signal) {
+            received.add(in.getId() + ":" + signal.type() + ":" + signal.payload());
+            hit.countDown();
+        }
+    }
+
+    private static void await(CountDownLatch latch, int seconds, String what) throws Exception {
+        assertThat(latch.await(seconds, TimeUnit.SECONDS)).as(what).isTrue();
+    }
+
+    @Test
+    @DisplayName("CRATE installs a real npm project and fires OK down the cable")
+    void installReadiesTheProject() throws Exception {
+        PackageManagerDevice crate = new PackageManagerDevice();
+        ProbeDevice probe = new ProbeDevice();
+        rack.addDevice(crate);
+        rack.addDevice(probe);
+        rack.connect(crate.getPort("ok"), probe.getPort("in"));
+
+        crate.receive(crate.getPort("run"), Signal.trigger(true));
+
+        await(probe.hit, 90, "install must finish and fire OK");
+        assertThat(new File(projectDir.toFile(), "package-lock.json"))
+                .as("npm install must produce a lockfile").exists();
+    }
+
+    @Test
+    @DisplayName("FORGE resolves AUTO to the build script and produces the artifact")
+    void buildProducesArtifacts() throws Exception {
+        BuildDevice forge = new BuildDevice();
+        ProbeDevice probe = new ProbeDevice();
+        rack.addDevice(forge);
+        rack.addDevice(probe);
+        rack.connect(forge.getPort("ok"), probe.getPort("in"));
+
+        forge.receive(forge.getPort("run"), Signal.trigger(true));
+
+        await(probe.hit, 60, "build must finish and fire OK");
+        assertThat(new File(projectDir.toFile(), "dist/out.txt"))
+                .as("the build script's artifact").exists();
+    }
+
+    @Test
+    @DisplayName("VERITAS runs the real test script and OK carries the verdict")
+    void testRunnerFiresOk() throws Exception {
+        TestDevice veritas = new TestDevice();
+        ProbeDevice probe = new ProbeDevice();
+        rack.addDevice(veritas);
+        rack.addDevice(probe);
+        rack.connect(veritas.getPort("ok"), probe.getPort("in"));
+
+        veritas.receive(veritas.getPort("run"), Signal.trigger(true));
+
+        await(probe.hit, 60, "test run must finish and fire OK");
+    }
+
+    @Test
+    @DisplayName("SURGE serves, announces the REAL printed URL, and stops without orphans")
+    void devServerLifecycle() throws Exception {
+        DevServerDevice surge = new DevServerDevice();
+        ProbeDevice urlProbe = new ProbeDevice();
+        rack.addDevice(surge);
+        rack.addDevice(urlProbe);
+        rack.connect(surge.getPort("url"), urlProbe.getPort("data"));
+
+        surge.receive(surge.getPort("run"), Signal.trigger(true));
+
+        // the server prints its OS-assigned port; SURGE must re-announce it
+        long deadline = System.currentTimeMillis() + 30_000;
+        String realUrl = null;
+        long childPid = -1;
+        while (System.currentTimeMillis() < deadline && (realUrl == null || childPid < 0)) {
+            for (String s : urlProbe.received) {
+                if (s.contains("http://localhost:") && !s.endsWith(":5173")) {
+                    realUrl = s.substring(s.indexOf("http"));
+                }
+            }
+            childPid = serverPidFromLog();
+            Thread.sleep(200);
+        }
+        assertThat(realUrl).as("SURGE must announce the server's real URL").isNotNull();
+        assertThat(childPid).as("server must log its PID").isGreaterThan(0);
+        assertThat(ProcessHandle.of(childPid)).as("server alive while serving").isPresent();
+
+        // STOP by cable, like the rack would
+        surge.receive(surge.getPort("stop"), Signal.trigger(true));
+
+        long pid = childPid;
+        long stopDeadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < stopDeadline
+                && ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false)) {
+            Thread.sleep(200);
+        }
+        assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false))
+                .as("no orphaned dev server after STOP").isFalse();
+    }
+
+    @Test
+    @DisplayName("panic() reaps the whole process tree synchronously - the shutdown guarantee")
+    void panicReapsDescendants() throws Exception {
+        DevServerDevice surge = new DevServerDevice();
+        rack.addDevice(surge);
+
+        // npm run dev -> node server.js: a parent with a child, exactly
+        // the tree a real dev server leaves behind
+        surge.receive(surge.getPort("run"), Signal.trigger(true));
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline && busPid < 0) {
+            Thread.sleep(200);
+        }
+        assertThat(busPid).as("server must come up and log its PID").isGreaterThan(0);
+        long pid = busPid;
+        assertThat(ProcessHandle.of(pid)).isPresent();
+
+        // panic is the JVM-shutdown path: it must return only when the
+        // tree is dead, because nothing runs after the hooks
+        surge.panic();
+
+        assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false))
+                .as("panic must leave no survivors, synchronously").isFalse();
+    }
+
+    private long serverPidFromLog() {
+        // SURGE's child logs "PID <n>" on the rack bus via stdout; the
+        // probe only hears the URL jack, so read it from the bus instead
+        return busPid;
+    }
+
+    private volatile long busPid = -1;
+    private final org.nmox.studio.rack.engine.RackBus.Listener pidTap = (device, line, err) -> {
+        if (line.startsWith("PID ")) {
+            try {
+                busPid = Long.parseLong(line.substring(4).trim());
+            } catch (NumberFormatException ignored) {
+            }
+        }
+    };
+
+    @BeforeEach
+    void tapBus() {
+        busPid = -1;
+        org.nmox.studio.rack.engine.RackBus.subscribe(pidTap);
+    }
+
+    @AfterEach
+    void untapBus() {
+        org.nmox.studio.rack.engine.RackBus.unsubscribe(pidTap);
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/engine/BigTreeWatcherTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/BigTreeWatcherTest.java
@@ -1,0 +1,89 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real repos are big. The watcher must stay cheap on a tree with
+ * thousands of files - and a node_modules an order of magnitude
+ * bigger - while still noticing the one file that changed.
+ */
+class BigTreeWatcherTest {
+
+    @TempDir
+    Path root;
+
+    private FileWatcher watcher;
+
+    @AfterEach
+    void tearDown() {
+        if (watcher != null) {
+            watcher.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("5k-file tree: change detection stays prompt, node_modules stays invisible")
+    void bigTreeStaysFast() throws Exception {
+        // 2,000 source files across 100 dirs
+        for (int d = 0; d < 100; d++) {
+            Path dir = root.resolve("src/pkg" + d);
+            Files.createDirectories(dir);
+            for (int f = 0; f < 20; f++) {
+                Files.writeString(dir.resolve("file" + f + ".js"), "export const x = " + f + ";");
+            }
+        }
+        // 3,000 dependency files the watcher must not even glance at
+        for (int d = 0; d < 100; d++) {
+            Path dir = root.resolve("node_modules/dep" + d + "/lib");
+            Files.createDirectories(dir);
+            for (int f = 0; f < 30; f++) {
+                Files.writeString(dir.resolve("m" + f + ".js"), "module.exports = " + f + ";");
+            }
+        }
+
+        CountDownLatch fired = new CountDownLatch(1);
+        long startNanos = System.nanoTime();
+        watcher = new FileWatcher(root.toFile(), 300, null, changed -> fired.countDown());
+        watcher.start();
+        Thread.sleep(900); // baseline scan + one idle poll
+
+        long baselineMs = (System.nanoTime() - startNanos) / 1_000_000;
+        assertThat(baselineMs).as("watcher startup on a 5k tree must not block").isLessThan(10_000);
+
+        // a single real change must surface within a few polls
+        Files.writeString(root.resolve("src/pkg42/file7.js"), "export const x = 'changed';");
+        assertThat(fired.await(6, TimeUnit.SECONDS))
+                .as("one changed file in a big tree must be noticed").isTrue();
+    }
+
+    @Test
+    @DisplayName("Storms inside node_modules never wake the rack")
+    void nodeModulesStormIsSilent() throws Exception {
+        File nm = new File(root.toFile(), "node_modules/busy");
+        assertThat(nm.mkdirs()).isTrue();
+        Files.writeString(root.resolve("package.json"), "{}");
+
+        CountDownLatch fired = new CountDownLatch(1);
+        watcher = new FileWatcher(root.toFile(), 200, null, changed -> fired.countDown());
+        watcher.start();
+        Thread.sleep(500);
+
+        // an install-like write storm
+        for (int i = 0; i < 200; i++) {
+            Files.writeString(nm.toPath().resolve("pkg" + i + ".js"), "x");
+        }
+
+        assertThat(fired.await(2, TimeUnit.SECONDS))
+                .as("node_modules churn must not fire the watcher").isFalse();
+    }
+}


### PR DESCRIPTION
## What

The "usable by real web devs" sprint: prove the core loop against real tools, guarantee process hygiene, and make failures actionable.

## Proven, not promised

- **RealPipelineTest** runs real `node`/`npm` (zero deps, no network) through the actual devices and cables: install → OK trigger + lockfile; AUTO build → artifact on disk; test run → verdict by trigger; dev server → announces its *printed* URL, stops with no orphans; `panic()` reaps a two-level process tree synchronously. Skips cleanly where node is absent.
- **Live exit-safety smoke**: started vite through SURGE in the running app, quit the IDE from the menu, and verified in the process table: **zero survivors** of the `npm exec vite → node vite` tree.

## Fixed

- **Shutdown-hook hole**: the async kill-escalation thread never ran during JVM exit (hooks return → JVM dies). New `Handle.killAndWait()` TERMs the tree, waits, KILLs, and sweeps descendants; `panic()` (STOP ALL + reaper) now uses it.
- **Human failure modes**: missing tool → "NPM NOT FOUND — install it, or launch the IDE from a terminal so your PATH carries it"; `EADDRINUSE` → "PORT 5173 IN USE — DIAL ANOTHER OR STOP THE OTHER SERVER"; unparseable package.json → "PACKAGE.JSON UNREADABLE" on CRATE instead of silently breaking every AUTO knob.

## Performance rails

- 5,000-file tree (3,000 in node_modules): prompt watching, one-file change detection, silence through install storms (`BigTreeWatcherTest`)
- 1MB JavaScript file tokenizes fully, cleanly, far under the 2s budget (`LexerPerformanceTest`)

Full suite green locally including the new gauntlet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)