### PR TITLE
HARBOR: Docker engine in the rack + the control panel behind it

### DIFF
--- a/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
@@ -36,7 +36,8 @@ public enum DeviceType {
     TEMPO("tempo", "TEMPO", "Step Sequencer — fire pipelines on a clock", new Color(255, 211, 105), TempoDevice::new),
     TYPECHECK("typecheck", "TYPEGUARD", "Type Checker — tsc, watch-aware", new Color(49, 120, 198), TypecheckDevice::new),
     TUNNEL("tunnel", "WORMHOLE", "Public Tunnel — cloudflared/ngrok/localtunnel", new Color(156, 89, 209), TunnelDevice::new),
-    BENCH("bench", "GAUNTLET", "Load Bench — autocannon throughput", new Color(224, 122, 47), BenchDevice::new);
+    BENCH("bench", "GAUNTLET", "Load Bench — autocannon throughput", new Color(224, 122, 47), BenchDevice::new),
+    DOCKER("docker", "HARBOR", "Docker Engine — panel, prune, status", new Color(36, 150, 237), DockerDevice::new);
 
     private final String id;
     private final String title;
@@ -92,7 +93,7 @@ public enum DeviceType {
             case DEV_SERVER, TUNNEL, BROWSER, HTTP -> PaletteCategory.SERVE;
             case ANGULAR, PHOENIX, NEXTJS -> PaletteCategory.FRAMEWORKS;
             case CONSOLE, TERMINAL, BENCH, DEBUG -> PaletteCategory.OBSERVE;
-            case GIT, AUDIT, DEPLOY -> PaletteCategory.SHIP;
+            case GIT, AUDIT, DEPLOY, DOCKER -> PaletteCategory.SHIP;
             case ENV, ROSETTA -> PaletteCategory.UTILITY;
         };
     }
@@ -127,6 +128,7 @@ public enum DeviceType {
             case DEPLOY -> "Flip ARM, then LAUNCH deploys to the dialed target.\nUnarmed pads ignore even patched triggers - by design.";
             case ENV -> "Sets NODE_ENV/CI/custom vars for every command the rack runs.\nWhat the knob says is what every device gets.";
             case ROSETTA -> "Mixed repo? Pin every AUTO knob to one toolchain with the dial.\nAUTO follows detection; KIND out reports the choice.";
+            case DOCKER -> "The ENGINE LED tracks the daemon; LCDs show containers up, images held, disk reclaimable.\nPANEL opens the full control room — containers, images, volumes, networks, and one-click Dockerize.";
         };
     }
 

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DockerDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DockerDevice.java
@@ -1,0 +1,198 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.util.List;
+import org.nmox.studio.rack.docker.DockerClient;
+import org.nmox.studio.rack.docker.DockerPanelTopComponent;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.ui.controls.Knob;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.Led;
+import org.nmox.studio.rack.ui.controls.RackButton;
+import org.nmox.studio.rack.ui.controls.RackStyle;
+
+/**
+ * HARBOR Docker Engine: the rack-mounted face of the container runtime.
+ * The ENGINE LED tracks the daemon, the LCDs carry the three numbers a
+ * developer actually wants at a glance (containers up, images held,
+ * disk reclaimable), and PANEL opens the full control room - the
+ * Docker Panel - where the real power lives.
+ */
+public class DockerDevice extends RackDevice {
+
+    private static final String[] POLL_RATES = {"off", "10s", "30s", "60s"};
+    private static final int[] POLL_MS = {0, 10_000, 30_000, 60_000};
+
+    private final Led engineLed;
+    private final LcdDisplay containersLcd;
+    private final LcdDisplay imagesLcd;
+    private final LcdDisplay reclaimLcd;
+    private final Knob pollKnob;
+    private final javax.swing.Timer poller;
+    private volatile boolean engineUp;
+
+    public DockerDevice() {
+        super("docker", "HARBOR", "DOCKER ENGINE", new Color(36, 150, 237), 2);
+
+        RackButton panel = place(new RackButton("PANEL", RackStyle.GO), RackStyle.TRANSPORT_X, 52);
+        RackButton refresh = place(new RackButton("RFRSH", RackStyle.QUERY), RackStyle.TRANSPORT_STOP_X, 52);
+        RackButton prune = place(new RackButton("PRUNE", RackStyle.MUTATE), 180, 52);
+        pollKnob = place(new Knob("POLL", POLL_RATES, 2), 254, 40);
+        engineLed = place(new Led("ENGINE", new Color(36, 150, 237)), 326, 58);
+
+        int lcdX = 396;
+        containersLcd = place(new LcdDisplay(150, 1), lcdX, 34);
+        imagesLcd = place(new LcdDisplay(150, 1), lcdX, 62);
+        reclaimLcd = place(new LcdDisplay(150, 1), lcdX, 90);
+        containersLcd.setText("ENGINE?");
+        imagesLcd.setText("—");
+        reclaimLcd.setText("—");
+        containersLcd.setToolTipText("running / total containers");
+        imagesLcd.setToolTipText("images held and their disk size");
+        reclaimLcd.setToolTipText("disk you could get back with PRUNE / the panel");
+
+        panel.setToolTipText("Open the Docker Panel — containers, images, volumes, networks, dockerize");
+        prune.setToolTipText("Safe prune: dangling images + build cache (never touches tagged images or volumes)");
+        refresh.setToolTipText("Re-read engine status now");
+
+        panel.addActionListener(e -> openPanel());
+        refresh.addActionListener(e -> refresh());
+        prune.addActionListener(e -> safePrune());
+        pollKnob.addChangeListener(this::restartPoller);
+
+        param("poll", pollKnob);
+
+        addInPort("run", "RUN", SignalType.TRIGGER);
+        addOutPort("running", "RUNNING", SignalType.GATE);
+        addOutPort("out", "OUT", SignalType.DATA);
+
+        poller = new javax.swing.Timer(POLL_MS[2], e -> refresh());
+        poller.setRepeats(true);
+    }
+
+    // ---- actions ----
+
+    private void openPanel() {
+        DockerPanelTopComponent.openPanel();
+    }
+
+    /** Reclaims only what is always safe: dangling images + build cache. */
+    private void safePrune() {
+        onEdt(() -> reclaimLcd.setText("PRUNING…"));
+        DockerClient.getDefault().prune("image", false)
+                .thenCompose(r -> DockerClient.getDefault().prune("builder", false))
+                .whenComplete((r, ex) -> refresh());
+    }
+
+    private void refresh() {
+        DockerClient client = DockerClient.getDefault();
+        client.engineVersion().thenAccept(version -> {
+            boolean up = version != null;
+            boolean changed = up != engineUp;
+            engineUp = up;
+            onEdt(() -> {
+                engineLed.setOn(up);
+                if (!up) {
+                    containersLcd.setTextColor(RackStyle.LCD_AMBER);
+                    containersLcd.setText("ENGINE DOWN — START DOCKER");
+                    imagesLcd.setText("—");
+                    reclaimLcd.setText("—");
+                }
+            });
+            if (changed) {
+                emit("running", Signal.gate(up));
+            }
+            if (!up) {
+                return;
+            }
+            client.containers().thenAccept(cs -> {
+                long running = cs.stream().filter(DockerClient.ContainerInfo::running).count();
+                onEdt(() -> {
+                    containersLcd.setTextColor(RackStyle.LCD_TEXT);
+                    containersLcd.setText(running + "/" + cs.size() + " CONTAINERS UP");
+                });
+                emit("out", Signal.data("docker: " + running + "/" + cs.size() + " containers up"));
+            });
+            client.systemDf().thenAccept(rows -> {
+                String images = "—";
+                String reclaim = "—";
+                for (DockerClient.DfRow row : rows) {
+                    if ("Images".equalsIgnoreCase(row.type())) {
+                        images = row.totalCount() + " IMAGES · " + row.size();
+                    }
+                }
+                String total = totalReclaimable(rows);
+                if (!total.isEmpty()) {
+                    reclaim = total + " RECLAIMABLE";
+                }
+                final String i = images;
+                final String r = reclaim;
+                onEdt(() -> {
+                    imagesLcd.setText(i);
+                    reclaimLcd.setText(r);
+                });
+            });
+        });
+    }
+
+    /** Sums the human-readable reclaimable column well enough to glance at. */
+    public static String totalReclaimable(List<DockerClient.DfRow> rows) {
+        double gb = 0;
+        for (DockerClient.DfRow row : rows) {
+            String r = row.reclaimable();
+            if (r == null || r.isEmpty()) {
+                continue;
+            }
+            java.util.regex.Matcher m = java.util.regex.Pattern
+                    .compile("([\\d.]+)\\s*(kB|KB|MB|GB|TB|B)").matcher(r);
+            if (m.find()) {
+                double v = Double.parseDouble(m.group(1));
+                gb += switch (m.group(2)) {
+                    case "TB" -> v * 1024;
+                    case "GB" -> v;
+                    case "MB" -> v / 1024;
+                    case "kB", "KB" -> v / (1024 * 1024);
+                    default -> 0;
+                };
+            }
+        }
+        if (gb <= 0) {
+            return "";
+        }
+        return gb >= 1 ? String.format("%.1fGB", gb) : String.format("%.0fMB", gb * 1024);
+    }
+
+    // ---- polling lifecycle ----
+
+    private void restartPoller() {
+        int ms = POLL_MS[pollKnob.getSelectedIndex()];
+        poller.stop();
+        if (ms > 0) {
+            poller.setDelay(ms);
+            poller.setInitialDelay(ms);
+            poller.start();
+        }
+    }
+
+    @Override
+    protected void onAttached() {
+        refresh();
+        restartPoller();
+    }
+
+    @Override
+    public void dispose() {
+        poller.stop();
+        super.dispose();
+    }
+
+    @Override
+    public void receive(Port in, Signal signal) {
+        if ("run".equals(in.getId())) {
+            refresh();
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/docker/DockerClient.java
+++ b/rack/src/main/java/org/nmox/studio/rack/docker/DockerClient.java
@@ -1,0 +1,344 @@
+package org.nmox.studio.rack.docker;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.json.JSONObject;
+import org.nmox.studio.rack.engine.ToolLocator;
+
+/**
+ * The engine room: an asynchronous wrapper over the real docker CLI.
+ * Going through the CLI (rather than the socket API) means contexts,
+ * Docker Desktop, colima, and rootless setups all behave exactly as
+ * they do in the developer's terminal - and ToolLocator finds the
+ * binary even when the IDE was launched from Finder.
+ *
+ * All list calls use line-delimited {@code --format '{{json .}}'}
+ * output; the parsers are pure static functions, tested on canned
+ * output without a daemon.
+ */
+public final class DockerClient {
+
+    private static final DockerClient INSTANCE = new DockerClient();
+
+    private final ExecutorService pool = Executors.newFixedThreadPool(4, r -> {
+        Thread t = new Thread(r, "nmox-docker");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private DockerClient() {
+    }
+
+    public static DockerClient getDefault() {
+        return INSTANCE;
+    }
+
+    // ---- raw execution ----
+
+    /** One finished CLI call. */
+    public record Result(int exit, String stdout, String stderr) {
+
+        public boolean ok() {
+            return exit == 0;
+        }
+    }
+
+    /** Runs docker with the given args; never throws, never prompts. */
+    public Result run(long timeoutSeconds, String... args) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("docker");
+        Collections.addAll(cmd, args);
+        try {
+            ProcessBuilder pb = new ProcessBuilder(ToolLocator.resolveCommand(cmd))
+                    .redirectInput(new File(System.getProperty("os.name", "")
+                            .toLowerCase().contains("win") ? "NUL" : "/dev/null"));
+            pb.environment().put("PATH", ToolLocator.augmentedPath());
+            pb.environment().put("NO_COLOR", "1");
+            Process p = pb.start();
+            String out = readAll(p.getInputStream());
+            String err = readAll(p.getErrorStream());
+            if (!p.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+                return new Result(-1, out, "docker timed out after " + timeoutSeconds + "s");
+            }
+            return new Result(p.exitValue(), out, err);
+        } catch (IOException ex) {
+            return new Result(-1, "", "docker not found - install Docker Desktop or add docker to PATH");
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return new Result(-1, "", "interrupted");
+        }
+    }
+
+    private static String readAll(java.io.InputStream in) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            char[] buf = new char[8192];
+            int n;
+            while ((n = r.read(buf)) > 0) {
+                sb.append(buf, 0, n);
+            }
+        }
+        return sb.toString();
+    }
+
+    private <T> CompletableFuture<T> async(java.util.function.Supplier<T> s) {
+        return CompletableFuture.supplyAsync(s, pool);
+    }
+
+    // ---- engine ----
+
+    /** Server version, or null when the daemon is unreachable. */
+    public CompletableFuture<String> engineVersion() {
+        return async(() -> {
+            Result r = run(8, "version", "--format", "{{.Server.Version}}");
+            String v = r.stdout.trim();
+            return r.ok() && !v.isEmpty() ? v : null;
+        });
+    }
+
+    // ---- model records ----
+
+    public record ContainerInfo(String id, String name, String image, String state,
+            String status, String ports, List<Integer> hostPorts) {
+
+        public boolean running() {
+            return "running".equalsIgnoreCase(state);
+        }
+    }
+
+    public record ImageInfo(String repository, String tag, String id, String size,
+            String created, boolean dangling) {
+
+        public String ref() {
+            return dangling ? id : repository + ":" + tag;
+        }
+    }
+
+    public record VolumeInfo(String name, String driver) {
+    }
+
+    public record NetworkInfo(String id, String name, String driver, String scope) {
+    }
+
+    /** One row of `docker system df`: a category and what it would free. */
+    public record DfRow(String type, String totalCount, String active,
+            String size, String reclaimable) {
+    }
+
+    public record StatRow(String id, String name, String cpu, String mem) {
+    }
+
+    // ---- listings ----
+
+    public CompletableFuture<List<ContainerInfo>> containers() {
+        return async(() -> parseContainers(
+                run(15, "ps", "-a", "--no-trunc", "--format", "{{json .}}").stdout));
+    }
+
+    public CompletableFuture<List<ImageInfo>> images() {
+        return async(() -> parseImages(
+                run(15, "images", "--format", "{{json .}}").stdout));
+    }
+
+    public CompletableFuture<List<VolumeInfo>> volumes() {
+        return async(() -> parseVolumes(
+                run(15, "volume", "ls", "--format", "{{json .}}").stdout));
+    }
+
+    public CompletableFuture<List<NetworkInfo>> networks() {
+        return async(() -> parseNetworks(
+                run(15, "network", "ls", "--format", "{{json .}}").stdout));
+    }
+
+    public CompletableFuture<List<DfRow>> systemDf() {
+        return async(() -> parseDf(
+                run(30, "system", "df", "--format", "{{json .}}").stdout));
+    }
+
+    public CompletableFuture<List<StatRow>> statsSnapshot() {
+        return async(() -> parseStats(
+                run(20, "stats", "--no-stream", "--format", "{{json .}}").stdout));
+    }
+
+    // ---- detail ----
+
+    public CompletableFuture<String> logs(String id, int tail) {
+        return async(() -> {
+            Result r = run(20, "logs", "--tail", String.valueOf(tail), "--timestamps", id);
+            return r.stdout + (r.stderr.isEmpty() ? "" : "\n" + r.stderr);
+        });
+    }
+
+    public CompletableFuture<String> inspect(String id) {
+        return async(() -> run(15, "inspect", id).stdout);
+    }
+
+    public CompletableFuture<String> history(String image) {
+        return async(() -> run(15, "history", "--no-trunc", "--format",
+                "{{.Size}}\t{{.CreatedBy}}", image).stdout);
+    }
+
+    // ---- verbs ----
+
+    public CompletableFuture<Result> lifecycle(String verb, String id) {
+        return async(() -> switch (verb) {
+            case "start", "stop", "restart", "pause", "unpause", "kill" ->
+                run(60, verb, id);
+            case "rm" -> run(60, "rm", "-f", id);
+            default -> new Result(-1, "", "unknown verb " + verb);
+        });
+    }
+
+    public CompletableFuture<Result> removeImage(String ref, boolean force) {
+        return async(() -> force ? run(60, "rmi", "-f", ref) : run(60, "rmi", ref));
+    }
+
+    public CompletableFuture<Result> pull(String ref) {
+        return async(() -> run(600, "pull", ref));
+    }
+
+    public CompletableFuture<Result> tag(String src, String target) {
+        return async(() -> run(15, "tag", src, target));
+    }
+
+    public CompletableFuture<Result> removeVolume(String name) {
+        return async(() -> run(30, "volume", "rm", name));
+    }
+
+    public CompletableFuture<Result> removeNetwork(String id) {
+        return async(() -> run(30, "network", "rm", id));
+    }
+
+    /** kind: container|image|volume|network|builder. all=true widens image prune. */
+    public CompletableFuture<Result> prune(String kind, boolean all) {
+        return async(() -> switch (kind) {
+            case "container" -> run(120, "container", "prune", "-f");
+            case "image" -> all ? run(300, "image", "prune", "-a", "-f")
+                    : run(300, "image", "prune", "-f");
+            case "volume" -> run(120, "volume", "prune", "-f");
+            case "network" -> run(120, "network", "prune", "-f");
+            case "builder" -> run(300, "builder", "prune", "-f");
+            default -> new Result(-1, "", "unknown prune kind " + kind);
+        });
+    }
+
+    // ---- pure parsers (unit-tested without a daemon) ----
+
+    static List<JSONObject> jsonLines(String out) {
+        List<JSONObject> rows = new ArrayList<>();
+        for (String line : out.split("\n")) {
+            line = line.trim();
+            if (line.startsWith("{")) {
+                try {
+                    rows.add(new JSONObject(line));
+                } catch (RuntimeException ignored) {
+                    // partial line from a dying daemon; skip it
+                }
+            }
+        }
+        return rows;
+    }
+
+    /** "0.0.0.0:8080->80/tcp, :::8080->80/tcp" -> [8080]. */
+    private static final Pattern HOST_PORT = Pattern.compile("(?:^|[\\s,])(?:[\\d.]+|\\[?::]?\\]?):(\\d+)->");
+
+    static List<Integer> hostPorts(String ports) {
+        List<Integer> result = new ArrayList<>();
+        Matcher m = HOST_PORT.matcher(ports == null ? "" : ports);
+        while (m.find()) {
+            Integer p = Integer.valueOf(m.group(1));
+            if (!result.contains(p)) {
+                result.add(p);
+            }
+        }
+        return result;
+    }
+
+    static List<ContainerInfo> parseContainers(String out) {
+        List<ContainerInfo> list = new ArrayList<>();
+        for (JSONObject o : jsonLines(out)) {
+            String ports = o.optString("Ports", "");
+            list.add(new ContainerInfo(
+                    o.optString("ID", ""),
+                    o.optString("Names", ""),
+                    o.optString("Image", ""),
+                    o.optString("State", ""),
+                    o.optString("Status", ""),
+                    ports,
+                    hostPorts(ports)));
+        }
+        return list;
+    }
+
+    static List<ImageInfo> parseImages(String out) {
+        List<ImageInfo> list = new ArrayList<>();
+        for (JSONObject o : jsonLines(out)) {
+            String repo = o.optString("Repository", "");
+            String tag = o.optString("Tag", "");
+            list.add(new ImageInfo(repo, tag,
+                    o.optString("ID", ""),
+                    o.optString("Size", ""),
+                    o.optString("CreatedSince", ""),
+                    "<none>".equals(repo) || "<none>".equals(tag)));
+        }
+        return list;
+    }
+
+    static List<VolumeInfo> parseVolumes(String out) {
+        List<VolumeInfo> list = new ArrayList<>();
+        for (JSONObject o : jsonLines(out)) {
+            list.add(new VolumeInfo(o.optString("Name", ""), o.optString("Driver", "")));
+        }
+        return list;
+    }
+
+    static List<NetworkInfo> parseNetworks(String out) {
+        List<NetworkInfo> list = new ArrayList<>();
+        for (JSONObject o : jsonLines(out)) {
+            list.add(new NetworkInfo(
+                    o.optString("ID", ""),
+                    o.optString("Name", ""),
+                    o.optString("Driver", ""),
+                    o.optString("Scope", "")));
+        }
+        return list;
+    }
+
+    static List<DfRow> parseDf(String out) {
+        List<DfRow> list = new ArrayList<>();
+        for (JSONObject o : jsonLines(out)) {
+            list.add(new DfRow(
+                    o.optString("Type", ""),
+                    o.optString("TotalCount", ""),
+                    o.optString("Active", ""),
+                    o.optString("Size", ""),
+                    o.optString("Reclaimable", "")));
+        }
+        return list;
+    }
+
+    static List<StatRow> parseStats(String out) {
+        List<StatRow> list = new ArrayList<>();
+        for (JSONObject o : jsonLines(out)) {
+            list.add(new StatRow(
+                    o.optString("Container", ""),
+                    o.optString("Name", ""),
+                    o.optString("CPUPerc", ""),
+                    o.optString("MemUsage", "")));
+        }
+        return list;
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/docker/DockerPanelTopComponent.java
+++ b/rack/src/main/java/org/nmox/studio/rack/docker/DockerPanelTopComponent.java
@@ -1,0 +1,686 @@
+package org.nmox.studio.rack.docker;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Desktop;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import org.nmox.studio.rack.devices.ProjectInspector;
+import org.nmox.studio.rack.docker.DockerClient.ContainerInfo;
+import org.nmox.studio.rack.docker.DockerClient.DfRow;
+import org.nmox.studio.rack.docker.DockerClient.ImageInfo;
+import org.nmox.studio.rack.docker.DockerClient.NetworkInfo;
+import org.nmox.studio.rack.docker.DockerClient.Result;
+import org.nmox.studio.rack.docker.DockerClient.StatRow;
+import org.nmox.studio.rack.docker.DockerClient.VolumeInfo;
+import org.nmox.studio.rack.service.RackService;
+import org.openide.windows.TopComponent;
+
+/**
+ * The Docker Panel: the control room HARBOR's PANEL button opens.
+ * More power than the CLI hands you raw: the disk ledger knows what
+ * every category would reclaim and frees it in one click, containers
+ * carry live CPU/MEM with their ports clickable into the browser,
+ * bulk operations work across selections, and the Dockerize tab
+ * writes a production multi-stage Dockerfile from what the rack
+ * already knows about your project.
+ */
+@TopComponent.Description(
+        preferredID = "DockerPanelTopComponent",
+        persistenceType = TopComponent.PERSISTENCE_NEVER
+)
+@TopComponent.Registration(mode = "editor", openAtStartup = false)
+public final class DockerPanelTopComponent extends TopComponent {
+
+    private static final Color BG = new Color(25, 26, 29);
+    private static final Color TEXT = new Color(206, 208, 212);
+    private static final Color DIM = new Color(140, 142, 148);
+    private static final Color UP = new Color(80, 235, 100);
+    private static final Color DOWN = new Color(255, 90, 80);
+    private static final Color ACCENT = new Color(36, 150, 237);
+    private static final Font MONO = new Font(Font.MONOSPACED, Font.PLAIN, 12);
+
+    private static DockerPanelTopComponent instance;
+
+    private final DockerClient client = DockerClient.getDefault();
+    private final JLabel engineLabel = new JLabel("ENGINE: checking…");
+    private final JLabel statusLabel = new JLabel(" ");
+    private final javax.swing.Timer autoTimer = new javax.swing.Timer(15_000, e -> refreshAll());
+
+    private final JPanel enginePanel = new JPanel(new GridBagLayout());
+    private final DefaultTableModel containersModel = model("", "NAME", "IMAGE", "STATUS", "PORTS", "CPU", "MEM");
+    private final JTable containersTable = table(containersModel);
+    private final DefaultTableModel imagesModel = model("REFERENCE", "ID", "SIZE", "CREATED", "");
+    private final JTable imagesTable = table(imagesModel);
+    private final DefaultTableModel volumesModel = model("NAME", "DRIVER");
+    private final JTable volumesTable = table(volumesModel);
+    private final DefaultTableModel networksModel = model("NAME", "DRIVER", "SCOPE", "ID");
+    private final JTable networksTable = table(networksModel);
+
+    private List<ContainerInfo> containers = List.of();
+    private List<ImageInfo> images = List.of();
+    private List<VolumeInfo> volumes = List.of();
+    private List<NetworkInfo> networks = List.of();
+
+    private final JTextArea dockerfilePreview = preview();
+    private final JTextArea ignorePreview = preview();
+    private final JTextArea composePreview = preview();
+    private final JLabel dockerizeInfo = new JLabel(" ");
+    private Map<String, String> dockerizeFiles = Map.of();
+
+    public DockerPanelTopComponent() {
+        setName("Docker Panel");
+        setToolTipText("Containers, images, volumes, networks, and one-click dockerize");
+        setLayout(new BorderLayout());
+        setBackground(BG);
+
+        add(buildHeader(), BorderLayout.NORTH);
+
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.setBackground(BG);
+        tabs.addTab("Engine", wrap(enginePanel));
+        tabs.addTab("Containers", buildContainersTab());
+        tabs.addTab("Images", buildImagesTab());
+        tabs.addTab("Volumes", buildVolumesTab());
+        tabs.addTab("Networks", buildNetworksTab());
+        tabs.addTab("Dockerize", buildDockerizeTab());
+        add(tabs, BorderLayout.CENTER);
+
+        statusLabel.setForeground(DIM);
+        statusLabel.setBorder(BorderFactory.createEmptyBorder(3, 10, 3, 10));
+        add(statusLabel, BorderLayout.SOUTH);
+    }
+
+    /** HARBOR's PANEL button lands here. */
+    public static void openPanel() {
+        SwingUtilities.invokeLater(() -> {
+            if (instance == null) {
+                instance = new DockerPanelTopComponent();
+            }
+            instance.open();
+            instance.requestActive();
+            instance.refreshAll();
+        });
+    }
+
+    @Override
+    public void componentClosed() {
+        autoTimer.stop();
+    }
+
+    // ---- header ----
+
+    private JPanel buildHeader() {
+        JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 6));
+        header.setBackground(BG);
+        engineLabel.setForeground(TEXT);
+        engineLabel.setFont(engineLabel.getFont().deriveFont(Font.BOLD));
+        header.add(engineLabel);
+        JButton refresh = new JButton("Refresh All");
+        refresh.addActionListener(e -> refreshAll());
+        header.add(refresh);
+        JCheckBox auto = new JCheckBox("Auto-refresh 15s", false);
+        auto.setBackground(BG);
+        auto.setForeground(DIM);
+        auto.addActionListener(e -> {
+            if (auto.isSelected()) {
+                autoTimer.start();
+            } else {
+                autoTimer.stop();
+            }
+        });
+        header.add(auto);
+        return header;
+    }
+
+    // ---- shared widgets ----
+
+    private static DefaultTableModel model(String... cols) {
+        return new DefaultTableModel(cols, 0) {
+            @Override
+            public boolean isCellEditable(int r, int c) {
+                return false;
+            }
+        };
+    }
+
+    private static JTable table(DefaultTableModel m) {
+        JTable t = new JTable(m);
+        t.setBackground(BG);
+        t.setForeground(TEXT);
+        t.setGridColor(new Color(45, 46, 50));
+        t.setRowHeight(24);
+        t.setFont(MONO);
+        t.getTableHeader().setBackground(new Color(35, 36, 40));
+        t.getTableHeader().setForeground(DIM);
+        t.setSelectionBackground(new Color(40, 70, 110));
+        t.setSelectionForeground(Color.WHITE);
+        t.setDefaultRenderer(Object.class, new DefaultTableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable tb, Object v,
+                    boolean sel, boolean foc, int row, int col) {
+                Component c = super.getTableCellRendererComponent(tb, v, sel, foc, row, col);
+                String s = String.valueOf(v);
+                if (!sel) {
+                    c.setForeground("●".equals(s) ? UP : "○".equals(s) ? DIM
+                            : "◐".equals(s) ? new Color(255, 190, 60)
+                            : "DANGLING".equals(s) ? new Color(255, 190, 60) : TEXT);
+                }
+                return c;
+            }
+        });
+        return t;
+    }
+
+    private static JTextArea preview() {
+        JTextArea a = new JTextArea();
+        a.setEditable(false);
+        a.setFont(MONO);
+        a.setBackground(new Color(18, 19, 21));
+        a.setForeground(new Color(96, 235, 120));
+        return a;
+    }
+
+    private static JScrollPane wrap(Component c) {
+        JScrollPane sp = new JScrollPane(c);
+        sp.setBorder(BorderFactory.createEmptyBorder());
+        sp.getViewport().setBackground(BG);
+        return sp;
+    }
+
+    private JButton btn(String label, Runnable action) {
+        JButton b = new JButton(label);
+        b.addActionListener(e -> action.run());
+        return b;
+    }
+
+    private void status(String s) {
+        SwingUtilities.invokeLater(() -> statusLabel.setText(s));
+    }
+
+    /** Runs a verb, surfaces failure, refreshes the panel after. */
+    private void verbThenRefresh(java.util.concurrent.CompletableFuture<Result> f, String what) {
+        status(what + "…");
+        f.whenComplete((r, ex) -> SwingUtilities.invokeLater(() -> {
+            if (r != null && !r.ok()) {
+                JOptionPane.showMessageDialog(this,
+                        r.stderr().isBlank() ? "docker exited " + r.exit() : r.stderr().strip(),
+                        what + " failed", JOptionPane.ERROR_MESSAGE);
+            }
+            refreshAll();
+        }));
+    }
+
+    // ---- refresh ----
+
+    private void refreshAll() {
+        client.engineVersion().thenAccept(v -> SwingUtilities.invokeLater(() -> {
+            if (v == null) {
+                engineLabel.setText("ENGINE: DOWN — start Docker Desktop / colima, then Refresh");
+                engineLabel.setForeground(DOWN);
+            } else {
+                engineLabel.setText("ENGINE: UP · v" + v);
+                engineLabel.setForeground(UP);
+            }
+        }));
+        refreshEngineTab();
+        refreshContainers();
+        refreshImages();
+        refreshVolumesNetworks();
+        status("refreshed " + java.time.LocalTime.now().withNano(0));
+    }
+
+    private void refreshEngineTab() {
+        client.systemDf().thenAccept(rows -> SwingUtilities.invokeLater(() -> {
+            enginePanel.removeAll();
+            enginePanel.setBackground(BG);
+            GridBagConstraints g = new GridBagConstraints();
+            g.insets = new java.awt.Insets(6, 12, 6, 12);
+            g.anchor = GridBagConstraints.WEST;
+            g.gridy = 0;
+            for (String h : new String[]{"CATEGORY", "COUNT", "ACTIVE", "SIZE", "RECLAIMABLE", ""}) {
+                g.gridx = enginePanel.getComponentCount() % 6;
+                JLabel l = new JLabel(h);
+                l.setForeground(DIM);
+                enginePanel.add(l, g);
+            }
+            for (DfRow row : rows) {
+                g.gridy++;
+                g.gridx = 0;
+                enginePanel.add(label(row.type(), TEXT, Font.BOLD), g);
+                g.gridx = 1;
+                enginePanel.add(label(row.totalCount(), TEXT, Font.PLAIN), g);
+                g.gridx = 2;
+                enginePanel.add(label(row.active(), TEXT, Font.PLAIN), g);
+                g.gridx = 3;
+                enginePanel.add(label(row.size(), TEXT, Font.PLAIN), g);
+                g.gridx = 4;
+                enginePanel.add(label(row.reclaimable(), ACCENT, Font.BOLD), g);
+                g.gridx = 5;
+                String kind = pruneKind(row.type());
+                if (kind != null) {
+                    boolean volumes = "volume".equals(kind);
+                    enginePanel.add(btn("RECLAIM", () -> {
+                        if (!volumes || confirm("Remove ALL unused volumes? Their data is gone for good.")) {
+                            verbThenRefresh(client.prune(kind, false), "prune " + kind);
+                        }
+                    }), g);
+                }
+            }
+            g.gridy++;
+            g.gridx = 0;
+            g.gridwidth = 6;
+            enginePanel.add(btn("DEEP CLEAN — remove ALL unused images (not just dangling)", () -> {
+                if (confirm("Remove every image not used by a container? Re-pulls may be slow.")) {
+                    verbThenRefresh(client.prune("image", true), "deep image prune");
+                }
+            }), g);
+            enginePanel.revalidate();
+            enginePanel.repaint();
+        }));
+    }
+
+    private static String pruneKind(String dfType) {
+        String t = dfType.toLowerCase();
+        if (t.startsWith("image")) {
+            return "image";
+        }
+        if (t.startsWith("container")) {
+            return "container";
+        }
+        if (t.contains("volume")) {
+            return "volume";
+        }
+        if (t.contains("build")) {
+            return "builder";
+        }
+        return null;
+    }
+
+    private static JLabel label(String s, Color c, int style) {
+        JLabel l = new JLabel(s == null ? "" : s);
+        l.setForeground(c);
+        l.setFont(l.getFont().deriveFont(style));
+        return l;
+    }
+
+    private boolean confirm(String message) {
+        return JOptionPane.showConfirmDialog(this, message, "Docker Panel",
+                JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION;
+    }
+
+    // ---- containers ----
+
+    private Component buildContainersTab() {
+        JPanel p = new JPanel(new BorderLayout());
+        p.setBackground(BG);
+        p.add(wrap(containersTable), BorderLayout.CENTER);
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
+        actions.setBackground(BG);
+        actions.add(btn("Start", () -> eachSelectedContainer(c -> verbThenRefresh(client.lifecycle("start", c.id()), "start " + c.name()))));
+        actions.add(btn("Stop", () -> eachSelectedContainer(c -> verbThenRefresh(client.lifecycle("stop", c.id()), "stop " + c.name()))));
+        actions.add(btn("Restart", () -> eachSelectedContainer(c -> verbThenRefresh(client.lifecycle("restart", c.id()), "restart " + c.name()))));
+        actions.add(btn("Remove", () -> {
+            if (confirm("Force-remove selected container(s)?")) {
+                eachSelectedContainer(c -> verbThenRefresh(client.lifecycle("rm", c.id()), "remove " + c.name()));
+            }
+        }));
+        actions.add(btn("Logs", () -> eachSelectedContainer(this::showLogs)));
+        actions.add(btn("Inspect", () -> eachSelectedContainer(c ->
+                client.inspect(c.id()).thenAccept(json -> textDialog("inspect " + c.name(), json)))));
+        actions.add(btn("Open in Browser", () -> eachSelectedContainer(this::openPorts)));
+        p.add(actions, BorderLayout.SOUTH);
+        return p;
+    }
+
+    private void eachSelectedContainer(Consumer<ContainerInfo> action) {
+        for (int row : containersTable.getSelectedRows()) {
+            if (row >= 0 && row < containers.size()) {
+                action.accept(containers.get(row));
+            }
+        }
+    }
+
+    private void showLogs(ContainerInfo c) {
+        client.logs(c.id(), 500).thenAccept(text ->
+                textDialog("logs " + c.name() + "  (last 500 lines)", text));
+    }
+
+    private void openPorts(ContainerInfo c) {
+        for (Integer port : c.hostPorts()) {
+            try {
+                Desktop.getDesktop().browse(URI.create("http://localhost:" + port));
+                return;
+            } catch (Exception ignored) {
+            }
+        }
+        status(c.name() + " publishes no host ports");
+    }
+
+    private void textDialog(String title, String text) {
+        SwingUtilities.invokeLater(() -> {
+            JTextArea area = preview();
+            area.setText(text);
+            area.setCaretPosition(0);
+            JScrollPane sp = new JScrollPane(area);
+            sp.setPreferredSize(new java.awt.Dimension(820, 520));
+            JOptionPane.showMessageDialog(this, sp, title, JOptionPane.PLAIN_MESSAGE);
+        });
+    }
+
+    private void refreshContainers() {
+        client.containers().thenCombine(client.statsSnapshot(), (cs, stats) -> {
+            Map<String, StatRow> byId = new HashMap<>();
+            for (StatRow s : stats) {
+                byId.put(s.id(), s);
+            }
+            return Map.entry(cs, byId);
+        }).thenAccept(e -> SwingUtilities.invokeLater(() -> {
+            containers = e.getKey();
+            containersModel.setRowCount(0);
+            for (ContainerInfo c : containers) {
+                StatRow s = e.getValue().get(c.id().substring(0, Math.min(12, c.id().length())));
+                containersModel.addRow(new Object[]{
+                    c.running() ? "●" : c.state().contains("paus") ? "◐" : "○",
+                    c.name(), c.image(), c.status(), c.ports(),
+                    s == null ? "" : s.cpu(), s == null ? "" : s.mem()});
+            }
+        }));
+    }
+
+    // ---- images ----
+
+    private Component buildImagesTab() {
+        JPanel p = new JPanel(new BorderLayout());
+        p.setBackground(BG);
+        p.add(wrap(imagesTable), BorderLayout.CENTER);
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
+        actions.setBackground(BG);
+        JTextField pullField = new JTextField(22);
+        pullField.setToolTipText("image reference, e.g. nginx:alpine");
+        actions.add(pullField);
+        actions.add(btn("Pull", () -> {
+            String ref = pullField.getText().trim();
+            if (!ref.isEmpty()) {
+                verbThenRefresh(client.pull(ref), "pull " + ref);
+            }
+        }));
+        actions.add(btn("Run…", () -> eachSelectedImage(this::quickRun)));
+        actions.add(btn("Tag…", () -> eachSelectedImage(img -> {
+            String target = JOptionPane.showInputDialog(this, "New tag for " + img.ref() + ":", img.ref());
+            if (target != null && !target.isBlank()) {
+                verbThenRefresh(client.tag(img.ref(), target.trim()), "tag");
+            }
+        })));
+        actions.add(btn("Layers", () -> eachSelectedImage(img ->
+                client.history(img.ref()).thenAccept(h -> textDialog("layers " + img.ref(), h)))));
+        actions.add(btn("Remove", () -> {
+            if (confirm("Remove selected image(s)?")) {
+                eachSelectedImage(img -> verbThenRefresh(client.removeImage(img.ref(), true), "rmi " + img.ref()));
+            }
+        }));
+        actions.add(btn("Remove all dangling", () ->
+                verbThenRefresh(client.prune("image", false), "prune dangling images")));
+        p.add(actions, BorderLayout.SOUTH);
+        return p;
+    }
+
+    private void eachSelectedImage(Consumer<ImageInfo> action) {
+        for (int row : imagesTable.getSelectedRows()) {
+            if (row >= 0 && row < images.size()) {
+                action.accept(images.get(row));
+            }
+        }
+    }
+
+    /** A run dialog with the three things you always need: name, ports, env. */
+    private void quickRun(ImageInfo img) {
+        JTextField name = new JTextField(16);
+        JTextField ports = new JTextField("8080:80", 16);
+        JTextField env = new JTextField(16);
+        JPanel form = new JPanel(new GridBagLayout());
+        GridBagConstraints g = new GridBagConstraints();
+        g.insets = new java.awt.Insets(4, 4, 4, 4);
+        g.anchor = GridBagConstraints.WEST;
+        g.gridy = 0;
+        g.gridx = 0;
+        form.add(new JLabel("Name (blank = auto):"), g);
+        g.gridx = 1;
+        form.add(name, g);
+        g.gridy = 1;
+        g.gridx = 0;
+        form.add(new JLabel("Ports host:container (space-separated):"), g);
+        g.gridx = 1;
+        form.add(ports, g);
+        g.gridy = 2;
+        g.gridx = 0;
+        form.add(new JLabel("Env KEY=VAL (space-separated):"), g);
+        g.gridx = 1;
+        form.add(env, g);
+        if (JOptionPane.showConfirmDialog(this, form, "Run " + img.ref(),
+                JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE) != JOptionPane.OK_OPTION) {
+            return;
+        }
+        List<String> args = new ArrayList<>(List.of("run", "-d"));
+        if (!name.getText().isBlank()) {
+            args.addAll(List.of("--name", name.getText().trim()));
+        }
+        for (String pm : ports.getText().trim().split("\\s+")) {
+            if (pm.contains(":")) {
+                args.addAll(List.of("-p", pm));
+            }
+        }
+        for (String ev : env.getText().trim().split("\\s+")) {
+            if (ev.contains("=")) {
+                args.addAll(List.of("-e", ev));
+            }
+        }
+        args.add(img.ref());
+        status("docker " + String.join(" ", args));
+        java.util.concurrent.CompletableFuture
+                .supplyAsync(() -> client.run(120, args.toArray(String[]::new)))
+                .thenAccept(r -> {
+                    if (!r.ok()) {
+                        SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this,
+                                r.stderr().strip(), "run failed", JOptionPane.ERROR_MESSAGE));
+                    }
+                    refreshAll();
+                });
+    }
+
+    private void refreshImages() {
+        client.images().thenAccept(list -> SwingUtilities.invokeLater(() -> {
+            images = list;
+            imagesModel.setRowCount(0);
+            for (ImageInfo i : images) {
+                imagesModel.addRow(new Object[]{
+                    i.dangling() ? "<dangling>" : i.ref(),
+                    i.id().length() > 12 ? i.id().substring(0, 12) : i.id(),
+                    i.size(), i.created(), i.dangling() ? "DANGLING" : ""});
+            }
+        }));
+    }
+
+    // ---- volumes & networks ----
+
+    private Component buildVolumesTab() {
+        JPanel p = new JPanel(new BorderLayout());
+        p.setBackground(BG);
+        p.add(wrap(volumesTable), BorderLayout.CENTER);
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
+        actions.setBackground(BG);
+        actions.add(btn("Remove", () -> {
+            if (confirm("Remove selected volume(s)? Their data is gone for good.")) {
+                for (int row : volumesTable.getSelectedRows()) {
+                    if (row < volumes.size()) {
+                        verbThenRefresh(client.removeVolume(volumes.get(row).name()), "remove volume");
+                    }
+                }
+            }
+        }));
+        actions.add(btn("Prune unused", () -> {
+            if (confirm("Remove ALL unused volumes? Their data is gone for good.")) {
+                verbThenRefresh(client.prune("volume", false), "prune volumes");
+            }
+        }));
+        p.add(actions, BorderLayout.SOUTH);
+        return p;
+    }
+
+    private Component buildNetworksTab() {
+        JPanel p = new JPanel(new BorderLayout());
+        p.setBackground(BG);
+        p.add(wrap(networksTable), BorderLayout.CENTER);
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
+        actions.setBackground(BG);
+        actions.add(btn("Remove", () -> {
+            for (int row : networksTable.getSelectedRows()) {
+                if (row < networks.size()) {
+                    verbThenRefresh(client.removeNetwork(networks.get(row).id()), "remove network");
+                }
+            }
+        }));
+        actions.add(btn("Prune unused", () ->
+                verbThenRefresh(client.prune("network", false), "prune networks")));
+        p.add(actions, BorderLayout.SOUTH);
+        return p;
+    }
+
+    private void refreshVolumesNetworks() {
+        client.volumes().thenAccept(list -> SwingUtilities.invokeLater(() -> {
+            volumes = list;
+            volumesModel.setRowCount(0);
+            for (VolumeInfo v : volumes) {
+                volumesModel.addRow(new Object[]{v.name(), v.driver()});
+            }
+        }));
+        client.networks().thenAccept(list -> SwingUtilities.invokeLater(() -> {
+            networks = list;
+            networksModel.setRowCount(0);
+            for (NetworkInfo n : networks) {
+                networksModel.addRow(new Object[]{n.name(), n.driver(), n.scope(), n.id()});
+            }
+        }));
+    }
+
+    // ---- dockerize ----
+
+    private Component buildDockerizeTab() {
+        JPanel p = new JPanel(new BorderLayout());
+        p.setBackground(BG);
+        dockerizeInfo.setForeground(TEXT);
+        dockerizeInfo.setBorder(BorderFactory.createEmptyBorder(8, 12, 8, 12));
+        p.add(dockerizeInfo, BorderLayout.NORTH);
+
+        JTabbedPane previews = new JTabbedPane();
+        previews.addTab("Dockerfile", wrap(dockerfilePreview));
+        previews.addTab(".dockerignore", wrap(ignorePreview));
+        previews.addTab("compose.yaml", wrap(composePreview));
+        p.add(previews, BorderLayout.CENTER);
+
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
+        actions.setBackground(BG);
+        actions.add(btn("Regenerate", this::regenerateDockerize));
+        actions.add(btn("Write files into project", this::writeDockerizeFiles));
+        actions.add(btn("Build image", () -> dockerizeCommand("build", "-t", imageName(), ".")));
+        actions.add(btn("Run container", () -> {
+            int port = currentPort();
+            dockerizeCommand("run", "-d", "--name", imageName() + "-dev",
+                    "-p", port + ":" + port, imageName());
+        }));
+        p.add(actions, BorderLayout.SOUTH);
+        regenerateDockerize();
+        return p;
+    }
+
+    private File projectDir() {
+        return RackService.getDefault().getRack().getProjectDir();
+    }
+
+    private String imageName() {
+        return projectDir().getName().toLowerCase().replaceAll("[^a-z0-9_-]", "-");
+    }
+
+    private ProjectInspector.ProjectKind currentKind() {
+        return ProjectInspector.detectKind(projectDir());
+    }
+
+    private int currentPort() {
+        return DockerizeGenerator.defaultPort(currentKind(),
+                DockerizeGenerator.buildsStatic(projectDir()));
+    }
+
+    private void regenerateDockerize() {
+        ProjectInspector.ProjectKind kind = currentKind();
+        boolean statics = DockerizeGenerator.buildsStatic(projectDir());
+        dockerizeFiles = DockerizeGenerator.generate(kind, imageName(), statics);
+        dockerizeInfo.setText("Project: " + projectDir().getName()
+                + "   ·   detected toolchain: " + kind
+                + (statics ? " (static bundle → nginx)" : "")
+                + "   ·   image: " + imageName() + "   ·   port: " + currentPort());
+        dockerfilePreview.setText(dockerizeFiles.getOrDefault("Dockerfile", ""));
+        ignorePreview.setText(dockerizeFiles.getOrDefault(".dockerignore", ""));
+        composePreview.setText(dockerizeFiles.getOrDefault("compose.yaml", ""));
+    }
+
+    private void writeDockerizeFiles() {
+        File dir = projectDir();
+        List<String> existing = new ArrayList<>();
+        for (String name : dockerizeFiles.keySet()) {
+            if (new File(dir, name).exists()) {
+                existing.add(name);
+            }
+        }
+        if (!existing.isEmpty() && !confirm("Overwrite existing " + String.join(", ", existing) + "?")) {
+            return;
+        }
+        try {
+            for (Map.Entry<String, String> e : dockerizeFiles.entrySet()) {
+                Files.writeString(new File(dir, e.getKey()).toPath(), e.getValue());
+            }
+            status("wrote " + String.join(", ", dockerizeFiles.keySet()) + " into " + dir.getName());
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "write failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    /** Long docker runs stream into the HARBOR output tab like any rack tool. */
+    private void dockerizeCommand(String... args) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("docker");
+        java.util.Collections.addAll(cmd, args);
+        status("docker " + String.join(" ", args));
+        org.nmox.studio.rack.engine.CommandExecutor.run("HARBOR", projectDir(), Map.of(),
+                cmd, line -> {
+                }, code -> {
+                    status("docker " + args[0] + (code == 0 ? " OK" : " failed [" + code + "]"));
+                    refreshAll();
+                });
+        org.nmox.studio.rack.engine.CommandExecutor.showOutput("HARBOR");
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/docker/DockerizeGenerator.java
+++ b/rack/src/main/java/org/nmox/studio/rack/docker/DockerizeGenerator.java
@@ -1,0 +1,175 @@
+package org.nmox.studio.rack.docker;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.nmox.studio.rack.devices.ProjectInspector;
+
+/**
+ * Turns what the rack already knows about a project into production
+ * container files: a multi-stage Dockerfile tuned to the detected
+ * toolchain, a .dockerignore that keeps the context lean, and a
+ * compose.yaml to run it. This is the "more power than docker gives
+ * you" move - docker can build an image, but it cannot look at your
+ * package.json and write the Dockerfile.
+ */
+public final class DockerizeGenerator {
+
+    private DockerizeGenerator() {
+    }
+
+    /** What we will write: filename -> content. Deterministic, no I/O. */
+    public static Map<String, String> generate(ProjectInspector.ProjectKind kind,
+            String projectName, boolean nodeBuildsStatic) {
+        Map<String, String> files = new LinkedHashMap<>();
+        String name = projectName == null || projectName.isBlank() ? "app" : projectName;
+        switch (kind) {
+            case NODE -> {
+                files.put("Dockerfile", nodeBuildsStatic ? nodeStatic() : nodeServer());
+                files.put(".dockerignore", ignore("node_modules", "dist", ".git", "*.log"));
+            }
+            case GO -> {
+                files.put("Dockerfile", go(name));
+                files.put(".dockerignore", ignore("bin", ".git"));
+            }
+            case RUST -> {
+                files.put("Dockerfile", rust(name));
+                files.put(".dockerignore", ignore("target", ".git"));
+            }
+            case PYTHON -> {
+                files.put("Dockerfile", python());
+                files.put(".dockerignore", ignore("__pycache__", ".venv", ".git"));
+            }
+            default -> {
+                files.put("Dockerfile", generic());
+                files.put(".dockerignore", ignore(".git"));
+            }
+        }
+        files.put("compose.yaml", compose(name, defaultPort(kind, nodeBuildsStatic)));
+        return files;
+    }
+
+    /** The port the generated container listens on. */
+    public static int defaultPort(ProjectInspector.ProjectKind kind, boolean nodeBuildsStatic) {
+        return switch (kind) {
+            case NODE -> nodeBuildsStatic ? 80 : 3000;
+            case GO, RUST -> 8080;
+            case PYTHON -> 8000;
+            default -> 8080;
+        };
+    }
+
+    /** True when the Node project builds a static bundle (vite & friends). */
+    public static boolean buildsStatic(File projectDir) {
+        return ProjectInspector.firstDependency(projectDir,
+                "vite", "react-scripts", "@angular/cli", "svelte", "parcel") != null;
+    }
+
+    private static String ignore(String... extra) {
+        StringBuilder sb = new StringBuilder("""
+                Dockerfile
+                compose.yaml
+                .dockerignore
+                """);
+        for (String e : extra) {
+            sb.append(e).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String nodeStatic() {
+        return """
+                # Build the static bundle, serve it with nginx - tiny final image
+                FROM node:22-alpine AS build
+                WORKDIR /app
+                COPY package*.json ./
+                RUN npm ci
+                COPY . .
+                RUN npm run build
+
+                FROM nginx:alpine
+                COPY --from=build /app/dist /usr/share/nginx/html
+                EXPOSE 80
+                """;
+    }
+
+    private static String nodeServer() {
+        return """
+                # Install with the lockfile, run as the non-root node user
+                FROM node:22-alpine
+                WORKDIR /app
+                ENV NODE_ENV=production
+                COPY package*.json ./
+                RUN npm ci --omit=dev
+                COPY . .
+                USER node
+                EXPOSE 3000
+                CMD ["npm", "start"]
+                """;
+    }
+
+    private static String go(String name) {
+        return """
+                # Static binary in a distroless image - ~10MB, no shell to exploit
+                FROM golang:1.23 AS build
+                WORKDIR /src
+                COPY go.* ./
+                RUN go mod download
+                COPY . .
+                RUN CGO_ENABLED=0 go build -o /%s ./...
+
+                FROM gcr.io/distroless/static-debian12
+                COPY --from=build /%s /%s
+                EXPOSE 8080
+                ENTRYPOINT ["/%s"]
+                """.formatted(name, name, name, name);
+    }
+
+    private static String rust(String name) {
+        return """
+                # Release build, then a minimal runtime layer
+                FROM rust:1.83 AS build
+                WORKDIR /src
+                COPY . .
+                RUN cargo build --release
+
+                FROM debian:bookworm-slim
+                COPY --from=build /src/target/release/%s /usr/local/bin/%s
+                EXPOSE 8080
+                CMD ["%s"]
+                """.formatted(name, name, name);
+    }
+
+    private static String python() {
+        return """
+                FROM python:3.13-slim
+                WORKDIR /app
+                COPY requirements.txt ./
+                RUN pip install --no-cache-dir -r requirements.txt
+                COPY . .
+                EXPOSE 8000
+                CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+                """;
+    }
+
+    private static String generic() {
+        return """
+                # No toolchain detected - a starting point, not a guess
+                FROM debian:bookworm-slim
+                WORKDIR /app
+                COPY . .
+                CMD ["/bin/sh", "-c", "echo 'edit this Dockerfile for your runtime' && sleep infinity"]
+                """;
+    }
+
+    private static String compose(String name, int port) {
+        return """
+                services:
+                  %s:
+                    build: .
+                    ports:
+                      - "%d:%d"
+                    restart: unless-stopped
+                """.formatted(name, port, port);
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/docker/DockerClientParseTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/docker/DockerClientParseTest.java
@@ -1,0 +1,85 @@
+package org.nmox.studio.rack.docker;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** The parsers, fed real-world docker CLI output - no daemon needed. */
+class DockerClientParseTest {
+
+    @Test
+    @DisplayName("Containers parse: state, ports, and clickable host ports")
+    void parsesContainers() {
+        String out = """
+                {"ID":"abc123","Names":"web","Image":"nginx:1.27","State":"running","Status":"Up 2 hours","Ports":"0.0.0.0:8080->80/tcp, :::8080->80/tcp"}
+                {"ID":"def456","Names":"db","Image":"postgres:16","State":"exited","Status":"Exited (0) 3 days ago","Ports":""}
+                garbage line the daemon coughed up
+                """;
+        List<DockerClient.ContainerInfo> list = DockerClient.parseContainers(out);
+        assertThat(list).hasSize(2);
+        assertThat(list.get(0).running()).isTrue();
+        assertThat(list.get(0).hostPorts()).containsExactly(8080);
+        assertThat(list.get(1).running()).isFalse();
+        assertThat(list.get(1).hostPorts()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Host-port extraction handles IPv4, IPv6, and multi-port strings")
+    void extractsHostPorts() {
+        assertThat(DockerClient.hostPorts("0.0.0.0:3000->3000/tcp, 0.0.0.0:9229->9229/tcp"))
+                .containsExactly(3000, 9229);
+        assertThat(DockerClient.hostPorts(":::5432->5432/tcp")).containsExactly(5432);
+        assertThat(DockerClient.hostPorts("80/tcp")).isEmpty();
+        assertThat(DockerClient.hostPorts(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Images parse: dangling detection via <none>")
+    void parsesImages() {
+        String out = """
+                {"Repository":"nginx","Tag":"1.27","ID":"sha1","Size":"188MB","CreatedSince":"3 weeks ago"}
+                {"Repository":"<none>","Tag":"<none>","ID":"sha2","Size":"1.1GB","CreatedSince":"5 days ago"}
+                """;
+        List<DockerClient.ImageInfo> list = DockerClient.parseImages(out);
+        assertThat(list).hasSize(2);
+        assertThat(list.get(0).dangling()).isFalse();
+        assertThat(list.get(0).ref()).isEqualTo("nginx:1.27");
+        assertThat(list.get(1).dangling()).isTrue();
+        assertThat(list.get(1).ref()).isEqualTo("sha2");
+    }
+
+    @Test
+    @DisplayName("system df parse: the reclaim ledger")
+    void parsesDf() {
+        String out = """
+                {"Type":"Images","TotalCount":"12","Active":"4","Size":"6.5GB","Reclaimable":"4.2GB (64%)"}
+                {"Type":"Build Cache","TotalCount":"88","Active":"0","Size":"2.1GB","Reclaimable":"2.1GB"}
+                """;
+        List<DockerClient.DfRow> rows = DockerClient.parseDf(out);
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).type()).isEqualTo("Images");
+        assertThat(rows.get(0).reclaimable()).startsWith("4.2GB");
+    }
+
+    @Test
+    @DisplayName("Stats snapshot parse: live cpu/mem per container")
+    void parsesStats() {
+        String out = """
+                {"Container":"abc","Name":"web","CPUPerc":"0.34%","MemUsage":"24MiB / 7.6GiB"}
+                """;
+        List<DockerClient.StatRow> rows = DockerClient.parseStats(out);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).cpu()).isEqualTo("0.34%");
+    }
+
+    @Test
+    @DisplayName("Volumes and networks parse")
+    void parsesVolumesAndNetworks() {
+        assertThat(DockerClient.parseVolumes("{\"Name\":\"pgdata\",\"Driver\":\"local\"}\n"))
+                .singleElement().satisfies(v -> assertThat(v.name()).isEqualTo("pgdata"));
+        assertThat(DockerClient.parseNetworks("{\"ID\":\"n1\",\"Name\":\"bridge\",\"Driver\":\"bridge\",\"Scope\":\"local\"}\n"))
+                .singleElement().satisfies(n -> assertThat(n.driver()).isEqualTo("bridge"));
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/docker/DockerIntegrationTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/docker/DockerIntegrationTest.java
@@ -1,0 +1,33 @@
+package org.nmox.studio.rack.docker;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Against a real daemon when one is reachable (CI's ubuntu runners
+ * have one); skips cleanly everywhere else. Read-only: lists and df,
+ * no mutations.
+ */
+class DockerIntegrationTest {
+
+    @BeforeAll
+    static void requireDaemon() throws Exception {
+        String v = DockerClient.getDefault().engineVersion().get();
+        assumeTrue(v != null, "docker daemon not reachable; integration skipped");
+    }
+
+    @Test
+    @DisplayName("Real listings parse end to end")
+    void realListingsParse() throws Exception {
+        // empty lists are fine; what must hold is: no exception, no nulls
+        assertThat(DockerClient.getDefault().containers().get()).isNotNull();
+        assertThat(DockerClient.getDefault().images().get()).isNotNull();
+        assertThat(DockerClient.getDefault().volumes().get()).isNotNull();
+        assertThat(DockerClient.getDefault().networks().get()).isNotNull();
+        assertThat(DockerClient.getDefault().systemDf().get()).isNotEmpty();
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/docker/DockerizeGeneratorTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/docker/DockerizeGeneratorTest.java
@@ -1,0 +1,73 @@
+package org.nmox.studio.rack.docker;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.rack.devices.DockerDevice;
+import org.nmox.studio.rack.devices.ProjectInspector.ProjectKind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** The Dockerize generator: deterministic, production-shaped output. */
+class DockerizeGeneratorTest {
+
+    @Test
+    @DisplayName("Static Node projects get a multi-stage build into nginx")
+    void nodeStatic() {
+        Map<String, String> files = DockerizeGenerator.generate(ProjectKind.NODE, "shop", true);
+        assertThat(files).containsKeys("Dockerfile", ".dockerignore", "compose.yaml");
+        assertThat(files.get("Dockerfile"))
+                .contains("AS build").contains("npm ci").contains("nginx").contains("EXPOSE 80");
+        assertThat(files.get(".dockerignore")).contains("node_modules");
+        assertThat(files.get("compose.yaml")).contains("shop:").contains("\"80:80\"");
+    }
+
+    @Test
+    @DisplayName("Node servers run as the non-root node user with prod deps only")
+    void nodeServer() {
+        String df = DockerizeGenerator.generate(ProjectKind.NODE, "api", false).get("Dockerfile");
+        assertThat(df).contains("USER node").contains("--omit=dev").contains("EXPOSE 3000");
+    }
+
+    @Test
+    @DisplayName("Go gets a distroless static binary")
+    void goDistroless() {
+        String df = DockerizeGenerator.generate(ProjectKind.GO, "svc", false).get("Dockerfile");
+        assertThat(df).contains("CGO_ENABLED=0").contains("distroless");
+        assertThat(df).contains("ENTRYPOINT [\"/svc\"]");
+    }
+
+    @Test
+    @DisplayName("Rust and Python templates carry their toolchains")
+    void rustAndPython() {
+        assertThat(DockerizeGenerator.generate(ProjectKind.RUST, "rs", false).get("Dockerfile"))
+                .contains("cargo build --release");
+        assertThat(DockerizeGenerator.generate(ProjectKind.PYTHON, "py", false).get("Dockerfile"))
+                .contains("pip install").contains("uvicorn");
+    }
+
+    @Test
+    @DisplayName("Unknown toolchains say so instead of guessing")
+    void genericIsHonest() {
+        assertThat(DockerizeGenerator.generate(ProjectKind.NONE, "x", false).get("Dockerfile"))
+                .contains("No toolchain detected");
+    }
+
+    @Test
+    @DisplayName("Default ports follow the runtime")
+    void defaultPorts() {
+        assertThat(DockerizeGenerator.defaultPort(ProjectKind.NODE, true)).isEqualTo(80);
+        assertThat(DockerizeGenerator.defaultPort(ProjectKind.NODE, false)).isEqualTo(3000);
+        assertThat(DockerizeGenerator.defaultPort(ProjectKind.PYTHON, false)).isEqualTo(8000);
+    }
+
+    @Test
+    @DisplayName("HARBOR's reclaimable total sums mixed units readably")
+    void reclaimableTotal() {
+        var rows = java.util.List.of(
+                new DockerClient.DfRow("Images", "12", "4", "6.5GB", "4.2GB (64%)"),
+                new DockerClient.DfRow("Build Cache", "88", "0", "2.1GB", "512MB"),
+                new DockerClient.DfRow("Containers", "3", "1", "10MB", "0B"));
+        assertThat(DockerDevice.totalReclaimable(rows)).isEqualTo("4.7GB");
+    }
+}


### PR DESCRIPTION
## What

A Docker rack unit and the control room it opens — built to be the first place a developer goes for containers, with powers the bare CLI doesn't hand you.

**HARBOR (2U device)**: ENGINE LED tracks the daemon (dialable poll), LCDs show containers up / images+size / **total reclaimable disk summed across all docker categories**, PRUNE does the always-safe clean (dangling images + build cache only), RUNNING gate + OUT data jack for patching. PANEL opens:

**The Docker Panel**:
- **Engine** — the `system df` disk ledger with per-category RECLAIM buttons (volumes double-confirmed), plus DEEP CLEAN for all unused images
- **Containers** — live table (state dots, ports, CPU/MEM from stats), multi-select lifecycle ops, logs/inspect viewers, *Open in Browser* jumps to the published host port
- **Images** — pull, tag, layer history, quick-run dialog (name/ports/env), dangling badges + one-click remove-all-dangling
- **Volumes / Networks** — list, remove, prune-unused
- **Dockerize** — reads the aimed project's toolchain via ProjectInspector and generates a production multi-stage Dockerfile (vite→nginx, node server as non-root, Go→distroless, Rust, Python/uvicorn), .dockerignore, compose.yaml; preview → write → BUILD/RUN streamed through the rack executor

## Verification

- Parsers pure + unit-tested on canned CLI output (containers/images/df/stats/ports incl. IPv6)
- Generator unit-tested per toolchain; HARBOR's reclaimable-sum tested on mixed units
- `DockerIntegrationTest` runs read-only listings against a real daemon — **executes on CI's docker**, skips cleanly where absent
- Device contract suite (169 checks) covers HARBOR automatically
- Full suite green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)