### PR TITLE
The Awareness Sprint: BLACKBOX flight recorder + SONAR port radar

### DIFF
--- a/rack/src/main/java/org/nmox/studio/rack/devices/BlackboxDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BlackboxDevice.java
@@ -1,0 +1,209 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.engine.FlightRecorder;
+import org.nmox.studio.rack.engine.FlightRecorder.Event;
+import org.nmox.studio.rack.engine.FlightRecorder.Kind;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.Led;
+import org.nmox.studio.rack.ui.controls.RackButton;
+import org.nmox.studio.rack.ui.controls.RackStyle;
+
+/**
+ * BLACKBOX Flight Recorder: the rack's session memory. Every launch,
+ * exit, duration, and error any device produces is on the tape; the
+ * faceplate answers "what just happened" and VIEW scrolls the whole
+ * timeline. The creep line is the part no other tool does: it knows
+ * what your build USUALLY takes, and says so when it quietly doubles.
+ */
+public class BlackboxDevice extends RackDevice {
+
+    private final LcdDisplay lastLcd;
+    private final LcdDisplay healthLcd;
+    private final Led recLed;
+    private final javax.swing.Timer recFade = new javax.swing.Timer(350, e -> recOff());
+    private final Runnable recorderListener = this::onRecorderChange;
+
+    public BlackboxDevice() {
+        super("blackbox", "BLACKBOX", "FLIGHT RECORDER", new Color(255, 122, 36), 2);
+
+        RackButton view = place(new RackButton("VIEW", RackStyle.QUERY), RackStyle.TRANSPORT_X, 52);
+        recLed = place(new Led("REC", new Color(255, 80, 60)), 116, 58);
+
+        lastLcd = place(new LcdDisplay(420, 1), 180, 34);
+        healthLcd = place(new LcdDisplay(420, 1), 180, 66);
+        lastLcd.setText("RECORDING — RUN SOMETHING");
+        healthLcd.setText("NO ERRORS ON TAPE");
+        lastLcd.setToolTipText("the last completed run on the tape");
+        healthLcd.setToolTipText("errors in the last 10 minutes, and any device running slower than its average");
+
+        view.setToolTipText("Scroll the session timeline — every launch, exit, duration, and error");
+        view.addActionListener(e -> showTimeline());
+
+        addOutPort("out", "OUT", SignalType.DATA);
+
+        recFade.setRepeats(false);
+    }
+
+    private void recOff() {
+        recLed.setOn(false);
+    }
+
+    @Override
+    protected void onAttached() {
+        FlightRecorder.getDefault().addChangeListener(recorderListener);
+        refreshFaceplate();
+    }
+
+    @Override
+    public void dispose() {
+        FlightRecorder.getDefault().removeChangeListener(recorderListener);
+        recFade.stop();
+        super.dispose();
+    }
+
+    private void onRecorderChange() {
+        onEdt(() -> {
+            recLed.setOn(true);
+            recFade.restart();
+            refreshFaceplate();
+        });
+    }
+
+    private void refreshFaceplate() {
+        FlightRecorder rec = FlightRecorder.getDefault();
+        Event last = rec.last();
+        if (last != null) {
+            String dur = last.durationMs() >= 0 ? "  " + (last.durationMs() / 1000.0) + "s" : "";
+            boolean ok = last.kind() == Kind.EXIT_OK;
+            lastLcd.setTextColor(ok ? RackStyle.LCD_TEXT : new Color(255, 90, 80));
+            lastLcd.setText("LAST: " + last.device() + " " + (ok ? "OK" : last.text().toUpperCase()) + dur);
+        }
+        int errors = rec.errorsSince(System.currentTimeMillis() - 600_000).size();
+        String creep = rec.slowCreep();
+        if (creep != null) {
+            FlightRecorder.Stats s = rec.statistics().get(creep);
+            healthLcd.setTextColor(RackStyle.LCD_AMBER);
+            healthLcd.setText(creep + " SLOWING: " + (s.lastMs() / 1000.0) + "s VS "
+                    + (s.averageMs() / 1000.0) + "s AVG");
+        } else if (errors > 0) {
+            healthLcd.setTextColor(new Color(255, 90, 80));
+            healthLcd.setText(errors + " ERROR" + (errors == 1 ? "" : "S") + " / 10 MIN — VIEW FOR THE TAPE");
+        } else {
+            healthLcd.setTextColor(RackStyle.LCD_TEXT);
+            healthLcd.setText("NO ERRORS ON TAPE");
+        }
+    }
+
+    // ---- the timeline viewer ----
+
+    private void showTimeline() {
+        JDialog dialog = new JDialog((java.awt.Frame) SwingUtilities.getWindowAncestor(this),
+                "BLACKBOX — session timeline", false);
+        dialog.setLayout(new BorderLayout());
+
+        DefaultTableModel model = new DefaultTableModel(
+                new String[]{"TIME", "DEVICE", "EVENT", "DETAIL", "DURATION"}, 0) {
+            @Override
+            public boolean isCellEditable(int r, int c) {
+                return false;
+            }
+        };
+        JTable table = new JTable(model);
+        table.setFont(new java.awt.Font(java.awt.Font.MONOSPACED, java.awt.Font.PLAIN, 12));
+        table.setRowHeight(22);
+        table.setDefaultRenderer(Object.class, new javax.swing.table.DefaultTableCellRenderer() {
+            @Override
+            public java.awt.Component getTableCellRendererComponent(JTable t, Object v,
+                    boolean sel, boolean foc, int row, int col) {
+                java.awt.Component c = super.getTableCellRendererComponent(t, v, sel, foc, row, col);
+                String kind = String.valueOf(t.getValueAt(row, 2));
+                if (!sel) {
+                    c.setForeground(switch (kind) {
+                        case "EXIT_OK" -> new Color(80, 200, 110);
+                        case "EXIT_FAIL", "ERROR" -> new Color(230, 80, 70);
+                        case "LAUNCH" -> new Color(110, 160, 230);
+                        default -> t.getForeground();
+                    });
+                }
+                return c;
+            }
+        });
+
+        JCheckBox errorsOnly = new JCheckBox("errors only");
+        Runnable fill = () -> {
+            model.setRowCount(0);
+            SimpleDateFormat fmt = new SimpleDateFormat("HH:mm:ss");
+            List<Event> events = FlightRecorder.getDefault().timeline();
+            for (Event e : events) {
+                if (errorsOnly.isSelected()
+                        && e.kind() != Kind.ERROR && e.kind() != Kind.EXIT_FAIL) {
+                    continue;
+                }
+                model.addRow(new Object[]{
+                    fmt.format(new Date(e.at())), e.device(), e.kind().name(),
+                    e.text(), e.durationMs() >= 0 ? (e.durationMs() / 1000.0) + "s" : ""});
+            }
+            if (model.getRowCount() > 0) {
+                table.scrollRectToVisible(table.getCellRect(model.getRowCount() - 1, 0, true));
+            }
+        };
+        errorsOnly.addActionListener(e -> fill.run());
+        fill.run();
+
+        JPanel south = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        south.add(errorsOnly);
+        JButton refresh = new JButton("Refresh");
+        refresh.addActionListener(e -> fill.run());
+        south.add(refresh);
+        JButton export = new JButton("Export to project");
+        export.addActionListener(e -> {
+            try {
+                java.io.File dir = new java.io.File(projectDir(), ".nmox");
+                java.nio.file.Files.createDirectories(dir.toPath());
+                java.io.File log = new java.io.File(dir, "flight-log.txt");
+                java.nio.file.Files.writeString(log.toPath(), FlightRecorder.getDefault().export());
+                south.add(new JLabel("wrote " + log.getName()));
+                south.revalidate();
+            } catch (Exception ex) {
+                javax.swing.JOptionPane.showMessageDialog(dialog, ex.getMessage());
+            }
+        });
+        south.add(export);
+        JPanel stats = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        for (Map.Entry<String, FlightRecorder.Stats> e
+                : FlightRecorder.getDefault().statistics().entrySet()) {
+            JLabel l = new JLabel(e.getKey() + " avg " + (e.getValue().averageMs() / 1000.0)
+                    + "s · last " + (e.getValue().lastMs() / 1000.0) + "s"
+                    + (e.getValue().creeping() ? " ▲" : "") + "   ");
+            if (e.getValue().creeping()) {
+                l.setForeground(new Color(230, 150, 40));
+            }
+            stats.add(l);
+        }
+
+        dialog.add(stats, BorderLayout.NORTH);
+        dialog.add(new JScrollPane(table), BorderLayout.CENTER);
+        dialog.add(south, BorderLayout.SOUTH);
+        dialog.setSize(900, 560);
+        dialog.setLocationRelativeTo(this);
+        dialog.setVisible(true);
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
@@ -37,7 +37,9 @@ public enum DeviceType {
     TYPECHECK("typecheck", "TYPEGUARD", "Type Checker — tsc, watch-aware", new Color(49, 120, 198), TypecheckDevice::new),
     TUNNEL("tunnel", "WORMHOLE", "Public Tunnel — cloudflared/ngrok/localtunnel", new Color(156, 89, 209), TunnelDevice::new),
     BENCH("bench", "GAUNTLET", "Load Bench — autocannon throughput", new Color(224, 122, 47), BenchDevice::new),
-    DOCKER("docker", "HARBOR", "Docker Engine — panel, prune, status", new Color(36, 150, 237), DockerDevice::new);
+    DOCKER("docker", "HARBOR", "Docker Engine — panel, prune, status", new Color(36, 150, 237), DockerDevice::new),
+    BLACKBOX("blackbox", "BLACKBOX", "Flight Recorder — session timeline, slow-creep alarm", new Color(255, 122, 36), BlackboxDevice::new),
+    SONAR("sonar", "SONAR", "Port Radar — who owns every port, one-click kill", new Color(80, 220, 190), SonarDevice::new);
 
     private final String id;
     private final String title;
@@ -92,7 +94,7 @@ public enum DeviceType {
             case PACKAGE_MANAGER, BUILD, TEST, LINT, FORMAT, TYPECHECK -> PaletteCategory.VERIFY;
             case DEV_SERVER, TUNNEL, BROWSER, HTTP -> PaletteCategory.SERVE;
             case ANGULAR, PHOENIX, NEXTJS -> PaletteCategory.FRAMEWORKS;
-            case CONSOLE, TERMINAL, BENCH, DEBUG -> PaletteCategory.OBSERVE;
+            case CONSOLE, TERMINAL, BENCH, DEBUG, BLACKBOX, SONAR -> PaletteCategory.OBSERVE;
             case GIT, AUDIT, DEPLOY, DOCKER -> PaletteCategory.SHIP;
             case ENV, ROSETTA -> PaletteCategory.UTILITY;
         };
@@ -129,6 +131,8 @@ public enum DeviceType {
             case ENV -> "Sets NODE_ENV/CI/custom vars for every command the rack runs.\nWhat the knob says is what every device gets.";
             case ROSETTA -> "Mixed repo? Pin every AUTO knob to one toolchain with the dial.\nAUTO follows detection; KIND out reports the choice.";
             case DOCKER -> "The ENGINE LED tracks the daemon; LCDs show containers up, images held, disk reclaimable.\nPANEL opens the full control room — containers, images, volumes, networks, and one-click Dockerize.";
+            case BLACKBOX -> "The rack's session memory: every launch, exit, duration, and error, timestamped.\nVIEW scrolls the timeline; the health line warns when a build quietly slows past its average.";
+            case SONAR -> "SWEEP maps every listening port to its owning process — docker containers labeled.\nVIEW opens the field: BROWSE any port, KILL any squatter. EADDRINUSE, solved.";
         };
     }
 

--- a/rack/src/main/java/org/nmox/studio/rack/devices/SonarDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/SonarDevice.java
@@ -1,0 +1,239 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+import org.nmox.studio.rack.docker.DockerClient;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.engine.PortScanner;
+import org.nmox.studio.rack.engine.PortScanner.PortInfo;
+import org.nmox.studio.rack.ui.controls.Knob;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.Led;
+import org.nmox.studio.rack.ui.controls.RackButton;
+import org.nmox.studio.rack.ui.controls.RackStyle;
+
+/**
+ * SONAR Port Radar: who is listening on localhost, with one-click
+ * resolution of the daily EADDRINUSE fight. The sweep maps each port
+ * to its owning process - and to its docker container when that's the
+ * real owner - and VIEW opens the field with BROWSE and KILL per row.
+ */
+public class SonarDevice extends RackDevice {
+
+    private static final String[] POLL_RATES = {"off", "10s", "30s", "60s"};
+    private static final int[] POLL_MS = {0, 10_000, 30_000, 60_000};
+
+    private final LcdDisplay countLcd;
+    private final LcdDisplay fieldLcd;
+    private final Led pingLed;
+    private final Knob pollKnob;
+    private final javax.swing.Timer poller;
+    private final javax.swing.Timer pingFade = new javax.swing.Timer(400, e -> pingOff());
+    private volatile List<PortInfo> lastScan = List.of();
+    private volatile Map<Integer, String> dockerOwners = Map.of();
+
+    public SonarDevice() {
+        super("sonar", "SONAR", "PORT RADAR", new Color(80, 220, 190), 2);
+
+        RackButton sweep = place(new RackButton("SWEEP", RackStyle.QUERY), RackStyle.TRANSPORT_X, 52);
+        RackButton view = place(new RackButton("VIEW", RackStyle.QUERY), RackStyle.TRANSPORT_STOP_X, 52);
+        pollKnob = place(new Knob("POLL", POLL_RATES, 2), 184, 40);
+        pingLed = place(new Led("PING", new Color(80, 220, 190)), 256, 58);
+
+        countLcd = place(new LcdDisplay(330, 1), 320, 34);
+        fieldLcd = place(new LcdDisplay(330, 1), 320, 66);
+        countLcd.setText("SWEEP TO SCAN");
+        fieldLcd.setText("—");
+        countLcd.setToolTipText("listening TCP ports on this machine");
+        fieldLcd.setToolTipText("the low band of the field — dev servers live here");
+
+        sweep.setToolTipText("Scan localhost for listening ports now");
+        view.setToolTipText("The full field: every port, its owner, BROWSE and KILL per row");
+        sweep.addActionListener(e -> sweep());
+        view.addActionListener(e -> showField());
+        pollKnob.addChangeListener(this::restartPoller);
+
+        param("poll", pollKnob);
+
+        addInPort("run", "RUN", SignalType.TRIGGER);
+        addOutPort("out", "OUT", SignalType.DATA);
+
+        poller = new javax.swing.Timer(POLL_MS[2], e -> sweep());
+        poller.setRepeats(true);
+        pingFade.setRepeats(false);
+    }
+
+    private void pingOff() {
+        pingLed.setOn(false);
+    }
+
+    // ---- sweeping ----
+
+    private void sweep() {
+        PortScanner.scan().thenAccept(ports -> {
+            lastScan = ports;
+            onEdt(() -> {
+                pingLed.setOn(true);
+                pingFade.restart();
+                countLcd.setText(ports.size() + " PORTS LISTENING");
+                StringBuilder low = new StringBuilder();
+                for (PortInfo p : ports) {
+                    if (p.port() >= 3000 && p.port() <= 9999 && low.length() < 30) {
+                        if (low.length() > 0) {
+                            low.append(" ");
+                        }
+                        low.append(p.port());
+                    }
+                }
+                fieldLcd.setText(low.length() == 0 ? "DEV BAND QUIET" : "DEV: " + low);
+            });
+            emit("out", org.nmox.studio.rack.model.Signal.data(
+                    "sonar: " + ports.size() + " ports listening"));
+        });
+        // docker's published ports belong to containers, not the daemon pid
+        DockerClient.getDefault().containers().thenAccept(cs -> {
+            Map<Integer, String> owners = new HashMap<>();
+            for (DockerClient.ContainerInfo c : cs) {
+                for (Integer port : c.hostPorts()) {
+                    owners.put(port, c.name());
+                }
+            }
+            dockerOwners = owners;
+        });
+    }
+
+    private void restartPoller() {
+        int ms = POLL_MS[pollKnob.getSelectedIndex()];
+        poller.stop();
+        if (ms > 0) {
+            poller.setDelay(ms);
+            poller.setInitialDelay(ms);
+            poller.start();
+        }
+    }
+
+    @Override
+    protected void onAttached() {
+        sweep();
+        restartPoller();
+    }
+
+    @Override
+    public void dispose() {
+        poller.stop();
+        pingFade.stop();
+        super.dispose();
+    }
+
+    @Override
+    public void receive(org.nmox.studio.rack.model.Port in,
+            org.nmox.studio.rack.model.Signal signal) {
+        if ("run".equals(in.getId())) {
+            sweep();
+        }
+    }
+
+    // ---- the field viewer ----
+
+    private void showField() {
+        sweep();
+        JDialog dialog = new JDialog((java.awt.Frame) SwingUtilities.getWindowAncestor(this),
+                "SONAR — the port field", false);
+        dialog.setLayout(new BorderLayout());
+
+        DefaultTableModel model = new DefaultTableModel(
+                new String[]{"PORT", "OWNER", "PID", "VIA"}, 0) {
+            @Override
+            public boolean isCellEditable(int r, int c) {
+                return false;
+            }
+        };
+        JTable table = new JTable(model);
+        table.setFont(new java.awt.Font(java.awt.Font.MONOSPACED, java.awt.Font.PLAIN, 12));
+        table.setRowHeight(22);
+
+        Runnable fill = () -> {
+            model.setRowCount(0);
+            for (PortInfo p : lastScan) {
+                String docker = dockerOwners.get(p.port());
+                model.addRow(new Object[]{p.port(), p.command(), p.pid(),
+                    docker != null ? "docker: " + docker : ""});
+            }
+        };
+        fill.run();
+
+        JPanel south = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JButton rescan = new JButton("Sweep again");
+        rescan.addActionListener(e -> {
+            sweep();
+            new javax.swing.Timer(900, ev -> {
+                fill.run();
+                ((javax.swing.Timer) ev.getSource()).stop();
+            }) {
+                {
+                    setRepeats(false);
+                    start();
+                }
+            };
+        });
+        south.add(rescan);
+        JButton browse = new JButton("Browse");
+        browse.addActionListener(e -> {
+            int row = table.getSelectedRow();
+            if (row >= 0) {
+                try {
+                    java.awt.Desktop.getDesktop().browse(
+                            java.net.URI.create("http://localhost:" + model.getValueAt(row, 0)));
+                } catch (Exception ignored) {
+                }
+            }
+        });
+        south.add(browse);
+        JButton kill = new JButton("Kill owner");
+        kill.addActionListener(e -> {
+            int row = table.getSelectedRow();
+            if (row < 0) {
+                return;
+            }
+            Object via = model.getValueAt(row, 3);
+            if (via != null && via.toString().startsWith("docker:")) {
+                JOptionPane.showMessageDialog(dialog,
+                        "Port " + model.getValueAt(row, 0) + " belongs to container "
+                        + via.toString().substring(8).trim()
+                        + " — stop it from HARBOR's Docker Panel instead of killing the daemon.",
+                        "SONAR", JOptionPane.INFORMATION_MESSAGE);
+                return;
+            }
+            long pid = Long.parseLong(String.valueOf(model.getValueAt(row, 2)));
+            String owner = String.valueOf(model.getValueAt(row, 1));
+            if (JOptionPane.showConfirmDialog(dialog,
+                    "Kill " + owner + " (pid " + pid + ") holding port "
+                    + model.getValueAt(row, 0) + "?", "SONAR",
+                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE)
+                    == JOptionPane.YES_OPTION) {
+                PortScanner.kill(pid);
+                rescan.doClick();
+            }
+        });
+        south.add(kill);
+
+        dialog.add(new JScrollPane(table), BorderLayout.CENTER);
+        dialog.add(south, BorderLayout.SOUTH);
+        dialog.setSize(640, 480);
+        dialog.setLocationRelativeTo(this);
+        dialog.setVisible(true);
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
@@ -58,6 +58,9 @@ public final class CommandExecutor {
         if (out != null) {
             out.println("$ " + String.join(" ", command));
         }
+        // lifecycle markers travel the bus too, so the flight recorder
+        // (and an all-tap MONITOR) sees launches, not just output
+        RackBus.publish(tabName, "$ " + String.join(" ", command), false);
 
         Process process;
         try {
@@ -119,6 +122,7 @@ public final class CommandExecutor {
             if (out != null) {
                 out.println("[exit " + code + "]");
             }
+            RackBus.publish(tabName, "[exit " + code + "]", code != 0);
             onExit.accept(code);
         }, "nmox-rack-pump-" + tabName);
         pump.setDaemon(true);

--- a/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorder.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorder.java
@@ -1,0 +1,200 @@
+package org.nmox.studio.rack.engine;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * The flight recorder: a session-long memory of what every device did
+ * and when. It folds raw bus traffic into events - launches, exits with
+ * durations, error lines - so "it worked twenty minutes ago, what
+ * happened since?" has an answer you can scroll instead of a feeling.
+ *
+ * It also keeps per-device duration statistics, which is how BLACKBOX
+ * notices the slow creep: the build that quietly went from 1.2s to
+ * 3.4s while you weren't measuring.
+ */
+public final class FlightRecorder implements RackBus.Listener {
+
+    public enum Kind {
+        LAUNCH, EXIT_OK, EXIT_FAIL, ERROR
+    }
+
+    /** One timeline entry. durationMs is -1 except on exits. */
+    public record Event(long at, String device, Kind kind, String text, long durationMs) {
+    }
+
+    /** Rolling duration stats for one device's successful runs. */
+    public static final class Stats {
+
+        private long count;
+        private double avgMs;
+        private long lastMs = -1;
+
+        void addOk(long ms) {
+            lastMs = ms;
+            count++;
+            avgMs += (ms - avgMs) / count;
+        }
+
+        public long count() {
+            return count;
+        }
+
+        public long averageMs() {
+            return Math.round(avgMs);
+        }
+
+        public long lastMs() {
+            return lastMs;
+        }
+
+        /** True when the latest run took notably longer than usual. */
+        public boolean creeping() {
+            return count >= 3 && lastMs > avgMs * 1.8 && lastMs - avgMs > 500;
+        }
+    }
+
+    private static final FlightRecorder INSTANCE = new FlightRecorder();
+    private static final int CAPACITY = 2_000;
+    /** Error lines kept per run, so a 10k-line stack trace stays a sample. */
+    private static final int ERRORS_PER_RUN = 5;
+
+    private final Deque<Event> events = new ArrayDeque<>();
+    private final Map<String, Long> launchAt = new HashMap<>();
+    private final Map<String, Integer> errorsThisRun = new HashMap<>();
+    private final Map<String, Stats> stats = new HashMap<>();
+    private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
+    private final java.util.function.LongSupplier clock;
+
+    private FlightRecorder() {
+        this(System::currentTimeMillis);
+        RackBus.subscribe(this);
+    }
+
+    /** Test constructor: injectable clock, no bus subscription. */
+    FlightRecorder(java.util.function.LongSupplier clock) {
+        this.clock = clock;
+    }
+
+    public static FlightRecorder getDefault() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void line(String device, String line, boolean err) {
+        long now = clock.getAsLong();
+        synchronized (this) {
+            if (line.startsWith("$ ")) {
+                launchAt.put(device, now);
+                errorsThisRun.put(device, 0);
+                add(new Event(now, device, Kind.LAUNCH, line.substring(2), -1));
+            } else if (line.startsWith("[exit ")) {
+                int code = parseExit(line);
+                Long started = launchAt.remove(device);
+                long ms = started == null ? -1 : now - started;
+                if (code == 0) {
+                    stats.computeIfAbsent(device, d -> new Stats()).addOk(ms);
+                    add(new Event(now, device, Kind.EXIT_OK, "OK", ms));
+                } else {
+                    add(new Event(now, device, Kind.EXIT_FAIL, "exit " + code, ms));
+                }
+            } else if (err && !line.isBlank()) {
+                int seen = errorsThisRun.merge(device, 1, Integer::sum);
+                if (seen <= ERRORS_PER_RUN) {
+                    add(new Event(now, device, Kind.ERROR, line, -1));
+                }
+            }
+        }
+        for (Runnable l : listeners) {
+            try {
+                l.run();
+            } catch (RuntimeException ignored) {
+            }
+        }
+    }
+
+    static int parseExit(String line) {
+        try {
+            return Integer.parseInt(line.replaceAll("[^0-9-]", ""));
+        } catch (NumberFormatException ex) {
+            return -1;
+        }
+    }
+
+    private void add(Event e) {
+        events.addLast(e);
+        while (events.size() > CAPACITY) {
+            events.removeFirst();
+        }
+    }
+
+    // ---- reading the record ----
+
+    public synchronized List<Event> timeline() {
+        return new ArrayList<>(events);
+    }
+
+    public synchronized List<Event> errorsSince(long sinceMs) {
+        List<Event> result = new ArrayList<>();
+        for (Event e : events) {
+            if (e.at() >= sinceMs && (e.kind() == Kind.ERROR || e.kind() == Kind.EXIT_FAIL)) {
+                result.add(e);
+            }
+        }
+        return result;
+    }
+
+    public synchronized Event last() {
+        for (var it = events.descendingIterator(); it.hasNext();) {
+            Event e = it.next();
+            if (e.kind() == Kind.EXIT_OK || e.kind() == Kind.EXIT_FAIL) {
+                return e;
+            }
+        }
+        return null;
+    }
+
+    public synchronized Map<String, Stats> statistics() {
+        return new HashMap<>(stats);
+    }
+
+    /** Any device whose latest run crept well past its average. */
+    public synchronized String slowCreep() {
+        for (Map.Entry<String, Stats> e : stats.entrySet()) {
+            if (e.getValue().creeping()) {
+                return e.getKey();
+            }
+        }
+        return null;
+    }
+
+    public void addChangeListener(Runnable r) {
+        listeners.add(r);
+    }
+
+    public void removeChangeListener(Runnable r) {
+        listeners.remove(r);
+    }
+
+    /** The whole record as text, for the EXPORT button and bug reports. */
+    public synchronized String export() {
+        StringBuilder sb = new StringBuilder("NMOX flight log\n");
+        java.text.SimpleDateFormat fmt = new java.text.SimpleDateFormat("HH:mm:ss");
+        for (Event e : events) {
+            sb.append(fmt.format(new java.util.Date(e.at()))).append("  ")
+                    .append(String.format("%-10s", e.device())).append(" ")
+                    .append(String.format("%-9s", e.kind())).append(" ")
+                    .append(e.text());
+            if (e.durationMs() >= 0) {
+                sb.append("  (").append(e.durationMs() / 1000.0).append("s)");
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/engine/PortScanner.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/PortScanner.java
@@ -1,0 +1,85 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The port radar: who is listening on localhost, by port, with the
+ * process that owns it. Built on lsof because every macOS and Linux
+ * box has it - the flags nobody remembers, remembered once, here.
+ */
+public final class PortScanner {
+
+    /** One listening socket: the port and the process holding it. */
+    public record PortInfo(int port, long pid, String command) {
+    }
+
+    private PortScanner() {
+    }
+
+    /** All listening TCP ports, deduped by port, lowest pid wins. */
+    public static CompletableFuture<List<PortInfo>> scan() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                ProcessBuilder pb = new ProcessBuilder(
+                        "lsof", "-nP", "-iTCP", "-sTCP:LISTEN", "-F", "pcn")
+                        .redirectInput(new File("/dev/null"));
+                pb.environment().put("PATH", ToolLocator.augmentedPath());
+                Process p = pb.start();
+                String out = new String(p.getInputStream().readAllBytes());
+                p.waitFor(10, TimeUnit.SECONDS);
+                return parse(out);
+            } catch (Exception ex) {
+                return List.of();
+            }
+        });
+    }
+
+    /**
+     * Parses lsof -F pcn machine output: p<pid>, c<command>, n<name>
+     * lines, where the name carries host:port. Pure; tested on canned
+     * output.
+     */
+    static List<PortInfo> parse(String out) {
+        Map<Integer, PortInfo> byPort = new LinkedHashMap<>();
+        long pid = -1;
+        String command = "";
+        Pattern portAtEnd = Pattern.compile(":(\\d+)$");
+        for (String line : out.split("\n")) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            char tag = line.charAt(0);
+            String value = line.substring(1);
+            switch (tag) {
+                case 'p' -> pid = Long.parseLong(value.trim());
+                case 'c' -> command = value.trim();
+                case 'n' -> {
+                    Matcher m = portAtEnd.matcher(value.trim());
+                    if (m.find()) {
+                        int port = Integer.parseInt(m.group(1));
+                        byPort.putIfAbsent(port, new PortInfo(port, pid, command));
+                    }
+                }
+                default -> {
+                    // f/t/other field tags are noise for our purposes
+                }
+            }
+        }
+        List<PortInfo> result = new ArrayList<>(byPort.values());
+        result.sort(java.util.Comparator.comparingInt(PortInfo::port));
+        return result;
+    }
+
+    /** SIGTERM the owner of a port; the caller confirms first. */
+    public static boolean kill(long pid) {
+        return ProcessHandle.of(pid).map(ProcessHandle::destroy).orElse(false);
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/engine/CommandExecutorTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/CommandExecutorTest.java
@@ -53,8 +53,11 @@ class CommandExecutorTest {
                     deviceLines::add, code -> done.countDown());
 
             assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
-            assertThat(busLines).containsExactlyInAnyOrder(
+            assertThat(busLines).contains(
                     "streams|plain|false", "streams|broken|true");
+            // lifecycle markers ride the bus too - the flight recorder needs them
+            assertThat(busLines).anyMatch(l -> l.startsWith("streams|$ sh"));
+            assertThat(busLines).anyMatch(l -> l.startsWith("streams|[exit 0]"));
             // the device callback still hears both streams (parsers need both)
             assertThat(deviceLines).containsExactlyInAnyOrder("plain", "broken");
         } finally {

--- a/rack/src/test/java/org/nmox/studio/rack/engine/FlightRecorderTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/FlightRecorderTest.java
@@ -1,0 +1,97 @@
+package org.nmox.studio.rack.engine;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.rack.engine.FlightRecorder.Kind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** The fold logic, on an injected clock - no bus, no waiting. */
+class FlightRecorderTest {
+
+    private AtomicLong now;
+    private FlightRecorder rec;
+
+    @BeforeEach
+    void fresh() {
+        now = new AtomicLong(1_000_000);
+        rec = new FlightRecorder(now::get);
+    }
+
+    private void tick(long ms) {
+        now.addAndGet(ms);
+    }
+
+    @Test
+    @DisplayName("Launch + exit pair into a run with a duration")
+    void pairsLaunchAndExit() {
+        rec.line("FORGE", "$ npm run build", false);
+        tick(1_200);
+        rec.line("FORGE", "[exit 0]", false);
+
+        var timeline = rec.timeline();
+        assertThat(timeline).hasSize(2);
+        assertThat(timeline.get(0).kind()).isEqualTo(Kind.LAUNCH);
+        assertThat(timeline.get(1).kind()).isEqualTo(Kind.EXIT_OK);
+        assertThat(timeline.get(1).durationMs()).isEqualTo(1_200);
+        assertThat(rec.last().device()).isEqualTo("FORGE");
+    }
+
+    @Test
+    @DisplayName("Failures and error lines land on the tape; stack traces stay a sample")
+    void recordsFailuresSampled() {
+        rec.line("VERITAS", "$ npm test", false);
+        for (int i = 0; i < 40; i++) {
+            rec.line("VERITAS", "Error: assertion " + i, true);
+        }
+        tick(800);
+        rec.line("VERITAS", "[exit 1]", true);
+
+        long errors = rec.timeline().stream().filter(e -> e.kind() == Kind.ERROR).count();
+        assertThat(errors).as("error sample cap").isEqualTo(5);
+        assertThat(rec.last().kind()).isEqualTo(Kind.EXIT_FAIL);
+        assertThat(rec.errorsSince(0)).hasSize(6); // 5 samples + the failed exit
+    }
+
+    @Test
+    @DisplayName("The slow creep: a run far past its average raises the flag")
+    void detectsSlowCreep() {
+        for (long ms : new long[]{1000, 1100, 1050}) {
+            rec.line("FORGE", "$ npm run build", false);
+            tick(ms);
+            rec.line("FORGE", "[exit 0]", false);
+        }
+        assertThat(rec.slowCreep()).isNull();
+
+        rec.line("FORGE", "$ npm run build", false);
+        tick(3_400);
+        rec.line("FORGE", "[exit 0]", false);
+
+        assertThat(rec.slowCreep()).isEqualTo("FORGE");
+        var stats = rec.statistics().get("FORGE");
+        assertThat(stats.lastMs()).isEqualTo(3_400);
+        assertThat(stats.creeping()).isTrue();
+    }
+
+    @Test
+    @DisplayName("The tape is a ring: capacity bounds memory")
+    void ringBufferCaps() {
+        for (int i = 0; i < 3_000; i++) {
+            rec.line("PING", "$ run " + i, false);
+        }
+        assertThat(rec.timeline()).hasSize(2_000);
+    }
+
+    @Test
+    @DisplayName("Export reads like a log a human would paste into a bug report")
+    void exportIsReadable() {
+        rec.line("FORGE", "$ npm run build", false);
+        tick(1_500);
+        rec.line("FORGE", "[exit 0]", false);
+        String log = rec.export();
+        assertThat(log).contains("FORGE").contains("LAUNCH").contains("npm run build")
+                .contains("EXIT_OK").contains("(1.5s)");
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/engine/PortScannerTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/PortScannerTest.java
@@ -1,0 +1,56 @@
+package org.nmox.studio.rack.engine;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** lsof -F pcn parsing on canned output - no scanning needed. */
+class PortScannerTest {
+
+    @Test
+    @DisplayName("Ports map to their owning process, deduped, sorted")
+    void parsesField() {
+        String out = """
+                p501
+                cnode
+                n*:5173
+                n127.0.0.1:5173
+                p777
+                cpostgres
+                n127.0.0.1:5432
+                p888
+                ccom.docke
+                n*:8080
+                """;
+        List<PortScanner.PortInfo> ports = PortScanner.parse(out);
+        assertThat(ports).hasSize(3);
+        assertThat(ports.get(0).port()).isEqualTo(5173);
+        assertThat(ports.get(0).command()).isEqualTo("node");
+        assertThat(ports.get(0).pid()).isEqualTo(501);
+        assertThat(ports.get(1).port()).isEqualTo(5432);
+        assertThat(ports.get(2).command()).isEqualTo("com.docke");
+    }
+
+    @Test
+    @DisplayName("IPv6 and odd name formats do not break the sweep")
+    void handlesIpv6AndNoise() {
+        String out = """
+                p42
+                cjava
+                n[::1]:8000
+                nlocalhost:9000
+                nnoporthere
+                """;
+        List<PortScanner.PortInfo> ports = PortScanner.parse(out);
+        assertThat(ports).extracting(PortScanner.PortInfo::port)
+                .containsExactly(8000, 9000);
+    }
+
+    @Test
+    @DisplayName("Empty output is an empty field, not an error")
+    void emptyOutput() {
+        assertThat(PortScanner.parse("")).isEmpty();
+    }
+}


### PR DESCRIPTION
## What

Two devices answering the questions developers ask all day that no tool answers — ideas drawn from watching this project get built (and debugged) today.

**BLACKBOX — the flight recorder.** "It worked twenty minutes ago, what happened?" now has a scrollable answer. The executor publishes launch/exit markers on the RackBus; FlightRecorder folds bus traffic into a timestamped session timeline (launches, exits with durations, sampled error lines), ring-buffered and exportable. The faceplate shows the last run + rolling error count, and the bit nothing else does: **per-device duration stats with a slow-creep alarm** — "FORGE SLOWING: 3.4s VS 1.1s AVG" before you've consciously noticed.

**SONAR — the port radar.** SWEEP maps every listening TCP port to its owning process, labels docker-container-owned ports, and shows the dev band on the faceplate. VIEW opens the field with BROWSE and confirmed KILL per row — and refuses to let you kill the docker daemon for a container's port, pointing you to HARBOR instead. EADDRINUSE, solved.

## Verification

- FlightRecorder fold logic tested on an injected clock: launch/exit pairing, durations, creep detection, error sampling caps, ring bounds
- PortScanner tested on canned `lsof -F pcn` output (IPv4/IPv6, dedupe, noise)
- Contract suite: 181 checks, both devices covered automatically
- **Live before merge**: a real `npm outdated` exit-1 landed on the tape as `EXIT_FAIL 0.806s` with the error count on the faceplate; SONAR's first sweep found 7 real ports with the dev band on the LCD

🤖 Generated with [Claude Code](https://claude.com/claude-code)