### PR TITLE
Workbench: Docker Manager shortcut in TOOLING

### DIFF
--- a/project/src/main/java/org/nmox/studio/project/ProjectExplorerTopComponent.java
+++ b/project/src/main/java/org/nmox/studio/project/ProjectExplorerTopComponent.java
@@ -310,6 +310,15 @@ public final class ProjectExplorerTopComponent extends TopComponent {
         row("Infra Designer", "DigitalOcean · Hetzner · Cloudflare flows",
                 false, null, "Design and deploy infrastructure Node-RED style",
                 () -> openWindow("InfraDesignerTopComponent"));
+        row("Docker Manager", "containers, images, disk reclaim, dockerize",
+                false, null, "The Docker Panel — HARBOR's control room",
+                () -> {
+                    try {
+                        org.nmox.studio.rack.docker.DockerPanelTopComponent.openPanel();
+                    } catch (RuntimeException | LinkageError ex) {
+                        // rack module unavailable; nothing to open
+                    }
+                });
         row("Terminal", "phosphor shell in the project directory",
                 false, null, "Black glass, lime text", this::openTerminal);
     }

--- a/rack/pom.xml
+++ b/rack/pom.xml
@@ -138,6 +138,7 @@
                         <publicPackage>org.nmox.studio.rack.service</publicPackage>
                         <publicPackage>org.nmox.studio.rack.engine</publicPackage>
                         <publicPackage>org.nmox.studio.rack.projectstudio</publicPackage>
+                        <publicPackage>org.nmox.studio.rack.docker</publicPackage>
                     </publicPackages>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The Docker Panel should be reachable from the first screen a developer sees. Adds a **Docker Manager** row to the Workbench's TOOLING shelf that opens HARBOR's control room directly; the rack module exports `org.nmox.studio.rack.docker` to make the call. Guarded like the other tooling rows for stripped-platform safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)