### PR TITLE
Gap sweep: three workflow bugs from walking the happy path by hand

### DIFF
--- a/rack/pom.xml
+++ b/rack/pom.xml
@@ -119,6 +119,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-modules</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>

--- a/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
+++ b/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
@@ -264,6 +264,12 @@ public final class RackTopComponent extends TopComponent {
     }
 
     void readProperties(java.util.Properties p) {
+        // restore last session's aim - but never clobber a choice the
+        // user already made this session (e.g. the New Project wizard
+        // aimed the rack before this window deserialized)
+        if (org.nmox.studio.rack.service.RackService.getDefault().isAimed()) {
+            return;
+        }
         String dir = p.getProperty("projectDir");
         if (dir != null) {
             File f = new File(dir);

--- a/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorderStart.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorderStart.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.rack.engine;
+
+import org.openide.modules.OnStart;
+
+/**
+ * A flight recorder that starts when you open the viewer has missed
+ * the flight. Touch the recorder at module startup so the tape runs
+ * from the first command of the session, BLACKBOX racked or not.
+ */
+@OnStart
+public class FlightRecorderStart implements Runnable {
+
+    @Override
+    public void run() {
+        FlightRecorder.getDefault();
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/NewProjectDialog.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/NewProjectDialog.java
@@ -206,6 +206,7 @@ public class NewProjectDialog extends JDialog {
         }
 
         createdProject = dir;
+        ProjectTemplates.initGitRepo(dir);
         // aim the rack: the template's patch mounts automatically
         RackService.getDefault().openProject(dir);
 

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/ProjectTemplates.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/ProjectTemplates.java
@@ -1150,6 +1150,41 @@ public enum ProjectTemplates {
      * contain files): sources, package.json, .gitignore, README, and the
      * pre-wired rack patch.
      */
+    /**
+     * Every real project starts versioned: init a repo and lay down the
+     * first commit so TIMELINE and the platform's git colors work from
+     * minute one. Best-effort - a machine without git still gets its
+     * project, just unversioned.
+     */
+    public static void initGitRepo(File dir) {
+        if (run(dir, "git", "init") != 0) {
+            return;
+        }
+        run(dir, "git", "add", "-A");
+        if (run(dir, "git", "commit", "-m", "Initial commit — scaffolded by NMOX Studio") != 0) {
+            // no committer identity configured; commit with a local fallback
+            run(dir, "git", "-c", "user.name=NMOX Studio", "-c", "user.email=studio@nmox.local",
+                    "commit", "-m", "Initial commit — scaffolded by NMOX Studio");
+        }
+    }
+
+    private static int run(File dir, String... cmd) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                    org.nmox.studio.rack.engine.ToolLocator.resolveCommand(java.util.List.of(cmd)))
+                    .directory(dir)
+                    .redirectErrorStream(true)
+                    .redirectInput(new File("/dev/null"));
+            pb.environment().put("PATH", org.nmox.studio.rack.engine.ToolLocator.augmentedPath());
+            pb.environment().put("GIT_TERMINAL_PROMPT", "0");
+            Process proc = pb.start();
+            proc.getInputStream().readAllBytes();
+            return proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS) ? proc.exitValue() : -1;
+        } catch (Exception ex) {
+            return -1;
+        }
+    }
+
     public void generate(File dir, String name) throws IOException {
         Path root = dir.toPath();
         Files.createDirectories(root);

--- a/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
@@ -25,6 +25,7 @@ public class RackService {
 
     private final Rack rack = new Rack();
     private boolean initialized;
+    private volatile boolean aimed;
 
     public static RackService getDefault() {
         RackService service = Lookup.getDefault().lookup(RackService.class);
@@ -60,8 +61,18 @@ public class RackService {
         if (dir == null || !dir.isDirectory()) {
             return;
         }
+        aimed = true;
         addRecentProject(dir);
         getRack().setProjectDir(dir);
+    }
+
+    /**
+     * True once anything has aimed the rack this session. Passive
+     * followers (persisted window state, the open-projects listener)
+     * must never clobber an aim the user already made.
+     */
+    public boolean isAimed() {
+        return aimed;
     }
 
     // ---- recent projects ----
@@ -142,6 +153,9 @@ public class RackService {
     }
 
     private void aimAtOpenProject() {
+        if (aimed) {
+            return; // an explicit choice always outranks the follower
+        }
         org.netbeans.api.project.Project[] projects =
                 org.netbeans.api.project.ui.OpenProjects.getDefault().getOpenProjects();
         File fallback = null;

--- a/rack/src/test/java/org/nmox/studio/rack/projectstudio/ProjectTemplatesTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/projectstudio/ProjectTemplatesTest.java
@@ -80,4 +80,33 @@ class ProjectTemplatesTest {
         org.junit.jupiter.api.Assertions.assertThrows(java.io.IOException.class,
                 () -> ProjectTemplates.VANILLA.generate(dir, "demo"));
     }
+
+    @Test
+    @org.junit.jupiter.api.DisplayName("A new project starts versioned: git init + first commit")
+    void newProjectStartsVersioned() throws Exception {
+        org.junit.jupiter.api.Assumptions.assumeTrue(gitAvailable(), "git not installed");
+        java.io.File dir = parent.resolve("versioned-app").toFile();
+        ProjectTemplates.values()[0].generate(dir, "versioned-app");
+
+        ProjectTemplates.initGitRepo(dir);
+
+        org.assertj.core.api.Assertions.assertThat(new java.io.File(dir, ".git"))
+                .as("repo must exist").isDirectory();
+        Process log = new ProcessBuilder("git", "-C", dir.getAbsolutePath(), "log", "--oneline")
+                .redirectErrorStream(true).start();
+        String out = new String(log.getInputStream().readAllBytes());
+        log.waitFor();
+        org.assertj.core.api.Assertions.assertThat(out)
+                .as("the first commit").contains("Initial commit");
+    }
+
+    private static boolean gitAvailable() {
+        for (String d : org.nmox.studio.rack.engine.ToolLocator.augmentedPath()
+                .split(java.io.File.pathSeparator)) {
+            if (new java.io.File(d, "git").canExecute()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/rack/src/test/java/org/nmox/studio/rack/service/AimPriorityTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/service/AimPriorityTest.java
@@ -1,0 +1,31 @@
+package org.nmox.studio.rack.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The aim-priority rule: an explicit openProject always outranks
+ * passive followers. This is the regression test for the wizard's
+ * fresh aim being clobbered by the rack window's persisted state.
+ */
+class AimPriorityTest {
+
+    @TempDir
+    java.io.File projectA;
+
+    @Test
+    @DisplayName("isAimed flips on the first explicit aim and stays")
+    void explicitAimIsSticky() {
+        RackService service = new RackService();
+        assertThat(service.isAimed()).as("fresh service is unaimed").isFalse();
+
+        service.openProject(projectA);
+
+        assertThat(service.isAimed()).isTrue();
+        assertThat(service.getRack().getProjectDir()).isEqualTo(projectA);
+        service.getRack().shutdown();
+    }
+}


### PR DESCRIPTION
## Method

Created a real Vite+React project through the New Project wizard and exercised the rack against it by hand — install, build, test, serve, stop, git, ports, tape — watching faceplates, toasts, and the exception log. Core loop: **clean** (all green, zero exceptions). Three workflow gaps surfaced and are fixed:

## Fixed

1. **Wizard aim clobbered by persisted state.** Opening the Task Rack after creating a project re-aimed the IDE at *last session's* project (`readProperties` restore; the OpenProjects follower had the same power). New invariant in `RackService`: explicit `openProject` sets `isAimed()`; passive followers never aim an already-aimed rack. Cold-start restore unaffected.

2. **Flight recorder missed the flight.** `FlightRecorder` started on first BLACKBOX touch (lazy init), losing everything before it. `@OnStart` now arms the tape at module load. Live proof: a BLACKBOX racked minutes after project creation already showed `Project Setup OK 2.991s`.

3. **New projects started unversioned.** The wizard wrote `.gitignore` but never `git init`, leaving TIMELINE at "NO REPO" on every fresh project. Creation now inits + lays an initial commit (best-effort; local identity fallback).

## Verification

- `AimPriorityTest` + `ProjectTemplatesTest.newProjectStartsVersioned` (git-gated) as regressions
- Full suite green
- All three re-verified live in the rebuilt app: wizard → rack stays aimed → `.git` with "Initial commit — scaffolded by NMOX Studio" → tape pre-populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)