### PR TITLE
CI: Node 24 action majors ahead of the June 16 forcing date

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     needs: version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -38,7 +38,7 @@ jobs:
              "NMOX-Studio-${{ needs.version.outputs.version }}-portable.zip"
       - name: Linux tar.gz and deb
         run: ./packaging/linux/build-packages.sh "${{ needs.version.outputs.version }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: linux-artifacts
           path: |
@@ -50,8 +50,8 @@ jobs:
     needs: version
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -64,7 +64,7 @@ jobs:
         run: mvn -B clean package -DskipTests
       - name: Build DMG
         run: ./packaging/macos/build-dmg.sh "${{ needs.version.outputs.version }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: macos-artifacts
           path: application/target/dist/NMOX-Studio-*-macos.dmg
@@ -73,8 +73,8 @@ jobs:
     needs: version
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -93,7 +93,7 @@ jobs:
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
             /DAppVersion=${{ needs.version.outputs.version }} `
             packaging\windows\nmox-studio.iss
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: windows-artifacts
           path: application/target/dist/NMOX-Studio-*-windows-setup.exe
@@ -102,7 +102,7 @@ jobs:
     needs: [version, linux, macos, windows]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           merge-multiple: true
           path: artifacts


### PR DESCRIPTION
GitHub's deprecation warning: Node 20 actions are forced to Node 24 on 2026-06-16 and removed 2026-09-16. This bumps every flagged action to its Node-24 major across both workflows: `checkout` v4→v5, `setup-java` v4→v5, `upload-artifact` v4→v5, plus `download-artifact` v4→v5 to keep the artifact pipeline on matched majors. `softprops/action-gh-release@v2` already runs Node 24.

This PR's own CI run validates checkout/setup-java live; the release-path actions (upload/download/gh-release) get proven at the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)