### PR TITLE
Session Resurrection: the IDE survives its own death

### DIFF
--- a/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
+++ b/rack/src/main/java/org/nmox/studio/rack/RackTopComponent.java
@@ -267,15 +267,10 @@ public final class RackTopComponent extends TopComponent {
         // restore last session's aim - but never clobber a choice the
         // user already made this session (e.g. the New Project wizard
         // aimed the rack before this window deserialized)
-        if (org.nmox.studio.rack.service.RackService.getDefault().isAimed()) {
-            return;
-        }
         String dir = p.getProperty("projectDir");
         if (dir != null) {
-            File f = new File(dir);
-            if (f.isDirectory()) {
-                org.nmox.studio.rack.service.RackService.getDefault().openProject(f);
-            }
+            org.nmox.studio.rack.service.RackService.getDefault()
+                    .openProjectPassively(new File(dir));
         }
     }
 }

--- a/rack/src/main/java/org/nmox/studio/rack/devices/CommandDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/CommandDevice.java
@@ -125,6 +125,11 @@ public abstract class CommandDevice extends RackDevice {
         launch(buildCommand());
     }
 
+    @Override
+    public void resume() {
+        primaryAction();
+    }
+
     /**
      * Whether this device only makes sense inside an npm project. When
      * true (the default), launches are refused unless the project dir

--- a/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorder.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorder.java
@@ -92,21 +92,21 @@ public final class FlightRecorder implements RackBus.Listener {
             if (line.startsWith("$ ")) {
                 launchAt.put(device, now);
                 errorsThisRun.put(device, 0);
-                add(new Event(now, device, Kind.LAUNCH, line.substring(2), -1));
+                record(new Event(now, device, Kind.LAUNCH, line.substring(2), -1));
             } else if (line.startsWith("[exit ")) {
                 int code = parseExit(line);
                 Long started = launchAt.remove(device);
                 long ms = started == null ? -1 : now - started;
                 if (code == 0) {
                     stats.computeIfAbsent(device, d -> new Stats()).addOk(ms);
-                    add(new Event(now, device, Kind.EXIT_OK, "OK", ms));
+                    record(new Event(now, device, Kind.EXIT_OK, "OK", ms));
                 } else {
-                    add(new Event(now, device, Kind.EXIT_FAIL, "exit " + code, ms));
+                    record(new Event(now, device, Kind.EXIT_FAIL, "exit " + code, ms));
                 }
             } else if (err && !line.isBlank()) {
                 int seen = errorsThisRun.merge(device, 1, Integer::sum);
                 if (seen <= ERRORS_PER_RUN) {
-                    add(new Event(now, device, Kind.ERROR, line, -1));
+                    record(new Event(now, device, Kind.ERROR, line, -1));
                 }
             }
         }
@@ -131,6 +131,12 @@ public final class FlightRecorder implements RackBus.Listener {
         while (events.size() > CAPACITY) {
             events.removeFirst();
         }
+    }
+
+    /** add() + journal append - the path live events take. */
+    private void record(Event e) {
+        add(e);
+        appendToJournal(e);
     }
 
     // ---- reading the record ----
@@ -171,6 +177,75 @@ public final class FlightRecorder implements RackBus.Listener {
             }
         }
         return null;
+    }
+
+    // ---- the journal: the tape survives the JVM ----
+
+    private java.io.File journal;
+    private static final long JOURNAL_MAX_BYTES = 1_500_000;
+
+    /**
+     * Attaches a JSONL journal: existing events load onto the tape (so
+     * BLACKBOX remembers past sessions), and every new event appends.
+     * Mosh for the flight record - the session outlives the process.
+     */
+    public synchronized void attachJournal(java.io.File file) {
+        this.journal = file;
+        try {
+            if (file.isFile()) {
+                for (String line : java.nio.file.Files.readAllLines(file.toPath())) {
+                    Event e = eventFromJson(line);
+                    if (e != null) {
+                        add(e);
+                    }
+                }
+            } else {
+                file.getParentFile().mkdirs();
+            }
+        } catch (Exception ignored) {
+            // an unreadable journal must never break recording
+        }
+    }
+
+    private void appendToJournal(Event e) {
+        if (journal == null) {
+            return;
+        }
+        try {
+            if (journal.length() > JOURNAL_MAX_BYTES) {
+                rotateJournal();
+            }
+            java.nio.file.Files.writeString(journal.toPath(), eventToJson(e) + "\n",
+                    java.nio.file.StandardOpenOption.CREATE,
+                    java.nio.file.StandardOpenOption.APPEND);
+        } catch (Exception ignored) {
+            // disk trouble must never break recording
+        }
+    }
+
+    /** Keeps the newer half when the journal outgrows its cap. */
+    private void rotateJournal() throws java.io.IOException {
+        java.util.List<String> lines = java.nio.file.Files.readAllLines(journal.toPath());
+        java.util.List<String> keep = lines.subList(lines.size() / 2, lines.size());
+        java.nio.file.Files.write(journal.toPath(), keep);
+    }
+
+    static String eventToJson(Event e) {
+        return new org.json.JSONObject()
+                .put("at", e.at()).put("device", e.device())
+                .put("kind", e.kind().name()).put("text", e.text())
+                .put("ms", e.durationMs()).toString();
+    }
+
+    static Event eventFromJson(String line) {
+        try {
+            org.json.JSONObject o = new org.json.JSONObject(line);
+            return new Event(o.getLong("at"), o.getString("device"),
+                    Kind.valueOf(o.getString("kind")), o.getString("text"),
+                    o.optLong("ms", -1));
+        } catch (RuntimeException ex) {
+            return null; // a corrupt line is not a corrupt tape
+        }
     }
 
     public void addChangeListener(Runnable r) {

--- a/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorderStart.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/FlightRecorderStart.java
@@ -12,6 +12,10 @@ public class FlightRecorderStart implements Runnable {
 
     @Override
     public void run() {
-        FlightRecorder.getDefault();
+        FlightRecorder recorder = FlightRecorder.getDefault();
+        String userdir = System.getProperty("netbeans.user");
+        if (userdir != null) {
+            recorder.attachJournal(new java.io.File(userdir, "var/nmox/flight.jsonl"));
+        }
     }
 }

--- a/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
@@ -272,6 +272,20 @@ public abstract class RackDevice extends JPanel {
         }
     }
 
+    /** True while this device has a tool process running. */
+    public boolean isLive() {
+        CommandExecutor.Handle h = running;
+        return h != null && h.isAlive();
+    }
+
+    /**
+     * Re-fires this device's primary action - session resurrection
+     * calls this to bring back what was running before the IDE died.
+     * Devices without a primary action ignore it.
+     */
+    public void resume() {
+    }
+
     /**
      * Emergency stop, callable from outside (STOP ALL, and the JVM
      * shutdown reaper). Kills synchronously with forced escalation:

--- a/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
@@ -46,11 +46,105 @@ public class RackService {
                 @Override
                 public void projectChanged() {
                     autoLoadPatch();
+                    offerResume();
                 }
             });
             followOpenProjects();
+            startSessionSnapshots();
         }
         return rack;
+    }
+
+    // ---- session resurrection: the mosh principle ----
+
+    private java.io.File sessionFile(java.io.File project) {
+        String userdir = System.getProperty("netbeans.user");
+        if (userdir == null) {
+            return null; // plain unit tests: no session persistence
+        }
+        String key = Integer.toHexString(project.getAbsolutePath().hashCode());
+        return new java.io.File(userdir, "var/nmox/sessions/" + key + ".json");
+    }
+
+    /**
+     * Snapshots what is live every few seconds - continuously, not on
+     * clean quit, so the session survives kill -9 and power loss. An
+     * empty snapshot deletes the file: stopping your tools IS the
+     * statement that there is nothing to resume.
+     */
+    private volatile boolean anyLiveThisSession;
+
+    private void startSessionSnapshots() {
+        javax.swing.Timer snap = new javax.swing.Timer(5_000, e -> {
+            java.io.File file = sessionFile(rack.getProjectDir());
+            if (file == null) {
+                return;
+            }
+            try {
+                SessionState state = SessionState.capture(rack);
+                if (!state.running().isEmpty()) {
+                    anyLiveThisSession = true;
+                    file.getParentFile().mkdirs();
+                    java.nio.file.Files.writeString(file.toPath(), state.toJson());
+                } else if (anyLiveThisSession) {
+                    // tools ran and were stopped: nothing to resume anymore.
+                    // A session file from a PREVIOUS process stays untouched
+                    // until then, so an ignored resume offer survives another
+                    // restart instead of being silently consumed.
+                    java.nio.file.Files.deleteIfExists(file.toPath());
+                }
+            } catch (Exception ignored) {
+                // a failed snapshot must never disturb the rack
+            }
+        });
+        snap.setRepeats(true);
+        snap.start();
+    }
+
+    /** After aiming: if the last session here died with tools running, offer them back. */
+    private void offerResume() {
+        java.io.File file = sessionFile(rack.getProjectDir());
+        if (file == null || !file.isFile()) {
+            return;
+        }
+        SessionState state;
+        try {
+            state = SessionState.fromJson(java.nio.file.Files.readString(file.toPath()));
+        } catch (Exception ex) {
+            return;
+        }
+        if (state == null || !state.fresh()
+                || !state.project().equals(rack.getProjectDir().getAbsolutePath())) {
+            return;
+        }
+        java.util.List<org.nmox.studio.rack.model.RackDevice> matches = state.matchAgainst(rack);
+        if (matches.isEmpty()) {
+            return;
+        }
+        StringBuilder names = new StringBuilder();
+        for (var d : matches) {
+            if (names.length() > 0) {
+                names.append(", ");
+            }
+            names.append(d.getTitle());
+        }
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            try {
+                org.openide.awt.NotificationDisplayer.getDefault().notify(
+                        "Resume last session?",
+                        javax.swing.UIManager.getIcon("OptionPane.informationIcon"),
+                        names + (matches.size() == 1 ? " was" : " were")
+                        + " running when the IDE closed — click to bring "
+                        + (matches.size() == 1 ? "it" : "them") + " back",
+                        e -> {
+                            for (var d : matches) {
+                                d.resume();
+                            }
+                        });
+            } catch (RuntimeException | LinkageError ignored) {
+                // notifications unavailable (tests, stripped platform)
+            }
+        });
     }
 
     /**
@@ -67,12 +161,25 @@ public class RackService {
     }
 
     /**
-     * True once anything has aimed the rack this session. Passive
-     * followers (persisted window state, the open-projects listener)
-     * must never clobber an aim the user already made.
+     * True once anything has explicitly aimed the rack this session.
+     * Passive followers (persisted window state, the open-projects
+     * listener) must never clobber an aim the user already made.
      */
     public boolean isAimed() {
         return aimed;
+    }
+
+    /**
+     * A passive aim: points the rack without claiming user intent, so
+     * later passive sources (e.g. the rack window's persisted project
+     * restoring after the open-projects follower) may still re-aim.
+     * Any explicit aim still outranks all of these.
+     */
+    public void openProjectPassively(File dir) {
+        if (aimed || dir == null || !dir.isDirectory()) {
+            return;
+        }
+        getRack().setProjectDir(dir);
     }
 
     // ---- recent projects ----
@@ -165,7 +272,7 @@ public class RackService {
                 continue;
             }
             if (new File(dir, "package.json").isFile()) {
-                openProject(dir);
+                openProjectPassively(dir);
                 return;
             }
             if (fallback == null) {
@@ -173,7 +280,7 @@ public class RackService {
             }
         }
         if (fallback != null) {
-            openProject(fallback);
+            openProjectPassively(fallback);
         }
     }
 }

--- a/rack/src/main/java/org/nmox/studio/rack/service/SessionState.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/SessionState.java
@@ -1,0 +1,88 @@
+package org.nmox.studio.rack.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.nmox.studio.rack.model.Rack;
+import org.nmox.studio.rack.model.RackDevice;
+
+/**
+ * What was alive in the rack, written continuously so it survives any
+ * kind of death - clean quit, crash, kill -9, power loss. The mosh
+ * principle applied to the IDE: the session is state to resynchronize,
+ * not a stream that dies with the process.
+ */
+public record SessionState(String project, long at, List<Entry> running) {
+
+    /** One live device: matched on resume by position and type. */
+    public record Entry(int index, String typeId, String title) {
+    }
+
+    /** Snapshot whatever is live right now; empty list = nothing to resume. */
+    public static SessionState capture(Rack rack) {
+        List<Entry> live = new ArrayList<>();
+        List<RackDevice> devices = rack.getDevices();
+        for (int i = 0; i < devices.size(); i++) {
+            RackDevice d = devices.get(i);
+            if (d.isLive()) {
+                live.add(new Entry(i, d.getTypeId(), d.getTitle()));
+            }
+        }
+        return new SessionState(rack.getProjectDir().getAbsolutePath(),
+                System.currentTimeMillis(), live);
+    }
+
+    public String toJson() {
+        JSONArray arr = new JSONArray();
+        for (Entry e : running) {
+            arr.put(new JSONObject()
+                    .put("index", e.index())
+                    .put("typeId", e.typeId())
+                    .put("title", e.title()));
+        }
+        return new JSONObject()
+                .put("project", project)
+                .put("at", at)
+                .put("running", arr)
+                .toString();
+    }
+
+    public static SessionState fromJson(String json) {
+        try {
+            JSONObject o = new JSONObject(json);
+            List<Entry> running = new ArrayList<>();
+            JSONArray arr = o.getJSONArray("running");
+            for (int i = 0; i < arr.length(); i++) {
+                JSONObject e = arr.getJSONObject(i);
+                running.add(new Entry(e.getInt("index"),
+                        e.getString("typeId"), e.optString("title", e.getString("typeId"))));
+            }
+            return new SessionState(o.getString("project"), o.getLong("at"), running);
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * The devices in this rack that the session says were running -
+     * matched by position AND type, so a re-arranged patch never
+     * resurrects the wrong unit.
+     */
+    public List<RackDevice> matchAgainst(Rack rack) {
+        List<RackDevice> matches = new ArrayList<>();
+        List<RackDevice> devices = rack.getDevices();
+        for (Entry e : running) {
+            if (e.index() < devices.size()
+                    && devices.get(e.index()).getTypeId().equals(e.typeId())) {
+                matches.add(devices.get(e.index()));
+            }
+        }
+        return matches;
+    }
+
+    /** Sessions older than this are history, not intent. */
+    public boolean fresh() {
+        return System.currentTimeMillis() - at < 7L * 24 * 3600 * 1000;
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/engine/FlightRecorderTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/FlightRecorderTest.java
@@ -94,4 +94,35 @@ class FlightRecorderTest {
         assertThat(log).contains("FORGE").contains("LAUNCH").contains("npm run build")
                 .contains("EXIT_OK").contains("(1.5s)");
     }
+
+    @Test
+    @DisplayName("The tape survives the JVM: journal writes and reloads")
+    void journalRoundTrips(@org.junit.jupiter.api.io.TempDir java.io.File dir) {
+        java.io.File journal = new java.io.File(dir, "flight.jsonl");
+
+        FlightRecorder first = new FlightRecorder(now::get);
+        first.attachJournal(journal);
+        first.line("FORGE", "$ npm run build", false);
+        tick(1_200);
+        first.line("FORGE", "[exit 0]", false);
+        assertThat(journal).exists();
+
+        FlightRecorder reborn = new FlightRecorder(now::get);
+        reborn.attachJournal(journal);
+        assertThat(reborn.timeline()).hasSize(2);
+        assertThat(reborn.timeline().get(1).kind()).isEqualTo(Kind.EXIT_OK);
+        assertThat(reborn.timeline().get(1).durationMs()).isEqualTo(1_200);
+    }
+
+    @Test
+    @DisplayName("A corrupt journal line is skipped, not fatal")
+    void corruptJournalLineSkipped(@org.junit.jupiter.api.io.TempDir java.io.File dir) throws Exception {
+        java.io.File journal = new java.io.File(dir, "flight.jsonl");
+        java.nio.file.Files.writeString(journal.toPath(),
+                FlightRecorder.eventToJson(new FlightRecorder.Event(1, "A", Kind.LAUNCH, "x", -1))
+                + "\n{garbage\n");
+        FlightRecorder rec2 = new FlightRecorder(now::get);
+        rec2.attachJournal(journal);
+        assertThat(rec2.timeline()).hasSize(1);
+    }
 }

--- a/rack/src/test/java/org/nmox/studio/rack/service/AimPriorityTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/service/AimPriorityTest.java
@@ -28,4 +28,26 @@ class AimPriorityTest {
         assertThat(service.getRack().getProjectDir()).isEqualTo(projectA);
         service.getRack().shutdown();
     }
+
+    @TempDir
+    java.io.File projectB;
+
+    @Test
+    @DisplayName("Passive aims may follow each other but never override an explicit aim")
+    void passiveNeverOverridesExplicit() {
+        RackService service = new RackService();
+
+        // passive then passive: later passive wins (cold-start restore order)
+        service.openProjectPassively(projectA);
+        assertThat(service.isAimed()).as("passive aim claims no intent").isFalse();
+        service.openProjectPassively(projectB);
+        assertThat(service.getRack().getProjectDir()).isEqualTo(projectB);
+
+        // explicit beats everything after it
+        service.openProject(projectA);
+        service.openProjectPassively(projectB);
+        assertThat(service.getRack().getProjectDir())
+                .as("passive must not clobber explicit").isEqualTo(projectA);
+        service.getRack().shutdown();
+    }
 }

--- a/rack/src/test/java/org/nmox/studio/rack/service/SessionStateTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/service/SessionStateTest.java
@@ -1,0 +1,68 @@
+package org.nmox.studio.rack.service;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.rack.devices.DeviceType;
+import org.nmox.studio.rack.model.Rack;
+import org.nmox.studio.rack.model.RackDevice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** The resurrection contract: state round-trips and matches safely. */
+class SessionStateTest {
+
+    @Test
+    @DisplayName("Session state round-trips through JSON")
+    void roundTrips() {
+        SessionState state = new SessionState("/p", 123L, List.of(
+                new SessionState.Entry(2, "dev-server", "SURGE"),
+                new SessionState.Entry(0, "console", "MONITOR")));
+        SessionState back = SessionState.fromJson(state.toJson());
+        assertThat(back).isEqualTo(state);
+    }
+
+    @Test
+    @DisplayName("Matching is positional AND typed: rearranged racks never resurrect the wrong unit")
+    void matchesSafely() {
+        Rack rack = new Rack();
+        try {
+            RackDevice monitor = DeviceType.CONSOLE.create();
+            RackDevice surge = DeviceType.DEV_SERVER.create();
+            rack.addDevice(monitor);
+            rack.addDevice(surge);
+
+            // session recorded SURGE at index 1: exact match resumes
+            SessionState good = new SessionState(rack.getProjectDir().getAbsolutePath(), 1,
+                    List.of(new SessionState.Entry(1, "dev-server", "SURGE")));
+            assertThat(good.matchAgainst(rack)).containsExactly(surge);
+
+            // same index, different type (patch was rearranged): no match
+            SessionState moved = new SessionState("x", 1,
+                    List.of(new SessionState.Entry(0, "dev-server", "SURGE")));
+            assertThat(moved.matchAgainst(rack)).isEmpty();
+
+            // index out of range: no match, no exception
+            SessionState gone = new SessionState("x", 1,
+                    List.of(new SessionState.Entry(9, "dev-server", "SURGE")));
+            assertThat(gone.matchAgainst(rack)).isEmpty();
+        } finally {
+            rack.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("Corrupt JSON is a null session, not an exception")
+    void corruptJsonIsNull() {
+        assertThat(SessionState.fromJson("{nope")).isNull();
+        assertThat(SessionState.fromJson("{}")).isNull();
+    }
+
+    @Test
+    @DisplayName("Freshness: week-old sessions are history, not intent")
+    void staleSessionsExpire() {
+        assertThat(new SessionState("/p", System.currentTimeMillis(), List.of()).fresh()).isTrue();
+        assertThat(new SessionState("/p", System.currentTimeMillis() - 8L * 24 * 3600 * 1000,
+                List.of()).fresh()).isFalse();
+    }
+}


### PR DESCRIPTION
## The idea

Mosh beat SSH by treating the session as **state to resynchronize** rather than a stream that dies with the connection. Applied to the IDE: quit, crash, `kill -9`, power loss — your working session should come back.

## What ships

- **The tape survives the JVM** — FlightRecorder journals events as JSONL in the userdir (load at start, append live, size-capped rotation). BLACKBOX remembers across sessions.
- **Continuous session snapshot** — every 5s, per project: which devices are live. Written continuously precisely so it survives unclean death. An ignored resume offer survives another restart (the file is only consumed after this process saw tools run).
- **Resurrection** — aim at a project whose last session died with tools running and a notification offers them back; one click re-fires each device. Matching is positional **and** typed (a rearranged patch can't resurrect the wrong unit); week-old sessions expire.
- **Aim semantics refined** — passive aims (open-projects follower, persisted window state) may follow each other; explicit aims outrank all of them.

## Proven live, the hard way

Started vite through SURGE → `kill -9` the IDE mid-serve (no shutdown hooks) → relaunched → clicked the resume notification → **HTTP 200 on localhost:5173** from a fresh vite tree. The session outlived the process.

## Tests

Journal round-trip + corrupt-line tolerance · SessionState JSON round-trip · positional+typed matching · freshness expiry · passive-vs-explicit aim priority. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)