### PR TITLE
Docs: real changelog (1.0.0–1.3.0) + truthful Features section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,110 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to NMOX Studio are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-- Initial project structure.
-- Added simple UI that displays "DON'T PANIC".
+
+## [1.3.0] — 2026-06-12
+
+### Added
+- **Session Resurrection** — the IDE survives its own death, mosh-style.
+  The rack's running state is snapshotted continuously (every 5s, per
+  project), so it survives clean quits, crashes, `kill -9`, and power loss.
+  Return to a project whose last session died with tools running and a
+  notification offers them back: one click restarts your dev server,
+  watcher, and friends. Proven by SIGKILL-ing the IDE mid-serve and
+  resurrecting vite with one click.
+- **Persistent flight tape** — BLACKBOX's recorder journals to disk and
+  reloads at startup, so the session timeline spans restarts.
+
+### Changed
+- Aim semantics: an explicit project choice (wizard, Workbench, Open…)
+  is never clobbered by passive sources (persisted window state, the
+  open-projects follower); passive sources may still follow each other.
+- CI runs on Node 24 action majors (`checkout@v5`, `setup-java@v5`,
+  `upload-artifact@v5`, `download-artifact@v5`) ahead of GitHub's
+  2026-06-16 forcing date.
+
+## [1.2.1] — 2026-06-12
+
+### Fixed
+- Three workflow bugs found by hand-walking the happy path:
+  - Opening the Task Rack no longer re-aims the IDE at last session's
+    project, clobbering the project you just created.
+  - The flight recorder records from application startup, not from the
+    first time a BLACKBOX is racked — the tape no longer misses the flight.
+  - New projects start versioned: `git init` plus an initial commit, so
+    TIMELINE and the platform's git integration work from minute one.
+
+## [1.2.0] — 2026-06-12
+
+### Added
+- **BLACKBOX Flight Recorder** — every launch, exit, duration, and error
+  on a scrollable session timeline, with per-device duration statistics
+  and a slow-creep alarm that notices when a build quietly doubles.
+- **SONAR Port Radar** — every listening port mapped to its owning
+  process (docker containers labeled), with browse and confirmed
+  one-click kill. EADDRINUSE, solved.
+- **Docker Manager** shortcut in the Workbench's TOOLING shelf.
+
+## [1.1.0] — 2026-06-12
+
+### Added
+- **HARBOR Docker Engine** rack device — ENGINE LED tracking the daemon,
+  LCDs for containers up / images held / total reclaimable disk, and an
+  always-safe PRUNE.
+- **The Docker Panel** — a six-tab control room: the `system df` disk
+  ledger with one-click per-category RECLAIM, live container management
+  with browser-jump ports, image pull/tag/history/quick-run/cleanup,
+  volumes, networks, and **Dockerize**: production multi-stage
+  Dockerfiles, `.dockerignore`, and `compose.yaml` generated from the
+  project's detected toolchain.
+
+## [1.0.1] — 2026-06-12
+
+### Fixed
+- The branded splash screen, window icons, and About page actually ship.
+  (A global `*.jar` gitignore silently excluded the `core.jar/` branding
+  directories for the project's entire history; v1.0.0 artifacts showed
+  the stock NetBeans splash.)
+
+## [1.0.0] — 2026-06-12
+
+Initial release. (Earlier in its life this project's entire UI displayed
+"DON'T PANIC". We kept the spirit.)
+
+### Added
+- **The Task Rack** — a Reason-style rack where every web-dev task is a
+  hardware device: knobs, LEDs, LCDs, and patch cables. Wire OK jacks
+  together and one keypress runs your pipeline. 28 devices at launch,
+  presets, patch persistence per project, and CI export of any patch to
+  a GitHub Actions workflow.
+- **Polyglot editing** — 30+ languages via TextMate grammars activated
+  through NetBeans CSL; LSP providers for 31 MIMEs with ordered
+  fallbacks; comment-aware spellcheck; typing intelligence; the NMOX
+  Phosphor dark theme.
+- **The Workbench** — a home base: current project with detected
+  toolchain chips, open and recent files, projects, and the tooling shelf.
+- **Project Studio** — templates (React, Vue, Svelte, Express, vanilla,
+  TypeScript library, Python, Go), file CRUD, package.json editor.
+- **Infra Designer** — Node-RED-style multi-cloud infrastructure flows
+  for DigitalOcean, Hetzner, and Cloudflare, with cost estimates,
+  dry-run planning, and live deploys.
+- **Rock-solid guarantees, tested in CI with real tools** — a gauntlet
+  that runs actual `npm install`/build/test/serve through the rack on
+  every commit; a synchronous process reaper so quitting the IDE never
+  orphans a dev server; human-readable failure modes; big-project
+  performance rails.
+- Installers for macOS (DMG), Windows (setup.exe), and Linux
+  (tar.gz/deb), plus a portable zip — built and published by a
+  tag-triggered release workflow.
+
+[Unreleased]: https://github.com/NMOX/NMOX-Studio/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/NMOX/NMOX-Studio/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/NMOX/NMOX-Studio/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/NMOX/NMOX-Studio/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/NMOX/NMOX-Studio/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/NMOX/NMOX-Studio/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/NMOX/NMOX-Studio/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -30,41 +30,47 @@ Grab **[the latest release](https://github.com/NMOX/NMOX-Studio/releases/latest)
 
 ## Features
 
-### ☁️ **Cloud Provider Integration**
-- **Multi-Cloud Support**: Deploy to AWS, Azure, Google Cloud Platform
-- **Unified Interface**: Single pane of glass for all cloud resources
-- **Cost Management**: Track and forecast cloud spending across providers
-- **Resource Management**: Create, configure, and manage VMs, networks, and storage
+### 🎛️ The Task Rack
+Every web-dev task is a hardware device — knobs, LEDs, LCDs, patch cables.
+Wire OK jacks together (Tab flips the rack) and one keypress runs install →
+build → test, with output scrolling on a phosphor monitor. 31 devices:
+package managers, bundlers, test runners, dev servers, linters, formatters,
+git, deploy, HTTP, tunnels, load bench, file watcher, clock, and more.
+Patches persist per project, ship as presets, and export to GitHub Actions.
 
-### 🐳 **Container & Orchestration**
-- **Docker Integration**: Full Docker container lifecycle management
-- **Kubernetes Support**: Deploy and manage applications on K8s clusters
-- **Container Registry**: Push/pull images from Docker Hub, ECR, ACR, GCR
-- **Helm Charts**: Deploy complex applications using Helm
+### 🧠 The rack remembers, sees, and survives
+- **BLACKBOX** records every launch, exit, duration, and error on a session
+  timeline that persists across restarts — with a slow-creep alarm that
+  notices when your build quietly doubles.
+- **SONAR** maps every listening port to its owning process (docker
+  containers labeled) with one-click kill. EADDRINUSE, solved.
+- **Session Resurrection**: crash, `kill -9`, or power loss — relaunch and
+  the IDE offers your running dev servers back. One click and they're alive.
 
-### 🚀 **Deployment Management**
-- **CI/CD Pipeline**: Integrated deployment pipelines
-- **Blue-Green Deployments**: Zero-downtime deployment strategies
-- **Rollback Support**: One-click rollback to previous versions
-- **Environment Management**: Dev, staging, and production environments
+### 🐳 First-class Docker
+The HARBOR device tracks the daemon (containers up, images held, disk
+reclaimable) and opens the Docker Panel: a disk-reclaim ledger, live
+container management with browser-jump ports, image tooling, volumes,
+networks — and **Dockerize**, which generates production multi-stage
+Dockerfiles from your project's detected toolchain.
 
-### 📊 **Monitoring & Observability**
-- **Real-time Metrics**: CPU, memory, network, and custom metrics
-- **Log Aggregation**: Centralized log viewing across all services
-- **Health Checks**: Automatic health monitoring and alerting
-- **Performance Analysis**: Identify bottlenecks and optimize resources
+### ⌨️ Polyglot editing
+30+ languages with syntax highlighting (TextMate grammars through NetBeans
+CSL), LSP for 31 MIMEs with ordered server fallbacks, typing intelligence,
+comment-aware spellcheck, and the NMOX Phosphor dark theme.
 
-### 🕸️ **Microservices Architecture**
-- **Service Discovery**: Automatic service registration and discovery
-- **API Gateway Management**: Configure and manage API gateways
-- **Service Mesh**: Integration with Istio and Linkerd
-- **Dependency Visualization**: Interactive service topology maps
+### 🏗️ Projects and infrastructure
+The Workbench home base (toolchain chips, open/recent files, tooling
+shelf), Project Studio templates that scaffold versioned, rack-wired
+projects, and a Node-RED-style Infra Designer for DigitalOcean, Hetzner,
+and Cloudflare with cost estimates and dry-run planning.
 
-### 🖥️ **Professional IDE Features**
-- **Modern UI**: Dockable windows with customizable layouts
-- **Project Management**: Organize deployments, services, and configurations
-- **Integrated Terminal**: Execute commands directly within the IDE
-- **Git Integration**: Version control for infrastructure as code
+### ✅ Proven, not promised
+CI runs real `npm install`/build/test/serve through the actual rack devices
+on every commit. Quitting the IDE reaps every child process — no orphaned
+dev servers, guaranteed and tested.
+
+See the [CHANGELOG](CHANGELOG.md) for the full release history.
 
 ## Quick Start
 


### PR DESCRIPTION
- `CHANGELOG.md`: Keep-a-Changelog format covering all six releases (1.0.0 → 1.3.0) with compare links; the original "DON'T PANIC" placeholder's spirit is preserved in the 1.0.0 entry.
- `README.md`: the Features section still described the pre-v0.1 aspirational cloud-deployment IDE; rewritten to describe what actually ships — the rack, BLACKBOX/SONAR, Session Resurrection, HARBOR/Docker Panel, polyglot editing, Workbench/Studio/Infra Designer, and the real-tools CI gauntlet. Changelog linked.

Both files are maintained with every release going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)