### PR TITLE
Tests: PREFLIGHT run-loop with real tools; journal rotation

### DIFF
--- a/rack/src/test/java/org/nmox/studio/rack/devices/PreflightDeviceTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/PreflightDeviceTest.java
@@ -1,0 +1,142 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nmox.studio.rack.engine.ToolLocator;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.Rack;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * The PREFLIGHT run-loop against real tools: the planner is unit
+ * tested elsewhere; this proves the device actually runs the list,
+ * reaches a verdict, and fires the right trigger - the jack that
+ * gates deploys.
+ */
+class PreflightDeviceTest {
+
+    @TempDir
+    Path projectDir;
+
+    private Rack rack;
+
+    @BeforeAll
+    static void requireTools() {
+        assumeTrue(toolOnPath("git"), "git not installed");
+        assumeTrue(toolOnPath("node"), "node not installed");
+    }
+
+    private static boolean toolOnPath(String tool) {
+        for (String dir : ToolLocator.augmentedPath().split(File.pathSeparator)) {
+            if (new File(dir, tool).canExecute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (rack != null) {
+            rack.shutdown();
+        }
+    }
+
+    /** A project whose whole checklist can pass in well under a second. */
+    private void writeCleanProject() throws Exception {
+        Files.writeString(projectDir.resolve("package.json"), """
+                {"name":"pf","scripts":{
+                  "test":"node -e \\"process.exit(0)\\"",
+                  "build":"node -e \\"process.exit(0)\\""
+                }}
+                """);
+        run("git", "init");
+        run("git", "add", "-A");
+        run("git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-m", "x");
+    }
+
+    private void run(String... cmd) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(cmd).directory(projectDir.toFile())
+                .redirectErrorStream(true);
+        pb.environment().put("PATH", ToolLocator.augmentedPath());
+        Process p = pb.start();
+        p.getInputStream().readAllBytes();
+        p.waitFor(30, TimeUnit.SECONDS);
+    }
+
+    private static final class Probe extends RackDevice {
+
+        final CountDownLatch ok = new CountDownLatch(1);
+        final CountDownLatch fail = new CountDownLatch(1);
+
+        Probe() {
+            super("probe", "PROBE", "PROBE", new Color(0, 0, 0), 1);
+            addInPort("okIn", "OK", SignalType.TRIGGER);
+            addInPort("failIn", "FAIL", SignalType.TRIGGER);
+        }
+
+        @Override
+        public void receive(Port in, Signal signal) {
+            if ("okIn".equals(in.getId())) {
+                ok.countDown();
+            } else {
+                fail.countDown();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("A clean project earns OK on the deploy-gating jack")
+    void cleanProjectFiresOk() throws Exception {
+        writeCleanProject();
+        rack = new Rack();
+        rack.setProjectDir(projectDir.toFile());
+        PreflightDevice preflight = new PreflightDevice();
+        Probe probe = new Probe();
+        rack.addDevice(preflight);
+        rack.addDevice(probe);
+        rack.connect(preflight.getPort("ok"), probe.getPort("okIn"));
+        rack.connect(preflight.getPort("fail"), probe.getPort("failIn"));
+
+        preflight.receive(preflight.getPort("run"), Signal.trigger(true));
+
+        assertThat(probe.ok.await(60, TimeUnit.SECONDS))
+                .as("all checks pass -> OK fires").isTrue();
+        assertThat(probe.fail.getCount()).as("FAIL must not fire").isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("A dirty tree blocks the verdict: FAIL fires, OK does not")
+    void dirtyTreeFiresFail() throws Exception {
+        writeCleanProject();
+        Files.writeString(projectDir.resolve("uncommitted.js"), "// not committed");
+        rack = new Rack();
+        rack.setProjectDir(projectDir.toFile());
+        PreflightDevice preflight = new PreflightDevice();
+        Probe probe = new Probe();
+        rack.addDevice(preflight);
+        rack.addDevice(probe);
+        rack.connect(preflight.getPort("ok"), probe.getPort("okIn"));
+        rack.connect(preflight.getPort("fail"), probe.getPort("failIn"));
+
+        preflight.receive(preflight.getPort("run"), Signal.trigger(true));
+
+        assertThat(probe.fail.await(60, TimeUnit.SECONDS))
+                .as("git unclean -> FAIL fires").isTrue();
+        assertThat(probe.ok.getCount()).as("OK must not fire").isEqualTo(1);
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/engine/FlightRecorderTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/engine/FlightRecorderTest.java
@@ -125,4 +125,30 @@ class FlightRecorderTest {
         rec2.attachJournal(journal);
         assertThat(rec2.timeline()).hasSize(1);
     }
+
+    @Test
+    @DisplayName("The journal rotates at its cap, keeping the newer half, still loadable")
+    void journalRotates(@org.junit.jupiter.api.io.TempDir java.io.File dir) {
+        java.io.File journal = new java.io.File(dir, "flight.jsonl");
+        FlightRecorder writer = new FlightRecorder(now::get);
+        writer.attachJournal(journal);
+
+        // ~20k events at ~90 bytes/line crosses the 1.5MB cap and rotates
+        for (int i = 0; i < 20_000; i++) {
+            tick(1);
+            writer.line("FORGE", "$ build-" + i, false);
+        }
+
+        assertThat(journal.length())
+                .as("rotation must keep the file near its cap, not unbounded")
+                .isLessThan(2_000_000);
+
+        FlightRecorder reborn = new FlightRecorder(now::get);
+        reborn.attachJournal(journal);
+        assertThat(reborn.timeline()).isNotEmpty();
+        var lastLoaded = reborn.timeline().get(reborn.timeline().size() - 1);
+        assertThat(lastLoaded.text())
+                .as("the newest event survives rotation")
+                .isEqualTo("build-19999");
+    }
 }


### PR DESCRIPTION
Backfilling thin coverage per the standing tests-as-we-go rule:

- **`PreflightDeviceTest`** — the device's actual run-loop against real tools: temp project with a git repo + node scripts; clean tree → OK jack fires (FAIL silent); one uncommitted file → FAIL fires (OK silent). The deploy-gating jack itself is under test. Tool-gated, runs on CI.
- **`FlightRecorderTest.journalRotates`** — 20k events cross the journal cap; the file stays bounded and a fresh recorder still loads the newest event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)