### PR TITLE
Bundle a jlinked Java runtime in every installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           path: |
             NMOX-Studio-*-portable.zip
             application/target/dist/NMOX-Studio-*-linux.tar.gz
-            application/target/dist/nmox-studio_*_all.deb
+            application/target/dist/nmox-studio_*.deb
 
   macos:
     needs: version
@@ -86,6 +86,15 @@ jobs:
           (Get-Content $f) -replace 'currentVersion=NMOX Studio .*', 'currentVersion=NMOX Studio ${{ needs.version.outputs.version }}' | Set-Content $f
       - name: Build application
         run: mvn -B clean package -DskipTests
+      - name: Bundle Java runtime
+        shell: pwsh
+        run: |
+          & "$env:JAVA_HOME\bin\jlink.exe" `
+            --module-path "$env:JAVA_HOME\jmods" `
+            --add-modules ALL-MODULE-PATH `
+            --strip-debug --no-header-files --no-man-pages `
+            --output application\target\nmoxstudio\jre
+          Add-Content application\target\nmoxstudio\etc\nmoxstudio.conf "`n# bundled runtime: the app runs on its own Java, whatever the host has`njdkhome=`"jre`""
       - name: Install Inno Setup
         run: choco install innosetup --no-progress -y
       - name: Build installer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **The installers no longer depend on the user's Java.** The DMG,
+  Windows setup, tar.gz and deb now embed a jlinked Java runtime
+  (`jre/` inside the app, `jdkhome="jre"` in its conf), so machines
+  with no Java — or only a legacy Java 8, which previously booted the
+  IDE far enough to die on a "Java 17 or newer required" dialog — just
+  work. The macOS launcher probes the bundled runtime, falls back to
+  an installed JDK 17+, and otherwise explains itself in a real dialog
+  instead of failing cryptically. The deb is now honest about being
+  `amd64` (it carries a native runtime) and no longer recommends a
+  system JRE. Only the portable zip still expects a host Java 17+.
+
 ## [1.4.0] — 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NMOX Studio is an IDE for web development with a twist: your tooling lives in a 
 
 ## Download
 
-Grab **[the latest release](https://github.com/NMOX/NMOX-Studio/releases/latest)** — DMG (macOS), installer (Windows), tar.gz/deb (Linux), or portable zip. Requires Java 17+.
+Grab **[the latest release](https://github.com/NMOX/NMOX-Studio/releases/latest)** — DMG (macOS), installer (Windows), tar.gz/deb (Linux), or portable zip. The DMG, installer, tar.gz and deb ship with their own Java runtime — nothing to install. (The portable zip alone expects a Java 17+ on the machine.)
 
 > **macOS note:** the app is not yet notarized. If Gatekeeper objects, right-click the app and choose *Open*, or run `xattr -d com.apple.quarantine "/Applications/NMOX Studio.app"`.
 

--- a/packaging/linux/build-packages.sh
+++ b/packaging/linux/build-packages.sh
@@ -21,6 +21,7 @@ mkdir -p "$TAR_STAGE/nmox-studio-$VERSION"
 cp -R "$APP_INPUT"/. "$TAR_STAGE/nmox-studio-$VERSION/"
 chmod +x "$TAR_STAGE/nmox-studio-$VERSION/bin/nmoxstudio" \
          "$TAR_STAGE/nmox-studio-$VERSION/platform/lib/nbexec" 2>/dev/null || true
+./packaging/tools/bundle-jre.sh "$TAR_STAGE/nmox-studio-$VERSION"
 tar -czf "$DIST/NMOX-Studio-${VERSION}-linux.tar.gz" -C "$TAR_STAGE" "nmox-studio-$VERSION"
 echo "    $DIST/NMOX-Studio-${VERSION}-linux.tar.gz"
 
@@ -42,6 +43,10 @@ mkdir -p "$DEB_STAGE/DEBIAN" \
 cp -R "$APP_INPUT"/. "$DEB_STAGE/opt/nmox-studio/"
 chmod +x "$DEB_STAGE/opt/nmox-studio/bin/nmoxstudio" \
          "$DEB_STAGE/opt/nmox-studio/platform/lib/nbexec" 2>/dev/null || true
+# reuse the runtime already jlinked for the tar.gz; conf line comes with it
+cp -R "$TAR_STAGE/nmox-studio-$VERSION/jre" "$DEB_STAGE/opt/nmox-studio/jre"
+cp "$TAR_STAGE/nmox-studio-$VERSION/etc/nmoxstudio.conf" \
+   "$DEB_STAGE/opt/nmox-studio/etc/nmoxstudio.conf"
 cp packaging/icons/nmox-studio-512.png "$DEB_STAGE/usr/share/icons/hicolor/512x512/apps/nmox-studio.png"
 cp packaging/icons/nmox-studio-128.png "$DEB_STAGE/usr/share/icons/hicolor/128x128/apps/nmox-studio.png"
 
@@ -69,18 +74,19 @@ Package: nmox-studio
 Version: ${VERSION}
 Section: devel
 Priority: optional
-Architecture: all
+Architecture: amd64
 Installed-Size: ${INSTALLED_SIZE}
 Depends: bash
-Recommends: openjdk-17-jre | java17-runtime, nodejs, npm, git
+Recommends: nodejs, npm, git
 Maintainer: NMOX <david.liedle@gmail.com>
 Homepage: https://github.com/NMOX/NMOX-Studio
 Description: Web development IDE with a Reason-style task rack
  NMOX Studio is a NetBeans Platform IDE for modern web development.
  Tasks - build, test, serve, lint, deploy - are hardware-style rack
- devices patched together with cables. Requires Java 17 or newer.
+ devices patched together with cables. Ships with its own Java
+ runtime; no Java installation is required.
 CONTROL
 
 dpkg-deb --build --root-owner-group "$DEB_STAGE" \
-    "$DIST/nmox-studio_${VERSION}_all.deb" >/dev/null
-echo "    $DIST/nmox-studio_${VERSION}_all.deb"
+    "$DIST/nmox-studio_${VERSION}_amd64.deb" >/dev/null
+echo "    $DIST/nmox-studio_${VERSION}_amd64.deb"

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -26,6 +26,9 @@ cp -R "$APP_INPUT" "$BUNDLE/Contents/Resources/nmoxstudio"
 chmod +x "$BUNDLE/Contents/Resources/nmoxstudio/bin/nmoxstudio" \
          "$BUNDLE/Contents/Resources/nmoxstudio/platform/lib/nbexec" 2>/dev/null || true
 
+echo "==> Bundling Java runtime"
+./packaging/tools/bundle-jre.sh "$BUNDLE/Contents/Resources/nmoxstudio"
+
 echo "==> Building icns"
 iconutil -c icns packaging/icons/nmox-studio.iconset \
     -o "$BUNDLE/Contents/Resources/nmox-studio.icns"
@@ -34,13 +37,19 @@ echo "==> Writing launcher"
 cat > "$BUNDLE/Contents/MacOS/nmox-studio" <<'LAUNCHER'
 #!/bin/sh
 DIR=$(cd "$(dirname "$0")" && pwd)
-# macOS GUI launches carry no shell env: locate a JDK 17+ the native
-# way so users with a JDK installed never see the "Java required" dialog
+RES="$DIR/../Resources/nmoxstudio"
+# The app ships its own Java runtime (jre/, jdkhome in the conf). Probe
+# it actually runs on this machine (an arch mismatch must not strand the
+# user), else fall back to an installed JDK 17+, else say so plainly.
+if "$RES/jre/bin/java" -version >/dev/null 2>&1; then
+    exec "$RES/bin/nmoxstudio" "$@"
+fi
 JDK=$(/usr/libexec/java_home -v 17+ 2>/dev/null || true)
 if [ -n "$JDK" ]; then
-    exec "$DIR/../Resources/nmoxstudio/bin/nmoxstudio" --jdkhome "$JDK" "$@"
+    exec "$RES/bin/nmoxstudio" --jdkhome "$JDK" "$@"
 fi
-exec "$DIR/../Resources/nmoxstudio/bin/nmoxstudio" "$@"
+osascript -e 'display dialog "NMOX Studio could not start its bundled Java runtime on this machine, and no Java 17+ installation was found.\n\nInstall a JDK 17 or newer (for example Temurin from adoptium.net) and launch again." buttons {"OK"} default button 1 with title "NMOX Studio" with icon caution' >/dev/null 2>&1 || true
+exit 1
 LAUNCHER
 chmod +x "$BUNDLE/Contents/MacOS/nmox-studio"
 

--- a/packaging/tools/bundle-jre.sh
+++ b/packaging/tools/bundle-jre.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Embeds a jlinked Java runtime inside an NMOX Studio cluster so the
+# installed app never depends on the user's Java. Idempotent.
+#
+#   ./packaging/tools/bundle-jre.sh <cluster-dir>
+#
+# Produces <cluster-dir>/jre and appends jdkhome="jre" to
+# etc/nmoxstudio.conf (the launcher resolves a relative jdkhome
+# against the cluster root). Requires a JDK with jmods (any 17+).
+set -euo pipefail
+
+CLUSTER="${1:?usage: bundle-jre.sh <cluster-dir>}"
+[ -d "$CLUSTER" ] || { echo "ERROR: $CLUSTER missing"; exit 1; }
+
+JDK="${JAVA_HOME:-$(/usr/libexec/java_home -v 17+ 2>/dev/null || true)}"
+[ -n "$JDK" ] && [ -d "$JDK/jmods" ] || {
+    echo "ERROR: need a JDK with jmods (JAVA_HOME=$JDK)"; exit 1; }
+
+if [ -x "$CLUSTER/jre/bin/java" ]; then
+    echo "==> bundled jre already present"
+else
+    echo "==> jlinking runtime from $JDK"
+    rm -rf "$CLUSTER/jre"
+    "$JDK/bin/jlink" \
+        --module-path "$JDK/jmods" \
+        --add-modules ALL-MODULE-PATH \
+        --strip-debug --no-header-files --no-man-pages \
+        --output "$CLUSTER/jre"
+fi
+
+CONF="$CLUSTER/etc/nmoxstudio.conf"
+if ! grep -q '^jdkhome=' "$CONF"; then
+    {
+        echo ''
+        echo '# bundled runtime: the app runs on its own Java, whatever the host has'
+        echo 'jdkhome="jre"'
+    } >> "$CONF"
+    echo "==> jdkhome=\"jre\" written to etc/nmoxstudio.conf"
+fi
+echo "==> bundled runtime: $(du -sh "$CLUSTER/jre" | cut -f1)"


### PR DESCRIPTION
## What

Fixes the "Java 17 or newer required" dialog users hit when launching the installed release on machines without a modern JDK.

**Root cause:** the launch chain was best-effort all the way down — the macOS stub's `java_home -v 17+` finds nothing, stock `nbexec` falls back to *any* Java 1.8+, and the platform's `boot.jar` then rejects the old JVM with that dialog after the fact. A machine with only legacy Java 8 (or none) was stranded.

**Fix:** stop depending on the host's Java. Each installer now embeds a jlinked runtime:
- shared `packaging/tools/bundle-jre.sh` jlinks `$JAVA_HOME/jmods` into `<cluster>/jre` and writes `jdkhome="jre"` into the conf (the launcher resolves relative jdkhome against the cluster root — works on all OSes)
- macOS DMG: bundles the runtime; the stub probes it actually runs (arch-mismatch safe), falls back to an installed JDK 17+, else shows a plain-language dialog
- Linux tar.gz + deb: bundle the same runtime; deb becomes honest `amd64` and drops the system-JRE recommendation
- Windows: jlink step added to the workflow before Inno Setup; the installer already packages the whole cluster

The portable zip intentionally stays bring-your-own-Java (it's cross-platform; a native runtime inside would be a lie) — README says so.

## Verified

Built the DMG locally with the bundled runtime and launched via LaunchServices: the IDE runs on `…/Resources/nmoxstudio/jre/bin/java` with the host JDK out of play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)