### PR TITLE
Release assembly: match the amd64 deb name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,6 @@ jobs:
           files: |
             artifacts/**/NMOX-Studio-*-portable.zip
             artifacts/**/NMOX-Studio-*-linux.tar.gz
-            artifacts/**/nmox-studio_*_all.deb
+            artifacts/**/nmox-studio_*.deb
             artifacts/**/NMOX-Studio-*-macos.dmg
             artifacts/**/NMOX-Studio-*-windows-setup.exe


### PR DESCRIPTION
The deb was renamed nmox-studio_<v>_amd64.deb when it gained a bundled runtime; the release step still globbed _all.deb, so v1.4.1 published without it. Glob now matches both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)