### PR TITLE
Open and respect the web project's config layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **The config layer a web project is actually full of now opens as
+  itself.** Thirteen new TextMate grammars cover `.editorconfig` and
+  INI, ignore files (`.gitignore`/`.dockerignore`/…), GraphQL, Vue,
+  Svelte, Astro, Pug, Handlebars, Liquid, nginx, Makefile, Protocol
+  Buffers and Prisma; YAML/TOML/Dockerfile/SQL ride the platform's
+  native support. Comment-toggling works in all of them, and LSP
+  intelligence attaches where a standard server exists (yaml, taplo,
+  dockerfile, graphql, vue, svelte, astro, prisma).
+- **Dotfiles and bare names resolve by filename**, the way the
+  platform's own Dockerfile support does: `.editorconfig`, `.env`
+  (and `.env.*`), `.gitignore`, `Makefile`, `nginx.conf` and friends
+  now get their real MIME instead of opening as plain text.
+
+### Fixed
+- **Spellcheck no longer treats config files as prose.** A wrong token
+  property key meant comment detection silently failed for every
+  TextMate language, so the checker fell back to flagging keys and
+  values — `charset`, `indent_style` — as misspellings. Now it reads
+  the scope stack correctly and checks words only inside comments,
+  across all 40+ lexed languages.
+- **Config files with no toolchain no longer crash the editor on
+  open.** A CSL language binding routed them through a code path whose
+  lexer class was unreachable at document-load time; the TextMate
+  grammar alone carries the highlighting.
+
 ## [1.4.1] — 2026-06-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ![NMOX Studio — the Task Rack](docs/images/task-rack.png)
 
-NMOX Studio is an IDE for web development with a twist: your tooling lives in a Reason-style **Task Rack**. Every task — install, build, test, serve, lint, deploy — is a hardware-styled device with knobs, LEDs, and patch cables; wire OK jacks together and one keypress runs your whole pipeline, with errors landing on a phosphor monitor bus. Around the rack: a polyglot editor (30+ languages via TextMate grammars, NetBeans CSL, and LSP), a Workbench home base, a Node-RED-style multi-cloud infra designer (DigitalOcean, Hetzner, Cloudflare), and project templates. Built on the NetBeans Rich Client Platform; the core developer loop is proven against real `node`/`npm` in CI on every commit.
+NMOX Studio is an IDE for web development with a twist: your tooling lives in a Reason-style **Task Rack**. Every task — install, build, test, serve, lint, deploy — is a hardware-styled device with knobs, LEDs, and patch cables; wire OK jacks together and one keypress runs your whole pipeline, with errors landing on a phosphor monitor bus. Around the rack: a polyglot editor (45+ languages via TextMate grammars, NetBeans CSL, and LSP — code and the whole config layer, down to `.editorconfig` and `.env`), a Workbench home base, a Node-RED-style multi-cloud infra designer (DigitalOcean, Hetzner, Cloudflare), and project templates. Built on the NetBeans Rich Client Platform; the core developer loop is proven against real `node`/`npm` in CI on every commit.
 
 ## Download
 
@@ -55,11 +55,14 @@ networks — and **Dockerize**, which generates production multi-stage
 Dockerfiles from your project's detected toolchain.
 
 ### ⌨️ Polyglot editing
-32 languages with syntax highlighting (TextMate grammars through NetBeans
-CSL) — including first-class HTML, CSS, SCSS and Less with tag, attribute,
-value and property completion — LSP for 35 MIMEs with ordered server
-fallbacks, a regex-aware JavaScript lexer, typing intelligence,
-comment-aware spellcheck, and the NMOX Phosphor dark theme.
+45+ languages with syntax highlighting (TextMate grammars through NetBeans
+CSL) — code plus the whole config layer: `.editorconfig`, dotenv, ignore
+files, GraphQL, Vue, Svelte, Astro, Pug, Handlebars, Liquid, nginx,
+Makefile, Protocol Buffers, Prisma, YAML, TOML, Dockerfile. First-class
+HTML, CSS, SCSS and Less with tag, attribute, value and property
+completion; LSP with ordered server fallbacks; a regex-aware JavaScript
+lexer; typing intelligence; comment-only spellcheck (your keys and values
+are never flagged as typos); and the NMOX Phosphor dark theme.
 
 ### 🏗️ Projects and infrastructure
 The Workbench home base (toolchain chips, open/recent files, tooling

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/AstroGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/AstroGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Astro TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "astro.tmLanguage.json", mimeType = "text/x-astro")
+@MIMEResolver.ExtensionRegistration(displayName = "Astro", mimeType = "text/x-astro", extension = {"astro"})
+public final class AstroGrammar {
+
+    private AstroGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/ConfigFileResolver.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/ConfigFileResolver.java
@@ -1,0 +1,63 @@
+package org.nmox.studio.editor.grammars;
+
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.MIMEResolver;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * MIME resolution for the config files a web developer lives in that
+ * carry no usable extension: dotfiles like {@code .editorconfig} and
+ * {@code .env}, and bare names like {@code Makefile} and
+ * {@code nginx.conf}. NetBeans treats a leading-dot filename as all
+ * name and no extension, so the grammar classes' extension rules never
+ * fire for these - the file would open as plain text, losing both
+ * highlighting and (worse) gaining prose spellcheck on its keys and
+ * values. Matching the full name the way the platform's own
+ * DockerfileResolver does is the reliable path.
+ *
+ * Real extensions (.ini, .vue, .graphql, .proto, ...) stay on each
+ * grammar's {@code @MIMEResolver.ExtensionRegistration}; this covers
+ * only what extensions cannot.
+ */
+@ServiceProvider(service = MIMEResolver.class, position = 480)
+public final class ConfigFileResolver extends MIMEResolver {
+
+    public ConfigFileResolver() {
+        super("text/x-ini", "text/x-ignore", "text/x-properties",
+                "text/x-makefile", "text/x-nginx-conf", "text/x-markdown");
+    }
+
+    @Override
+    public String findMIMEType(FileObject fo) {
+        String name = fo.getNameExt();
+        switch (name) {
+            case ".editorconfig":
+            case ".npmrc":
+            case ".gitconfig":
+                return "text/x-ini";
+            case ".gitignore":
+            case ".dockerignore":
+            case ".npmignore":
+            case ".eslintignore":
+            case ".prettierignore":
+            case ".gitattributes":
+                return "text/x-ignore";
+            case "Makefile":
+            case "makefile":
+            case "GNUmakefile":
+                return "text/x-makefile";
+            case "nginx.conf":
+                return "text/x-nginx-conf";
+            default:
+                // dotenv family: .env, .env.local, .env.production, ...
+                if (name.equals(".env") || name.startsWith(".env.")) {
+                    return "text/x-properties";
+                }
+                // .mdx rides the platform's Markdown support
+                if ("mdx".equals(fo.getExt())) {
+                    return "text/x-markdown";
+                }
+                return null;
+        }
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/GraphqlGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/GraphqlGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Graphql TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "graphql.tmLanguage.json", mimeType = "text/x-graphql")
+@MIMEResolver.ExtensionRegistration(displayName = "GraphQL", mimeType = "text/x-graphql", extension = {"graphql", "gql"})
+public final class GraphqlGrammar {
+
+    private GraphqlGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/HandlebarsGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/HandlebarsGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Handlebars TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "handlebars.tmLanguage.json", mimeType = "text/x-handlebars")
+@MIMEResolver.ExtensionRegistration(displayName = "Handlebars", mimeType = "text/x-handlebars", extension = {"hbs", "handlebars"})
+public final class HandlebarsGrammar {
+
+    private HandlebarsGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/IgnoreGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/IgnoreGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Ignore TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "ignore.tmLanguage.json", mimeType = "text/x-ignore")
+@MIMEResolver.ExtensionRegistration(displayName = "Ignore Files", mimeType = "text/x-ignore", extension = {"gitignore", "dockerignore", "npmignore", "eslintignore", "prettierignore", "gcloudignore", "gitattributes"})
+public final class IgnoreGrammar {
+
+    private IgnoreGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/IniGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/IniGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Ini TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "ini.tmLanguage.json", mimeType = "text/x-ini")
+@MIMEResolver.ExtensionRegistration(displayName = "INI / EditorConfig", mimeType = "text/x-ini", extension = {"ini", "cfg", "editorconfig", "npmrc", "gitconfig"})
+public final class IniGrammar {
+
+    private IniGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/LiquidGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/LiquidGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Liquid TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "liquid.tmLanguage.json", mimeType = "text/x-liquid")
+@MIMEResolver.ExtensionRegistration(displayName = "Liquid", mimeType = "text/x-liquid", extension = {"liquid"})
+public final class LiquidGrammar {
+
+    private LiquidGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/MakefileGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/MakefileGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Makefile TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "makefile.tmLanguage.json", mimeType = "text/x-makefile")
+@MIMEResolver.ExtensionRegistration(displayName = "Makefile", mimeType = "text/x-makefile", extension = {"mk"})
+public final class MakefileGrammar {
+
+    private MakefileGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/NOTICE-grammars.md
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/NOTICE-grammars.md
@@ -35,3 +35,25 @@ redistributes them under MIT-compatible licenses. Upstream origins:
 To refresh: bump the tag in this table and re-download; the holder
 classes in this package register each grammar with the platform's
 textmate-lexer module.
+
+## Config-layer tranche (added 2026-06-12)
+
+| Grammar | Source | License |
+|---|---|---|
+| ini.tmLanguage.json | microsoft/vscode 1.95.0 extensions/ini | MIT |
+| ignore.tmLanguage.json | microsoft/vscode 1.95.0 extensions/git-base | MIT |
+| pug.tmLanguage.json | microsoft/vscode 1.95.0 extensions/pug | MIT |
+| handlebars.tmLanguage.json | microsoft/vscode 1.95.0 extensions/handlebars | MIT |
+| makefile.tmLanguage.json | microsoft/vscode 1.95.0 extensions/make | MIT |
+| graphql.tmLanguage.json | graphql/graphiql vscode-graphql-syntax | MIT |
+| vue.tmLanguage.json | vuejs/language-tools | MIT |
+| svelte.tmLanguage.json | sveltejs/language-tools, converted YAML→JSON | MIT |
+| astro.tmLanguage.json | withastro/language-tools | MIT |
+| liquid.tmLanguage.json | Shopify/liquid-tm-grammar | MIT |
+| nginx.tmLanguage.json | ahmadalli/vscode-nginx-conf, converted plist→JSON | MIT |
+| proto.tmLanguage.json | zxh0/vscode-proto3 (proto3.tmLanguage.json) | MIT |
+| prisma.tmLanguage.json | prisma/language-tools | Apache-2.0 |
+
+YAML, TOML, Markdown, Dockerfile, SQL and diff are intentionally NOT
+bundled here: the NetBeans ide cluster ships native editor support for
+those mimes, and a second registration would duplicate editors.

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/NginxGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/NginxGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Nginx TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "nginx.tmLanguage.json", mimeType = "text/x-nginx-conf")
+@MIMEResolver.ExtensionRegistration(displayName = "nginx", mimeType = "text/x-nginx-conf", extension = {"nginx"})
+public final class NginxGrammar {
+
+    private NginxGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/PrismaGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/PrismaGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Prisma TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "prisma.tmLanguage.json", mimeType = "text/x-prisma")
+@MIMEResolver.ExtensionRegistration(displayName = "Prisma", mimeType = "text/x-prisma", extension = {"prisma"})
+public final class PrismaGrammar {
+
+    private PrismaGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/ProtoGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/ProtoGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Proto TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "proto.tmLanguage.json", mimeType = "text/x-protobuf")
+@MIMEResolver.ExtensionRegistration(displayName = "Protocol Buffers", mimeType = "text/x-protobuf", extension = {"proto"})
+public final class ProtoGrammar {
+
+    private ProtoGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/PugGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/PugGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Pug TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "pug.tmLanguage.json", mimeType = "text/x-pug")
+@MIMEResolver.ExtensionRegistration(displayName = "Pug", mimeType = "text/x-pug", extension = {"pug", "jade"})
+public final class PugGrammar {
+
+    private PugGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/SvelteGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/SvelteGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Svelte TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "svelte.tmLanguage.json", mimeType = "text/x-svelte")
+@MIMEResolver.ExtensionRegistration(displayName = "Svelte", mimeType = "text/x-svelte", extension = {"svelte"})
+public final class SvelteGrammar {
+
+    private SvelteGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/grammars/VueGrammar.java
+++ b/editor/src/main/java/org/nmox/studio/editor/grammars/VueGrammar.java
@@ -1,0 +1,17 @@
+package org.nmox.studio.editor.grammars;
+
+import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
+import org.openide.filesystems.MIMEResolver;
+
+/**
+ * Registers the Vue TextMate grammar (see NOTICE-grammars.md for the
+ * pinned upstream) and its file extensions. The platform's
+ * textmate-lexer module does the tokenizing and theme mapping.
+ */
+@GrammarRegistration(grammar = "vue.tmLanguage.json", mimeType = "text/x-vue")
+@MIMEResolver.ExtensionRegistration(displayName = "Vue", mimeType = "text/x-vue", extension = {"vue"})
+public final class VueGrammar {
+
+    private VueGrammar() {
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServers.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServers.java
@@ -408,4 +408,78 @@ public final class LanguageServers {
         }
     }
 
+    // ---- the config layer -------------------------------------------------
+
+    /** YAML via yaml-language-server: CI files, compose, k8s manifests. */
+    @MimeRegistration(mimeType = "text/x-yaml", service = LanguageServerProvider.class)
+    public static final class YamlServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "yaml-language-server", "--stdio");
+        }
+    }
+
+    /** TOML via taplo (cargo/brew install taplo-cli). */
+    @MimeRegistration(mimeType = "text/x-toml", service = LanguageServerProvider.class)
+    public static final class TomlServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launch(lookup, List.of("taplo", "lsp", "stdio"));
+        }
+    }
+
+    /** Dockerfile via dockerfile-language-server-nodejs. */
+    @MimeRegistration(mimeType = "text/x-dockerfile", service = LanguageServerProvider.class)
+    public static final class DockerfileServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "docker-langserver", "--stdio");
+        }
+    }
+
+    /** GraphQL via graphql-language-service-cli. */
+    @MimeRegistration(mimeType = "text/x-graphql", service = LanguageServerProvider.class)
+    public static final class GraphqlServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "graphql-lsp", "server", "-m", "stream");
+        }
+    }
+
+    /** Vue single-file components via the official language server. */
+    @MimeRegistration(mimeType = "text/x-vue", service = LanguageServerProvider.class)
+    public static final class VueServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "vue-language-server", "--stdio");
+        }
+    }
+
+    /** Svelte components via svelte-language-server. */
+    @MimeRegistration(mimeType = "text/x-svelte", service = LanguageServerProvider.class)
+    public static final class SvelteServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "svelteserver", "--stdio");
+        }
+    }
+
+    /** Astro components via @astrojs/language-server. */
+    @MimeRegistration(mimeType = "text/x-astro", service = LanguageServerProvider.class)
+    public static final class AstroServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "astro-ls", "--stdio");
+        }
+    }
+
+    /** Prisma schemas via @prisma/language-server. */
+    @MimeRegistration(mimeType = "text/x-prisma", service = LanguageServerProvider.class)
+    public static final class PrismaServer implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            return launchNpm(lookup, "prisma-language-server", "--stdio");
+        }
+    }
+
 }

--- a/editor/src/main/java/org/nmox/studio/editor/polyglot/LanguageComments.java
+++ b/editor/src/main/java/org/nmox/studio/editor/polyglot/LanguageComments.java
@@ -44,7 +44,18 @@ public final class LanguageComments {
             Map.entry("text/x-crystal", "#"),
             // CSS proper has only block comments; its preprocessors add //
             Map.entry("text/x-scss", "//"),
-            Map.entry("text/x-less", "//"));
+            Map.entry("text/x-less", "//"),
+            // the config layer: .editorconfig, ignore files, infra configs
+            Map.entry("text/x-ini", "#"),
+            Map.entry("text/x-ignore", "#"),
+            Map.entry("text/x-graphql", "#"),
+            Map.entry("text/x-pug", "//"),
+            Map.entry("text/x-nginx-conf", "#"),
+            Map.entry("text/x-makefile", "#"),
+            Map.entry("text/x-protobuf", "//"),
+            Map.entry("text/x-prisma", "//"),
+            Map.entry("text/x-dockerfile", "#"),
+            Map.entry("text/x-sql", "--"));
 
     private LanguageComments() {
     }

--- a/editor/src/main/java/org/nmox/studio/editor/spell/CodeSpellTokenListProvider.java
+++ b/editor/src/main/java/org/nmox/studio/editor/spell/CodeSpellTokenListProvider.java
@@ -51,7 +51,25 @@ import org.netbeans.modules.spellchecker.spi.language.TokenListProvider;
     @MimeRegistration(mimeType = "text/x-crystal", service = TokenListProvider.class),
         @MimeRegistration(mimeType = "text/css", service = TokenListProvider.class),
         @MimeRegistration(mimeType = "text/x-scss", service = TokenListProvider.class),
-        @MimeRegistration(mimeType = "text/x-less", service = TokenListProvider.class)
+        @MimeRegistration(mimeType = "text/x-less", service = TokenListProvider.class),
+    // the config layer: values are not prose, only comments get spellcheck
+    @MimeRegistration(mimeType = "text/x-ini", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-ignore", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-graphql", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-vue", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-svelte", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-astro", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-pug", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-handlebars", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-liquid", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-nginx-conf", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-makefile", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-protobuf", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-prisma", service = TokenListProvider.class),
+    // platform-owned config mimes that ship without a comments-only binding
+    @MimeRegistration(mimeType = "text/x-yaml", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-toml", service = TokenListProvider.class),
+    @MimeRegistration(mimeType = "text/x-dockerfile", service = TokenListProvider.class)
 })
 public class CodeSpellTokenListProvider implements TokenListProvider {
 
@@ -130,13 +148,12 @@ public class CodeSpellTokenListProvider implements TokenListProvider {
         }
 
         private static boolean isComment(Token<?> token) {
-            String category = token.id().primaryCategory();
-            if (category != null && category.contains("comment")) {
-                return true;
-            }
-            // TextMate tokens: the real category lives in the scope list property
-            Object scopes = token.getProperty("scopes");
-            return scopes != null && scopes.toString().contains("comment");
+            // TextMate tokens carry a single id (TEXTMATE); the real scope
+            // stack lives in the "categories" property (a List of scope
+            // names like "comment.line.number-sign.ini"). The custom JS/TS
+            // lexer instead names the category "comment" on the id itself.
+            return isCommentScope(token.id().primaryCategory(),
+                    token.getProperty("categories"));
         }
 
         @Override
@@ -156,5 +173,21 @@ public class CodeSpellTokenListProvider implements TokenListProvider {
         @Override
         public void removeChangeListener(ChangeListener l) {
         }
+    }
+
+    /**
+     * Whether a token sits inside a comment, across both token shapes we
+     * lex: the custom lexers name the id category "comment"; TextMate
+     * exposes the scope stack as a "categories" property (a List whose
+     * entries look like "comment.line.number-sign.ini"). Reading the
+     * wrong property key here is what let prose spellcheck leak onto
+     * config-file keys and values.
+     */
+    static boolean isCommentScope(String primaryCategory, Object categoriesProperty) {
+        if (primaryCategory != null && primaryCategory.contains("comment")) {
+            return true;
+        }
+        return categoriesProperty != null
+                && categoriesProperty.toString().contains("comment");
     }
 }

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/astro.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/astro.tmLanguage.json
@@ -1,0 +1,846 @@
+{
+  "name": "Astro",
+  "scopeName": "source.astro",
+  "fileTypes": [
+    "astro"
+  ],
+  "injections": {
+    "L:(meta.script.astro) (meta.lang.json) - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.json",
+          "patterns": [
+            {
+              "include": "source.json"
+            }
+          ]
+        }
+      ]
+    },
+    "L:(meta.script.astro) (meta.lang.js | meta.lang.javascript | meta.lang.partytown | meta.lang.node) - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.js",
+          "patterns": [
+            {
+              "include": "source.js"
+            }
+          ]
+        }
+      ]
+    },
+    "L:(meta.script.astro) (meta.lang.ts | meta.lang.typescript) - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.ts",
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.script.astro - meta.lang - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.js",
+          "patterns": [
+            {
+              "include": "source.js"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.astro meta.lang.stylus - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.stylus",
+          "patterns": [
+            {
+              "include": "source.stylus"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.astro meta.lang.sass - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.sass",
+          "patterns": [
+            {
+              "include": "source.sass"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.astro meta.lang.css - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css",
+          "patterns": [
+            {
+              "include": "source.css"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.astro meta.lang.scss - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css.scss",
+          "patterns": [
+            {
+              "include": "source.css.scss"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.astro meta.lang.less - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css.less",
+          "patterns": [
+            {
+              "include": "source.css.less"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.astro meta.lang.postcss - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css.postcss",
+          "patterns": [
+            {
+              "include": "source.css.postcss"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.astro - meta.lang - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.astro",
+          "contentName": "source.css",
+          "patterns": [
+            {
+              "include": "source.css"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "include": "#scope"
+    },
+    {
+      "include": "#frontmatter"
+    },
+    {
+      "include": "#text"
+    }
+  ],
+  "repository": {
+    "frontmatter": {
+      "begin": "\\A(-{3})\\s*$",
+      "end": "(^|\\G)(-{3})|\\.{3}\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "2": {
+          "name": "comment"
+        }
+      },
+      "contentName": "source.ts",
+      "patterns": [
+        {
+          "include": "source.ts"
+        }
+      ]
+    },
+    "scope": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#tags"
+        },
+        {
+          "include": "#interpolation"
+        },
+        {
+          "include": "#entities"
+        }
+      ]
+    },
+    "comments": {
+      "begin": "<!--",
+      "end": "-->",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.astro"
+        }
+      },
+      "name": "comment.block.astro",
+      "patterns": [
+        {
+          "match": "\\G-?>|<!--(?!>)|<!-(?=-->)|--!>",
+          "name": "invalid.illegal.characters-not-allowed-here.astro"
+        }
+      ]
+    },
+    "interpolation": {
+      "patterns": [
+        {
+          "begin": "\\{",
+          "end": "\\}",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.begin.astro"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.astro"
+            }
+          },
+          "contentName": "meta.embedded.expression.astro source.tsx",
+          "patterns": [
+            {
+              "begin": "\\G\\s*(?={)",
+              "end": "(?<=})",
+              "patterns": [
+                {
+                  "include": "source.tsx#object-literal"
+                }
+              ]
+            },
+            {
+              "include": "source.tsx"
+            }
+          ]
+        }
+      ]
+    },
+    "entities": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.astro"
+            },
+            "912": {
+              "name": "punctuation.definition.entity.astro"
+            }
+          },
+          "match": "(?x)\n\t\t\t\t\t\t(&)\t(?=[a-zA-Z])\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\t(a(s(ymp(eq)?|cr|t)|n(d(slope|d|v|and)?|g(s(t|ph)|zarr|e|le|rt(vb(d)?)?|msd(a(h|c|d|e|f|a|g|b))?)?)|c(y|irc|d|ute|E)?|tilde|o(pf|gon)|uml|p(id|os|prox(eq)?|e|E|acir)?|elig|f(r)?|w(conint|int)|l(pha|e(ph|fsym))|acute|ring|grave|m(p|a(cr|lg))|breve)|A(s(sign|cr)|nd|MP|c(y|irc)|tilde|o(pf|gon)|uml|pplyFunction|fr|Elig|lpha|acute|ring|grave|macr|breve))\n\t\t\t\t\t\t  | (B(scr|cy|opf|umpeq|e(cause|ta|rnoullis)|fr|a(ckslash|r(v|wed))|reve)|b(s(cr|im(e)?|ol(hsub|b)?|emi)|n(ot|e(quiv)?)|c(y|ong)|ig(s(tar|qcup)|c(irc|up|ap)|triangle(down|up)|o(times|dot|plus)|uplus|vee|wedge)|o(t(tom)?|pf|wtie|x(h(d|u|D|U)?|times|H(d|u|D|U)?|d(R|l|r|L)|u(R|l|r|L)|plus|D(R|l|r|L)|v(R|h|H|l|r|L)?|U(R|l|r|L)|V(R|h|H|l|r|L)?|minus|box))|Not|dquo|u(ll(et)?|mp(e(q)?|E)?)|prime|e(caus(e)?|t(h|ween|a)|psi|rnou|mptyv)|karow|fr|l(ock|k(1(2|4)|34)|a(nk|ck(square|triangle(down|left|right)?|lozenge)))|a(ck(sim(eq)?|cong|prime|epsilon)|r(vee|wed(ge)?))|r(eve|vbar)|brk(tbrk)?))\n\t\t\t\t\t\t  | (c(s(cr|u(p(e)?|b(e)?))|h(cy|i|eck(mark)?)|ylcty|c(irc|ups(sm)?|edil|a(ps|ron))|tdot|ir(scir|c(eq|le(d(R|circ|S|dash|ast)|arrow(left|right)))?|e|fnint|E|mid)?|o(n(int|g(dot)?)|p(y(sr)?|f|rod)|lon(e(q)?)?|m(p(fn|le(xes|ment))?|ma(t)?))|dot|u(darr(l|r)|p(s|c(up|ap)|or|dot|brcap)?|e(sc|pr)|vee|wed|larr(p)?|r(vearrow(left|right)|ly(eq(succ|prec)|vee|wedge)|arr(m)?|ren))|e(nt(erdot)?|dil|mptyv)|fr|w(conint|int)|lubs(uit)?|a(cute|p(s|c(up|ap)|dot|and|brcup)?|r(on|et))|r(oss|arr))|C(scr|hi|c(irc|onint|edil|aron)|ircle(Minus|Times|Dot|Plus)|Hcy|o(n(tourIntegral|int|gruent)|unterClockwiseContourIntegral|p(f|roduct)|lon(e)?)|dot|up(Cap)?|OPY|e(nterDot|dilla)|fr|lo(seCurly(DoubleQuote|Quote)|ckwiseContourIntegral)|a(yleys|cute|p(italDifferentialD)?)|ross))\n\t\t\t\t\t\t  | (d(s(c(y|r)|trok|ol)|har(l|r)|c(y|aron)|t(dot|ri(f)?)|i(sin|e|v(ide(ontimes)?|onx)?|am(s|ond(suit)?)?|gamma)|Har|z(cy|igrarr)|o(t(square|plus|eq(dot)?|minus)?|ublebarwedge|pf|wn(harpoon(left|right)|downarrows|arrow)|llar)|d(otseq|a(rr|gger))?|u(har|arr)|jcy|e(lta|g|mptyv)|f(isht|r)|wangle|lc(orn|rop)|a(sh(v)?|leth|rr|gger)|r(c(orn|rop)|bkarow)|b(karow|lac)|Arr)|D(s(cr|trok)|c(y|aron)|Scy|i(fferentialD|a(critical(Grave|Tilde|Do(t|ubleAcute)|Acute)|mond))|o(t(Dot|Equal)?|uble(Right(Tee|Arrow)|ContourIntegral|Do(t|wnArrow)|Up(DownArrow|Arrow)|VerticalBar|L(ong(RightArrow|Left(RightArrow|Arrow))|eft(RightArrow|Tee|Arrow)))|pf|wn(Right(TeeVector|Vector(Bar)?)|Breve|Tee(Arrow)?|arrow|Left(RightVector|TeeVector|Vector(Bar)?)|Arrow(Bar|UpArrow)?))|Zcy|el(ta)?|D(otrahd)?|Jcy|fr|a(shv|rr|gger)))\n\t\t\t\t\t\t  | (e(s(cr|im|dot)|n(sp|g)|c(y|ir(c)?|olon|aron)|t(h|a)|o(pf|gon)|dot|u(ro|ml)|p(si(v|lon)?|lus|ar(sl)?)|e|D(ot|Dot)|q(s(im|lant(less|gtr))|c(irc|olon)|u(iv(DD)?|est|als)|vparsl)|f(Dot|r)|l(s(dot)?|inters|l)?|a(ster|cute)|r(Dot|arr)|g(s(dot)?|rave)?|x(cl|ist|p(onentiale|ectation))|m(sp(1(3|4))?|pty(set|v)?|acr))|E(s(cr|im)|c(y|irc|aron)|ta|o(pf|gon)|NG|dot|uml|TH|psilon|qu(ilibrium|al(Tilde)?)|fr|lement|acute|grave|x(ists|ponentialE)|m(pty(SmallSquare|VerySmallSquare)|acr)))\n\t\t\t\t\t\t  | (f(scr|nof|cy|ilig|o(pf|r(k(v)?|all))|jlig|partint|emale|f(ilig|l(ig|lig)|r)|l(tns|lig|at)|allingdotseq|r(own|a(sl|c(1(2|8|3|4|5|6)|78|2(3|5)|3(8|4|5)|45|5(8|6)))))|F(scr|cy|illed(SmallSquare|VerySmallSquare)|o(uriertrf|pf|rAll)|fr))\n\t\t\t\t\t\t  | (G(scr|c(y|irc|edil)|t|opf|dot|T|Jcy|fr|amma(d)?|reater(Greater|SlantEqual|Tilde|Equal(Less)?|FullEqual|Less)|g|breve)|g(s(cr|im(e|l)?)|n(sim|e(q(q)?)?|E|ap(prox)?)|c(y|irc)|t(c(c|ir)|dot|quest|lPar|r(sim|dot|eq(qless|less)|less|a(pprox|rr)))?|imel|opf|dot|jcy|e(s(cc|dot(o(l)?)?|l(es)?)?|q(slant|q)?|l)?|v(nE|ertneqq)|fr|E(l)?|l(j|E|a)?|a(cute|p|mma(d)?)|rave|g(g)?|breve))\n\t\t\t\t\t\t  | (h(s(cr|trok|lash)|y(phen|bull)|circ|o(ok(leftarrow|rightarrow)|pf|arr|rbar|mtht)|e(llip|arts(uit)?|rcon)|ks(earow|warow)|fr|a(irsp|lf|r(dcy|r(cir|w)?)|milt)|bar|Arr)|H(s(cr|trok)|circ|ilbertSpace|o(pf|rizontalLine)|ump(DownHump|Equal)|fr|a(cek|t)|ARDcy))\n\t\t\t\t\t\t  | (i(s(cr|in(s(v)?|dot|v|E)?)|n(care|t(cal|prod|e(rcal|gers)|larhk)?|odot|fin(tie)?)?|c(y|irc)?|t(ilde)?|i(nfin|i(nt|int)|ota)?|o(cy|ta|pf|gon)|u(kcy|ml)|jlig|prod|e(cy|xcl)|quest|f(f|r)|acute|grave|m(of|ped|a(cr|th|g(part|e|line))))|I(scr|n(t(e(rsection|gral))?|visible(Comma|Times))|c(y|irc)|tilde|o(ta|pf|gon)|dot|u(kcy|ml)|Ocy|Jlig|fr|Ecy|acute|grave|m(plies|a(cr|ginaryI))?))\n\t\t\t\t\t\t  | (j(s(cr|ercy)|c(y|irc)|opf|ukcy|fr|math)|J(s(cr|ercy)|c(y|irc)|opf|ukcy|fr))\n\t\t\t\t\t\t  | (k(scr|hcy|c(y|edil)|opf|jcy|fr|appa(v)?|green)|K(scr|c(y|edil)|Hcy|opf|Jcy|fr|appa))\n\t\t\t\t\t\t  | (l(s(h|cr|trok|im(e|g)?|q(uo(r)?|b)|aquo)|h(ar(d|u(l)?)|blk)|n(sim|e(q(q)?)?|E|ap(prox)?)|c(y|ub|e(il|dil)|aron)|Barr|t(hree|c(c|ir)|imes|dot|quest|larr|r(i(e|f)?|Par))?|Har|o(ng(left(arrow|rightarrow)|rightarrow|mapsto)|times|z(enge|f)?|oparrow(left|right)|p(f|lus|ar)|w(ast|bar)|a(ng|rr)|brk)|d(sh|ca|quo(r)?|r(dhar|ushar))|ur(dshar|uhar)|jcy|par(lt)?|e(s(s(sim|dot|eq(qgtr|gtr)|approx|gtr)|cc|dot(o(r)?)?|g(es)?)?|q(slant|q)?|ft(harpoon(down|up)|threetimes|leftarrows|arrow(tail)?|right(squigarrow|harpoons|arrow(s)?))|g)?|v(nE|ertneqq)|f(isht|loor|r)|E(g)?|l(hard|corner|tri|arr)?|a(ng(d|le)?|cute|t(e(s)?|ail)?|p|emptyv|quo|rr(sim|hk|tl|pl|fs|lp|b(fs)?)?|gran|mbda)|r(har(d)?|corner|tri|arr|m)|g(E)?|m(idot|oust(ache)?)|b(arr|r(k(sl(d|u)|e)|ac(e|k))|brk)|A(tail|arr|rr))|L(s(h|cr|trok)|c(y|edil|aron)|t|o(ng(RightArrow|left(arrow|rightarrow)|rightarrow|Left(RightArrow|Arrow))|pf|wer(RightArrow|LeftArrow))|T|e(ss(Greater|SlantEqual|Tilde|EqualGreater|FullEqual|Less)|ft(Right(Vector|Arrow)|Ceiling|T(ee(Vector|Arrow)?|riangle(Bar|Equal)?)|Do(ubleBracket|wn(TeeVector|Vector(Bar)?))|Up(TeeVector|DownVector|Vector(Bar)?)|Vector(Bar)?|arrow|rightarrow|Floor|A(ngleBracket|rrow(RightArrow|Bar)?)))|Jcy|fr|l(eftarrow)?|a(ng|cute|placetrf|rr|mbda)|midot))\n\t\t\t\t\t\t  | (M(scr|cy|inusPlus|opf|u|e(diumSpace|llintrf)|fr|ap)|m(s(cr|tpos)|ho|nplus|c(y|omma)|i(nus(d(u)?|b)?|cro|d(cir|dot|ast)?)|o(dels|pf)|dash|u(ltimap|map)?|p|easuredangle|DDot|fr|l(cp|dr)|a(cr|p(sto(down|up|left)?)?|l(t(ese)?|e)|rker)))\n\t\t\t\t\t\t  | (n(s(hort(parallel|mid)|c(cue|e|r)?|im(e(q)?)?|u(cc(eq)?|p(set(eq(q)?)?|e|E)?|b(set(eq(q)?)?|e|E)?)|par|qsu(pe|be)|mid)|Rightarrow|h(par|arr|Arr)|G(t(v)?|g)|c(y|ong(dot)?|up|edil|a(p|ron))|t(ilde|lg|riangle(left(eq)?|right(eq)?)|gl)|i(s(d)?|v)?|o(t(ni(v(c|a|b))?|in(dot|v(c|a|b)|E)?)?|pf)|dash|u(m(sp|ero)?)?|jcy|p(olint|ar(sl|t|allel)?|r(cue|e(c(eq)?)?)?)|e(s(im|ear)|dot|quiv|ar(hk|r(ow)?)|xist(s)?|Arr)?|v(sim|infin|Harr|dash|Dash|l(t(rie)?|e|Arr)|ap|r(trie|Arr)|g(t|e))|fr|w(near|ar(hk|r(ow)?)|Arr)|V(dash|Dash)|l(sim|t(ri(e)?)?|dr|e(s(s)?|q(slant|q)?|ft(arrow|rightarrow))?|E|arr|Arr)|a(ng|cute|tur(al(s)?)?|p(id|os|prox|E)?|bla)|r(tri(e)?|ightarrow|arr(c|w)?|Arr)|g(sim|t(r)?|e(s|q(slant|q)?)?|E)|mid|L(t(v)?|eft(arrow|rightarrow)|l)|b(sp|ump(e)?))|N(scr|c(y|edil|aron)|tilde|o(nBreakingSpace|Break|t(R(ightTriangle(Bar|Equal)?|everseElement)|Greater(Greater|SlantEqual|Tilde|Equal|FullEqual|Less)?|S(u(cceeds(SlantEqual|Tilde|Equal)?|perset(Equal)?|bset(Equal)?)|quareSu(perset(Equal)?|bset(Equal)?))|Hump(DownHump|Equal)|Nested(GreaterGreater|LessLess)|C(ongruent|upCap)|Tilde(Tilde|Equal|FullEqual)?|DoubleVerticalBar|Precedes(SlantEqual|Equal)?|E(qual(Tilde)?|lement|xists)|VerticalBar|Le(ss(Greater|SlantEqual|Tilde|Equal|Less)?|ftTriangle(Bar|Equal)?))?|pf)|u|e(sted(GreaterGreater|LessLess)|wLine|gative(MediumSpace|Thi(nSpace|ckSpace)|VeryThinSpace))|Jcy|fr|acute))\n\t\t\t\t\t\t  | (o(s(cr|ol|lash)|h(m|bar)|c(y|ir(c)?)|ti(lde|mes(as)?)|S|int|opf|d(sold|iv|ot|ash|blac)|uml|p(erp|lus|ar)|elig|vbar|f(cir|r)|l(c(ir|ross)|t|ine|arr)|a(st|cute)|r(slope|igof|or|d(er(of)?|f|m)?|v|arr)?|g(t|on|rave)|m(i(nus|cron|d)|ega|acr))|O(s(cr|lash)|c(y|irc)|ti(lde|mes)|opf|dblac|uml|penCurly(DoubleQuote|Quote)|ver(B(ar|rac(e|ket))|Parenthesis)|fr|Elig|acute|r|grave|m(icron|ega|acr)))\n\t\t\t\t\t\t  | (p(s(cr|i)|h(i(v)?|one|mmat)|cy|i(tchfork|v)?|o(intint|und|pf)|uncsp|er(cnt|tenk|iod|p|mil)|fr|l(us(sim|cir|two|d(o|u)|e|acir|mn|b)?|an(ck(h)?|kv))|ar(s(im|l)|t|a(llel)?)?|r(sim|n(sim|E|ap)|cue|ime(s)?|o(d|p(to)?|f(surf|line|alar))|urel|e(c(sim|n(sim|eqq|approx)|curlyeq|eq|approx)?)?|E|ap)?|m)|P(s(cr|i)|hi|cy|i|o(incareplane|pf)|fr|lusMinus|artialD|r(ime|o(duct|portion(al)?)|ecedes(SlantEqual|Tilde|Equal)?)?))\n\t\t\t\t\t\t  | (q(scr|int|opf|u(ot|est(eq)?|at(int|ernions))|prime|fr)|Q(scr|opf|UOT|fr))\n\t\t\t\t\t\t  | (R(s(h|cr)|ho|c(y|edil|aron)|Barr|ight(Ceiling|T(ee(Vector|Arrow)?|riangle(Bar|Equal)?)|Do(ubleBracket|wn(TeeVector|Vector(Bar)?))|Up(TeeVector|DownVector|Vector(Bar)?)|Vector(Bar)?|arrow|Floor|A(ngleBracket|rrow(Bar|LeftArrow)?))|o(undImplies|pf)|uleDelayed|e(verse(UpEquilibrium|E(quilibrium|lement)))?|fr|EG|a(ng|cute|rr(tl)?)|rightarrow)|r(s(h|cr|q(uo(r)?|b)|aquo)|h(o(v)?|ar(d|u(l)?))|nmid|c(y|ub|e(il|dil)|aron)|Barr|t(hree|imes|ri(e|f|ltri)?)|i(singdotseq|ng|ght(squigarrow|harpoon(down|up)|threetimes|left(harpoons|arrows)|arrow(tail)?|rightarrows))|Har|o(times|p(f|lus|ar)|a(ng|rr)|brk)|d(sh|ca|quo(r)?|ldhar)|uluhar|p(polint|ar(gt)?)|e(ct|al(s|ine|part)?|g)|f(isht|loor|r)|l(har|arr|m)|a(ng(d|e|le)?|c(ute|e)|t(io(nals)?|ail)|dic|emptyv|quo|rr(sim|hk|c|tl|pl|fs|w|lp|ap|b(fs)?)?)|rarr|x|moust(ache)?|b(arr|r(k(sl(d|u)|e)|ac(e|k))|brk)|A(tail|arr|rr)))\n\t\t\t\t\t\t  | (s(s(cr|tarf|etmn|mile)|h(y|c(hcy|y)|ort(parallel|mid)|arp)|c(sim|y|n(sim|E|ap)|cue|irc|polint|e(dil)?|E|a(p|ron))?|t(ar(f)?|r(ns|aight(phi|epsilon)))|i(gma(v|f)?|m(ne|dot|plus|e(q)?|l(E)?|rarr|g(E)?)?)|zlig|o(pf|ftcy|l(b(ar)?)?)|dot(e|b)?|u(ng|cc(sim|n(sim|eqq|approx)|curlyeq|eq|approx)?|p(s(im|u(p|b)|et(neq(q)?|eq(q)?)?)|hs(ol|ub)|1|n(e|E)|2|d(sub|ot)|3|plus|e(dot)?|E|larr|mult)?|m|b(s(im|u(p|b)|et(neq(q)?|eq(q)?)?)|n(e|E)|dot|plus|e(dot)?|E|rarr|mult)?)|pa(des(uit)?|r)|e(swar|ct|tm(n|inus)|ar(hk|r(ow)?)|xt|mi|Arr)|q(su(p(set(eq)?|e)?|b(set(eq)?|e)?)|c(up(s)?|ap(s)?)|u(f|ar(e|f))?)|fr(own)?|w(nwar|ar(hk|r(ow)?)|Arr)|larr|acute|rarr|m(t(e(s)?)?|i(d|le)|eparsl|a(shp|llsetminus))|bquo)|S(scr|hort(RightArrow|DownArrow|UpArrow|LeftArrow)|c(y|irc|edil|aron)?|tar|igma|H(cy|CHcy)|opf|u(c(hThat|ceeds(SlantEqual|Tilde|Equal)?)|p(set|erset(Equal)?)?|m|b(set(Equal)?)?)|OFTcy|q(uare(Su(perset(Equal)?|bset(Equal)?)|Intersection|Union)?|rt)|fr|acute|mallCircle))\n\t\t\t\t\t\t  | (t(s(hcy|c(y|r)|trok)|h(i(nsp|ck(sim|approx))|orn|e(ta(sym|v)?|re(4|fore))|k(sim|ap))|c(y|edil|aron)|i(nt|lde|mes(d|b(ar)?)?)|o(sa|p(cir|f(ork)?|bot)?|ea)|dot|prime|elrec|fr|w(ixt|ohead(leftarrow|rightarrow))|a(u|rget)|r(i(sb|time|dot|plus|e|angle(down|q|left(eq)?|right(eq)?)?|minus)|pezium|ade)|brk)|T(s(cr|trok)|RADE|h(i(nSpace|ckSpace)|e(ta|refore))|c(y|edil|aron)|S(cy|Hcy)|ilde(Tilde|Equal|FullEqual)?|HORN|opf|fr|a(u|b)|ripleDot))\n\t\t\t\t\t\t  | (u(scr|h(ar(l|r)|blk)|c(y|irc)|t(ilde|dot|ri(f)?)|Har|o(pf|gon)|d(har|arr|blac)|u(arr|ml)|p(si(h|lon)?|harpoon(left|right)|downarrow|uparrows|lus|arrow)|f(isht|r)|wangle|l(c(orn(er)?|rop)|tri)|a(cute|rr)|r(c(orn(er)?|rop)|tri|ing)|grave|m(l|acr)|br(cy|eve)|Arr)|U(scr|n(ion(Plus)?|der(B(ar|rac(e|ket))|Parenthesis))|c(y|irc)|tilde|o(pf|gon)|dblac|uml|p(si(lon)?|downarrow|Tee(Arrow)?|per(RightArrow|LeftArrow)|DownArrow|Equilibrium|arrow|Arrow(Bar|DownArrow)?)|fr|a(cute|rr(ocir)?)|ring|grave|macr|br(cy|eve)))\n\t\t\t\t\t\t  | (v(s(cr|u(pn(e|E)|bn(e|E)))|nsu(p|b)|cy|Bar(v)?|zigzag|opf|dash|prop|e(e(eq|bar)?|llip|r(t|bar))|Dash|fr|ltri|a(ngrt|r(s(igma|u(psetneq(q)?|bsetneq(q)?))|nothing|t(heta|riangle(left|right))|p(hi|i|ropto)|epsilon|kappa|r(ho)?))|rtri|Arr)|V(scr|cy|opf|dash(l)?|e(e|r(yThinSpace|t(ical(Bar|Separator|Tilde|Line))?|bar))|Dash|vdash|fr|bar))\n\t\t\t\t\t\t  | (w(scr|circ|opf|p|e(ierp|d(ge(q)?|bar))|fr|r(eath)?)|W(scr|circ|opf|edge|fr))\n\t\t\t\t\t\t  | (X(scr|i|opf|fr)|x(s(cr|qcup)|h(arr|Arr)|nis|c(irc|up|ap)|i|o(time|dot|p(f|lus))|dtri|u(tri|plus)|vee|fr|wedge|l(arr|Arr)|r(arr|Arr)|map))\n\t\t\t\t\t\t  | (y(scr|c(y|irc)|icy|opf|u(cy|ml)|en|fr|ac(y|ute))|Y(scr|c(y|irc)|opf|uml|Icy|Ucy|fr|acute|Acy))\n\t\t\t\t\t\t  | (z(scr|hcy|c(y|aron)|igrarr|opf|dot|e(ta|etrf)|fr|w(nj|j)|acute)|Z(scr|c(y|aron)|Hcy|opf|dot|e(ta|roWidthSpace)|fr|acute))\n\t\t\t\t\t\t)\n\t\t\t\t\t\t(;)\n\t\t\t\t\t",
+          "name": "constant.character.entity.named.$2.astro"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.astro"
+            },
+            "3": {
+              "name": "punctuation.definition.entity.astro"
+            }
+          },
+          "match": "(&)#[0-9]+(;)",
+          "name": "constant.character.entity.numeric.decimal.astro"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.astro"
+            },
+            "3": {
+              "name": "punctuation.definition.entity.astro"
+            }
+          },
+          "match": "(&)#[xX][0-9a-fA-F]+(;)",
+          "name": "constant.character.entity.numeric.hexadecimal.astro"
+        },
+        {
+          "match": "&(?=[a-zA-Z0-9]+;)",
+          "name": "invalid.illegal.ambiguous-ampersand.astro"
+        }
+      ]
+    },
+    "attributes": {
+      "patterns": [
+        {
+          "include": "#attributes-events"
+        },
+        {
+          "include": "#attributes-keyvalue"
+        },
+        {
+          "include": "#attributes-interpolated"
+        }
+      ]
+    },
+    "attributes-events": {
+      "begin": "(on(s(croll|t(orage|alled)|u(spend|bmit)|e(curitypolicyviolation|ek(ing|ed)|lect))|hashchange|c(hange|o(ntextmenu|py)|u(t|echange)|l(ick|ose)|an(cel|play(through)?))|t(imeupdate|oggle)|in(put|valid)|o(nline|ffline)|d(urationchange|r(op|ag(start|over|e(n(ter|d)|xit)|leave)?)|blclick)|un(handledrejection|load)|p(opstate|lay(ing)?|a(ste|use|ge(show|hide))|rogress)|e(nded|rror|mptied)|volumechange|key(down|up|press)|focus|w(heel|aiting)|l(oad(start|e(nd|d(data|metadata)))?|anguagechange)|a(uxclick|fterprint|bort)|r(e(s(ize|et)|jectionhandled)|atechange)|m(ouse(o(ut|ver)|down|up|enter|leave|move)|essage(error)?)|b(efore(unload|print)|lur)))(?![\\\\w:-])",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "match": ".*",
+              "name": "entity.other.attribute-name.astro"
+            }
+          ]
+        }
+      },
+      "end": "(?=\\s*+[^=\\s])",
+      "name": "meta.attribute.$1.astro",
+      "patterns": [
+        {
+          "begin": "=",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.key-value.astro"
+            }
+          },
+          "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+          "patterns": [
+            {
+              "include": "#interpolation"
+            },
+            {
+              "include": "#attribute-literal"
+            },
+            {
+              "begin": "(?=[^\\s=<>`/]|/(?!>))",
+              "end": "(?!\\G)",
+              "name": "meta.embedded.line.js",
+              "patterns": [
+                {
+                  "match": "(([^\\s\\\"'=<>`/]|/(?!>))+)",
+                  "name": "string.unquoted.astro",
+                  "captures": {
+                    "0": {
+                      "name": "source.js"
+                    },
+                    "1": {
+                      "patterns": [
+                        {
+                          "include": "source.js"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "begin": "([\"])",
+                  "end": "\\1",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.begin.astro"
+                    }
+                  },
+                  "endCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.end.astro"
+                    }
+                  },
+                  "name": "string.quoted.astro",
+                  "patterns": [
+                    {
+                      "match": "([^\\n\\\"/]|/(?![/*]))+",
+                      "captures": {
+                        "0": {
+                          "patterns": [
+                            {
+                              "include": "source.js"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "begin": "//",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.js"
+                        }
+                      },
+                      "end": "(?=\\\")|\\n",
+                      "name": "comment.line.double-slash.js"
+                    },
+                    {
+                      "begin": "/\\*",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.begin.js"
+                        }
+                      },
+                      "end": "(?=\\\")|\\*/",
+                      "endCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.end.js"
+                        }
+                      },
+                      "name": "comment.block.js"
+                    }
+                  ]
+                },
+                {
+                  "begin": "(['])",
+                  "end": "\\1",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.begin.astro"
+                    }
+                  },
+                  "endCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.end.astro"
+                    }
+                  },
+                  "name": "string.quoted.astro",
+                  "patterns": [
+                    {
+                      "match": "([^\\n\\'/]|/(?![/*]))+",
+                      "captures": {
+                        "0": {
+                          "patterns": [
+                            {
+                              "include": "source.js"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "begin": "//",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.js"
+                        }
+                      },
+                      "end": "(?=\\')|\\n",
+                      "name": "comment.line.double-slash.js"
+                    },
+                    {
+                      "begin": "/\\*",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.begin.js"
+                        }
+                      },
+                      "end": "(?=\\')|\\*/",
+                      "endCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.end.js"
+                        }
+                      },
+                      "name": "comment.block.js"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "attributes-interpolated": {
+      "begin": "(?<!:|=)\\s*({)",
+      "end": "(\\})",
+      "contentName": "meta.embedded.expression.astro source.tsx",
+      "patterns": [
+        {
+          "include": "source.tsx"
+        }
+      ]
+    },
+    "attributes-keyvalue": {
+      "begin": "([_@$[:alpha:]][:._\\-$[:alnum:]]*)",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "match": ".*",
+              "name": "entity.other.attribute-name.astro"
+            }
+          ]
+        }
+      },
+      "end": "(?=\\s*+[^=\\s])",
+      "name": "meta.attribute.$1.astro",
+      "patterns": [
+        {
+          "begin": "=",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.key-value.astro"
+            }
+          },
+          "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+          "patterns": [
+            {
+              "include": "#attributes-value"
+            }
+          ]
+        }
+      ]
+    },
+    "attribute-literal": {
+      "begin": "(`)",
+      "end": "\\1",
+      "name": "string.template.astro",
+      "patterns": [
+        {
+          "include": "source.tsx#template-substitution-element"
+        },
+        {
+          "include": "source.tsx#string-character-escape"
+        }
+      ]
+    },
+    "attributes-value": {
+      "patterns": [
+        {
+          "include": "#interpolation"
+        },
+        {
+          "match": "([^\\s\"'=<>`/]|/(?!>))+",
+          "name": "string.unquoted.astro"
+        },
+        {
+          "begin": "(['\"])",
+          "end": "\\1",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.astro"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.astro"
+            }
+          },
+          "name": "string.quoted.astro"
+        },
+        {
+          "include": "#attribute-literal"
+        }
+      ]
+    },
+    "tags": {
+      "patterns": [
+        {
+          "include": "#tags-raw"
+        },
+        {
+          "include": "#tags-lang"
+        },
+        {
+          "include": "#tags-void"
+        },
+        {
+          "include": "#tags-general-end"
+        },
+        {
+          "include": "#tags-general-start"
+        }
+      ]
+    },
+    "tags-name": {
+      "patterns": [
+        {
+          "match": "[A-Z][a-zA-Z0-9_]*",
+          "name": "support.class.component.astro"
+        },
+        {
+          "match": "[a-z][\\w0-9:]*-[\\w0-9:-]*",
+          "name": "meta.tag.custom.astro entity.name.tag.astro"
+        },
+        {
+          "match": "[a-z][\\w0-9:-]*",
+          "name": "entity.name.tag.astro"
+        }
+      ]
+    },
+    "tags-start-attributes": {
+      "begin": "\\G",
+      "end": "(?=/?>)",
+      "name": "meta.tag.start.astro",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
+    "tags-lang-start-attributes": {
+      "begin": "\\G",
+      "end": "(?=/>)|>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.astro"
+        }
+      },
+      "name": "meta.tag.start.astro",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
+    "tags-start-node": {
+      "match": "(<)([^/\\s>/]*)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.astro"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#tags-name"
+            }
+          ]
+        }
+      },
+      "name": "meta.tag.start.astro"
+    },
+    "tags-end-node": {
+      "match": "(</)(.*?)\\s*(>)|(/>)",
+      "captures": {
+        "1": {
+          "name": "meta.tag.end.astro punctuation.definition.tag.begin.astro"
+        },
+        "2": {
+          "name": "meta.tag.end.astro",
+          "patterns": [
+            {
+              "include": "#tags-name"
+            }
+          ]
+        },
+        "3": {
+          "name": "meta.tag.end.astro punctuation.definition.tag.end.astro"
+        },
+        "4": {
+          "name": "meta.tag.start.astro punctuation.definition.tag.end.astro"
+        }
+      }
+    },
+    "tags-raw": {
+      "begin": "<([^/?!\\s<>]+)(?=[^>]+is:raw).*?",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-start-node"
+            }
+          ]
+        }
+      },
+      "end": "</\\1\\s*>|/>",
+      "endCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-end-node"
+            }
+          ]
+        }
+      },
+      "name": "meta.scope.tag.$1.astro meta.raw.astro",
+      "contentName": "source.unknown",
+      "patterns": [
+        {
+          "include": "#tags-lang-start-attributes"
+        }
+      ]
+    },
+    "tags-lang": {
+      "begin": "<(script|style)",
+      "end": "</\\1\\s*>|/>",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-start-node"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-end-node"
+            }
+          ]
+        }
+      },
+      "name": "meta.scope.tag.$1.astro meta.$1.astro",
+      "patterns": [
+        {
+          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text\\/)?(application\\/ld\\+json)\\2)",
+          "end": "(?=</|/>)",
+          "name": "meta.lang.json.astro",
+          "patterns": [
+            {
+              "include": "#tags-lang-start-attributes"
+            }
+          ]
+        },
+        {
+          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(module)\\2)",
+          "end": "(?=</|/>)",
+          "name": "meta.lang.javascript.astro",
+          "patterns": [
+            {
+              "include": "#tags-lang-start-attributes"
+            }
+          ]
+        },
+        {
+          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/|application/)?([\\w\\/+]+)\\2)",
+          "end": "(?=</|/>)",
+          "name": "meta.lang.$3.astro",
+          "patterns": [
+            {
+              "include": "#tags-lang-start-attributes"
+            }
+          ]
+        },
+        {
+          "include": "#tags-lang-start-attributes"
+        }
+      ]
+    },
+    "tags-void": {
+      "begin": "(<)(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)(?=\\s|/?>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.astro"
+        },
+        "2": {
+          "name": "entity.name.tag.astro"
+        }
+      },
+      "end": "/?>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.begin.astro"
+        }
+      },
+      "name": "meta.tag.void.astro",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
+    "tags-general-start": {
+      "begin": "(<)([^/\\s>/]*)",
+      "end": "(/?>)",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-start-node"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "meta.tag.start.astro punctuation.definition.tag.end.astro"
+        }
+      },
+      "name": "meta.scope.tag.$2.astro",
+      "patterns": [
+        {
+          "include": "#tags-start-attributes"
+        }
+      ]
+    },
+    "tags-general-end": {
+      "begin": "(</)([^/\\s>]*)",
+      "end": "(>)",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.tag.end.astro punctuation.definition.tag.begin.astro"
+        },
+        "2": {
+          "name": "meta.tag.end.astro",
+          "patterns": [
+            {
+              "include": "#tags-name"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "meta.tag.end.astro punctuation.definition.tag.end.astro"
+        }
+      },
+      "name": "meta.scope.tag.$2.astro"
+    },
+    "text": {
+      "patterns": [
+        {
+          "begin": "(?<=^|---|>|})",
+          "end": "(?=<|{|$)",
+          "name": "text.astro",
+          "patterns": [
+            {
+              "include": "#entities"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/graphql.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/graphql.tmLanguage.json
@@ -1,0 +1,783 @@
+{
+  "name": "GraphQL",
+  "scopeName": "source.graphql",
+  "fileTypes": ["graphql", "graphqls", "gql", "graphcool"],
+  "patterns": [{ "include": "#graphql" }],
+  "repository": {
+    "graphql": {
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-fragment-definition" },
+        { "include": "#graphql-directive-definition" },
+        { "include": "#graphql-type-interface" },
+        { "include": "#graphql-enum" },
+        { "include": "#graphql-scalar" },
+        { "include": "#graphql-union" },
+        { "include": "#graphql-schema" },
+        { "include": "#graphql-operation-def" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-operation-def": {
+      "patterns": [
+        { "include": "#graphql-query-mutation-subscription" },
+        { "include": "#graphql-name" },
+        { "include": "#graphql-variable-definitions" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-selection-set" }
+      ]
+    },
+    "graphql-fragment-definition": {
+      "name": "meta.fragment.graphql",
+      "begin": "\\s*(?:(\\bfragment\\b)\\s*([_A-Za-z][_0-9A-Za-z]*)?)",
+      "end": "(?<=})",
+      "captures": {
+        "1": { "name": "keyword.fragment.graphql" },
+        "2": { "name": "entity.name.fragment.graphql" }
+      },
+      "patterns": [
+        {
+          "match": "\\s*(?:(\\bon\\b)\\s*([_A-Za-z][_0-9A-Za-z]*))",
+          "captures": {
+            "1": { "name": "keyword.on.graphql" },
+            "2": { "name": "support.type.graphql" }
+          }
+        },
+        { "include": "#graphql-variable-definitions" },
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-selection-set" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-skip-newlines" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-query-mutation-subscription": {
+      "match": "\\s*\\b(query|mutation|subscription)\\b",
+      "captures": {
+        "1": { "name": "keyword.operation.graphql" }
+      }
+    },
+    "graphql-type-interface": {
+      "name": "meta.type.interface.graphql",
+      "begin": "\\s*\\b(?:(extends?)?\\b\\s*\\b(type)|(interface)|(input))\\b\\s*([_A-Za-z][_0-9A-Za-z]*)?",
+      "end": "(?=.)",
+      "applyEndPatternLast": 1,
+      "captures": {
+        "1": { "name": "keyword.type.graphql" },
+        "2": { "name": "keyword.type.graphql" },
+        "3": { "name": "keyword.interface.graphql" },
+        "4": { "name": "keyword.input.graphql" },
+        "5": { "name": "support.type.graphql" }
+      },
+      "patterns": [
+        {
+          "begin": "\\s*\\b(implements)\\b\\s*",
+          "end": "\\s*(?={)",
+          "beginCaptures": {
+            "1": { "name": "keyword.implements.graphql" }
+          },
+          "patterns": [
+            {
+              "match": "\\s*([_A-Za-z][_0-9A-Za-z]*)",
+              "captures": {
+                "1": { "name": "support.type.graphql" }
+              }
+            },
+            { "include": "#graphql-comment" },
+            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-directive" },
+            { "include": "#graphql-ampersand" },
+            { "include": "#graphql-comma" }
+          ]
+        },
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-type-object" },
+        { "include": "#literal-quasi-embedded" },
+        { "include": "#graphql-ignore-spaces" }
+      ]
+    },
+    "graphql-ignore-spaces": {
+      "match": "\\s*"
+    },
+    "graphql-type-object": {
+      "name": "meta.type.object.graphql",
+      "begin": "\\s*({)",
+      "end": "\\s*(})",
+      "beginCaptures": {
+        "1": { "name": "punctuation.operation.graphql" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.operation.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-object-type" },
+        { "include": "#graphql-type-definition" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-type-definition": {
+      "comment": "key (optionalArgs): Type",
+      "begin": "\\s*([_A-Za-z][_0-9A-Za-z]*)(?=\\s*\\(|:)",
+      "end": "(?=\\s*(([_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(})))|\\s*(,)",
+      "beginCaptures": {
+        "1": { "name": "variable.graphql" }
+      },
+      "endCaptures": {
+        "5": { "name": "punctuation.comma.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-variable-definitions" },
+        { "include": "#graphql-type-object" },
+        { "include": "#graphql-colon" },
+        { "include": "#graphql-input-types" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-schema": {
+      "begin": "\\s*\\b(schema)\\b",
+      "end": "(?<=})",
+      "beginCaptures": {
+        "1": { "name": "keyword.schema.graphql" }
+      },
+      "patterns": [
+        {
+          "begin": "\\s*({)",
+          "end": "\\s*(})",
+          "beginCaptures": {
+            "1": { "name": "punctuation.operation.graphql" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.operation.graphql" }
+          },
+          "patterns": [
+            {
+              "begin": "\\s*([_A-Za-z][_0-9A-Za-z]*)(?=\\s*\\(|:)",
+              "end": "(?=\\s*(([_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(})))|\\s*(,)",
+              "beginCaptures": {
+                "1": { "name": "variable.arguments.graphql" }
+              },
+              "endCaptures": {
+                "5": { "name": "punctuation.comma.graphql" }
+              },
+              "patterns": [
+                {
+                  "match": "\\s*([_A-Za-z][_0-9A-Za-z]*)",
+                  "captures": {
+                    "1": { "name": "support.type.graphql" }
+                  }
+                },
+                { "include": "#graphql-comment" },
+                { "include": "#graphql-description-docstring" },
+                { "include": "#graphql-description-singleline" },
+                { "include": "#graphql-colon" },
+                { "include": "#graphql-skip-newlines" }
+              ]
+            },
+            { "include": "#graphql-comment" },
+            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-skip-newlines" }
+          ]
+        },
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-skip-newlines" }
+      ]
+    },
+    "graphql-comment": {
+      "patterns": [
+        {
+          "comment": "need to prefix comment space with a scope else Atom's reflow cmd doesn't work",
+          "name": "comment.line.graphql.js",
+          "match": "(\\s*)(#).*",
+          "captures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.graphql"
+            }
+          }
+        },
+        {
+          "name": "comment.line.graphql.js",
+          "begin": "(\"\"\")",
+          "end": "(\"\"\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.graphql"
+            }
+          }
+        },
+        {
+          "name": "comment.line.graphql.js",
+          "begin": "(\")",
+          "end": "(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.graphql"
+            }
+          }
+        }
+      ]
+    },
+    "graphql-description-singleline": {
+      "name": "comment.line.number-sign.graphql",
+      "match": "#(?=([^\"]*\"[^\"]*\")*[^\"]*$).*$"
+    },
+    "graphql-description-docstring": {
+      "name": "comment.block.graphql",
+      "begin": "\"\"\"",
+      "end": "\"\"\""
+    },
+    "graphql-variable-definitions": {
+      "begin": "\\s*(\\()",
+      "end": "\\s*(\\))",
+      "captures": {
+        "1": { "name": "meta.brace.round.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-variable-definition" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-variable-definition": {
+      "comment": "variable: type = value,.... which may be a list",
+      "name": "meta.variables.graphql",
+      "begin": "\\s*(\\$?[_A-Za-z][_0-9A-Za-z]*)(?=\\s*\\(|:)",
+      "end": "(?=\\s*((\\$?[_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(}|\\))))|\\s*(,)",
+      "beginCaptures": {
+        "1": { "name": "variable.parameter.graphql" }
+      },
+      "endCaptures": {
+        "5": { "name": "punctuation.comma.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-colon" },
+        { "include": "#graphql-input-types" },
+        { "include": "#graphql-variable-assignment" },
+        { "include": "#literal-quasi-embedded" },
+        { "include": "#graphql-skip-newlines" }
+      ]
+    },
+    "graphql-input-types": {
+      "patterns": [
+        { "include": "#graphql-scalar-type" },
+        {
+          "match": "\\s*([_A-Za-z][_0-9A-Za-z]*)(?:\\s*(!))?",
+          "captures": {
+            "1": { "name": "support.type.graphql" },
+            "2": { "name": "keyword.operator.nulltype.graphql" }
+          }
+        },
+        {
+          "name": "meta.type.list.graphql",
+          "begin": "\\s*(\\[)",
+          "end": "\\s*(\\])(?:\\s*(!))?",
+          "captures": {
+            "1": { "name": "meta.brace.square.graphql" },
+            "2": { "name": "keyword.operator.nulltype.graphql" }
+          },
+          "patterns": [
+            { "include": "#graphql-comment" },
+            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-input-types" },
+            { "include": "#graphql-comma" },
+            { "include": "#literal-quasi-embedded" }
+          ]
+        }
+      ]
+    },
+    "graphql-scalar": {
+      "match": "\\s*\\b(scalar)\\b\\s*([_A-Za-z][_0-9A-Za-z]*)",
+      "captures": {
+        "1": { "name": "keyword.scalar.graphql" },
+        "2": { "name": "entity.scalar.graphql" }
+      }
+    },
+    "graphql-scalar-type": {
+      "match": "\\s*\\b(Int|Float|String|Boolean|ID)\\b(?:\\s*(!))?",
+      "captures": {
+        "1": { "name": "support.type.builtin.graphql" },
+        "2": { "name": "keyword.operator.nulltype.graphql" }
+      }
+    },
+    "graphql-variable-assignment": {
+      "begin": "\\s(=)",
+      "end": "(?=[\n,)])",
+      "applyEndPatternLast": 1,
+      "beginCaptures": {
+        "1": { "name": "punctuation.assignment.graphql" }
+      },
+      "patterns": [{ "include": "#graphql-value" }]
+    },
+    "graphql-comma": {
+      "match": "\\s*(,)",
+      "captures": {
+        "1": { "name": "punctuation.comma.graphql" }
+      }
+    },
+    "graphql-ampersand": {
+      "match": "\\s*(&)",
+      "captures": {
+        "1": { "name": "keyword.operator.logical.graphql" }
+      }
+    },
+    "graphql-colon": {
+      "match": "\\s*(:)",
+      "captures": {
+        "1": { "name": "punctuation.colon.graphql" }
+      }
+    },
+    "graphql-union-mark": {
+      "match": "\\s*(\\|)",
+      "captures": {
+        "1": { "name": "punctuation.union.graphql" }
+      }
+    },
+    "graphql-name": {
+      "match": "\\s*([_A-Za-z][_0-9A-Za-z]*)",
+      "captures": {
+        "1": { "name": "entity.name.function.graphql" }
+      }
+    },
+    "graphql-directive": {
+      "begin": "\\s*((@)\\s*([_A-Za-z][_0-9A-Za-z]*))",
+      "end": "(?=.)",
+      "applyEndPatternLast": 1,
+      "beginCaptures": {
+        "1": { "name": "entity.name.function.directive.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-arguments" },
+        { "include": "#literal-quasi-embedded" },
+        { "include": "#graphql-skip-newlines" }
+      ]
+    },
+    "graphql-directive-definition": {
+      "begin": "\\s*(\\bdirective\\b)\\s*(@[_A-Za-z][_0-9A-Za-z]*)",
+      "end": "(?=.)",
+      "applyEndPatternLast": 1,
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.directive.graphql"
+        },
+        "2": {
+          "name": "entity.name.function.directive.graphql"
+        },
+        "3": {
+          "name": "keyword.repeatable.graphql"
+        },
+        "4": {
+          "name": "keyword.on.graphql"
+        },
+        "5": {
+          "name": "support.type.graphql"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#graphql-variable-definitions"
+        },
+        {
+          "begin": "\\s*(\\brepeatable\\b)?\\s*(\\bon\\b)\\s*([_A-Za-z]*)",
+          "end": "(?=.)",
+          "applyEndPatternLast": 1,
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.repeatable.graphql"
+            },
+            "2": {
+              "name": "keyword.on.graphql"
+            },
+            "3": {
+              "name": "support.type.location.graphql"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#graphql-skip-newlines"
+            },
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#literal-quasi-embedded"
+            },
+            {
+              "match": "\\s*(\\|)\\s*([_A-Za-z]*)",
+              "captures": {
+                "2": {
+                  "name": "support.type.location.graphql"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        },
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-selection-set": {
+      "name": "meta.selectionset.graphql",
+      "begin": "\\s*({)",
+      "end": "\\s*(})",
+      "beginCaptures": {
+        "1": { "name": "punctuation.operation.graphql" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.operation.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-field" },
+        { "include": "#graphql-fragment-spread" },
+        { "include": "#graphql-inline-fragment" },
+        { "include": "#graphql-comma" },
+        { "include": "#native-interpolation" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-field": {
+      "patterns": [
+        {
+          "match": "\\s*([_A-Za-z][_0-9A-Za-z]*)\\s*(:)",
+          "captures": {
+            "1": { "name": "string.unquoted.alias.graphql" },
+            "2": { "name": "punctuation.colon.graphql" }
+          }
+        },
+        {
+          "match": "\\s*([_A-Za-z][_0-9A-Za-z]*)",
+          "captures": {
+            "1": { "name": "variable.graphql" }
+          }
+        },
+        { "include": "#graphql-arguments" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-selection-set" },
+        { "include": "#literal-quasi-embedded" },
+        { "include": "#graphql-skip-newlines" }
+      ]
+    },
+    "graphql-fragment-spread": {
+      "begin": "\\s*(\\.\\.\\.)\\s*(?!\\bon\\b)([_A-Za-z][_0-9A-Za-z]*)",
+      "end": "(?=.)",
+      "applyEndPatternLast": 1,
+      "captures": {
+        "1": { "name": "keyword.operator.spread.graphql" },
+        "2": { "name": "variable.fragment.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-arguments" },
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-selection-set" },
+        { "include": "#graphql-directive" },
+        { "include": "#literal-quasi-embedded" },
+        { "include": "#graphql-skip-newlines" }
+      ]
+    },
+    "graphql-inline-fragment": {
+      "begin": "\\s*(\\.\\.\\.)\\s*(?:(\\bon\\b)\\s*([_A-Za-z][_0-9A-Za-z]*))?",
+      "end": "(?=.)",
+      "applyEndPatternLast": 1,
+      "captures": {
+        "1": { "name": "keyword.operator.spread.graphql" },
+        "2": { "name": "keyword.on.graphql" },
+        "3": { "name": "support.type.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-selection-set" },
+        { "include": "#graphql-directive" },
+        { "include": "#graphql-skip-newlines" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-arguments": {
+      "name": "meta.arguments.graphql",
+      "begin": "\\s*(\\()",
+      "end": "\\s*(\\))",
+      "beginCaptures": {
+        "1": { "name": "meta.brace.round.directive.graphql" }
+      },
+      "endCaptures": {
+        "1": { "name": "meta.brace.round.directive.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        {
+          "begin": "\\s*([_A-Za-z][_0-9A-Za-z]*)(?:\\s*(:))",
+          "end": "(?=\\s*(?:(?:([_A-Za-z][_0-9A-Za-z]*)\\s*(:))|\\)))|\\s*(,)",
+          "beginCaptures": {
+            "1": { "name": "variable.parameter.graphql" },
+            "2": { "name": "punctuation.colon.graphql" }
+          },
+          "endCaptures": {
+            "3": { "name": "punctuation.comma.graphql" }
+          },
+          "patterns": [
+            { "include": "#graphql-comment" },
+            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-directive" },
+            { "include": "#graphql-value" },
+            { "include": "#graphql-skip-newlines" }
+          ]
+        },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-variable-name": {
+      "match": "\\s*(\\$[_A-Za-z][_0-9A-Za-z]*)",
+      "captures": {
+        "1": { "name": "variable.graphql" }
+      }
+    },
+    "graphql-float-value": {
+      "match": "\\s*(-?(0|[1-9][0-9]*)(\\.[0-9]+)?((e|E)(\\+|-)?[0-9]+)?)",
+      "captures": {
+        "1": { "name": "constant.numeric.float.graphql" }
+      }
+    },
+    "graphql-boolean-value": {
+      "match": "\\s*\\b(true|false)\\b",
+      "captures": {
+        "1": { "name": "constant.language.boolean.graphql" }
+      }
+    },
+    "graphql-null-value": {
+      "match": "\\s*\\b(null)\\b",
+      "captures": {
+        "1": { "name": "constant.language.null.graphql" }
+      }
+    },
+    "graphql-string-value": {
+      "contentName": "string.quoted.double.graphql",
+      "begin": "\\s*+((\"))",
+      "end": "\\s*+(?:((\"))|(\n))",
+      "beginCaptures": {
+        "1": { "name": "string.quoted.double.graphql" },
+        "2": { "name": "punctuation.definition.string.begin.graphql" }
+      },
+      "endCaptures": {
+        "1": { "name": "string.quoted.double.graphql" },
+        "2": { "name": "punctuation.definition.string.end.graphql" },
+        "3": { "name": "invalid.illegal.newline.graphql" }
+      },
+      "patterns": [
+        { "include": "#graphql-string-content" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-string-content": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.graphql",
+          "match": "\\\\[/'\"\\\\nrtbf]"
+        },
+        {
+          "name": "constant.character.escape.graphql",
+          "match": "\\\\u([0-9a-fA-F]{4})"
+        }
+      ]
+    },
+    "graphql-enum": {
+      "name": "meta.enum.graphql",
+      "begin": "\\s*+\\b(enum)\\b\\s*([_A-Za-z][_0-9A-Za-z]*)",
+      "end": "(?<=})",
+      "beginCaptures": {
+        "1": { "name": "keyword.enum.graphql" },
+        "2": { "name": "support.type.enum.graphql" }
+      },
+      "patterns": [
+        {
+          "name": "meta.type.object.graphql",
+          "begin": "\\s*({)",
+          "end": "\\s*(})",
+          "beginCaptures": {
+            "1": { "name": "punctuation.operation.graphql" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.operation.graphql" }
+          },
+          "patterns": [
+            { "include": "#graphql-object-type" },
+
+            { "include": "#graphql-comment" },
+            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-directive" },
+            { "include": "#graphql-enum-value" },
+            { "include": "#literal-quasi-embedded" }
+          ]
+        },
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" }
+      ]
+    },
+    "graphql-enum-value": {
+      "name": "constant.character.enum.graphql",
+      "match": "\\s*(?!=\\b(true|false|null)\\b)([_A-Za-z][_0-9A-Za-z]*)"
+    },
+    "graphql-value": {
+      "patterns": [
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-variable-name" },
+        { "include": "#graphql-float-value" },
+        { "include": "#graphql-string-value" },
+        { "include": "#graphql-boolean-value" },
+        { "include": "#graphql-null-value" },
+        { "include": "#graphql-enum-value" },
+        { "include": "#graphql-list-value" },
+        { "include": "#graphql-object-value" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "graphql-list-value": {
+      "patterns": [
+        {
+          "name": "meta.listvalues.graphql",
+          "begin": "\\s*+(\\[)",
+          "end": "\\s*(\\])",
+          "endCaptures": {
+            "1": { "name": "meta.brace.square.graphql" }
+          },
+          "beginCaptures": {
+            "1": { "name": "meta.brace.square.graphql" }
+          },
+          "patterns": [{ "include": "#graphql-value" }]
+        }
+      ]
+    },
+    "graphql-object-value": {
+      "patterns": [
+        {
+          "name": "meta.objectvalues.graphql",
+          "begin": "\\s*+({)",
+          "end": "\\s*(})",
+          "beginCaptures": {
+            "1": { "name": "meta.brace.curly.graphql" }
+          },
+          "endCaptures": {
+            "1": { "name": "meta.brace.curly.graphql" }
+          },
+          "patterns": [
+            { "include": "#graphql-object-field" },
+            { "include": "#graphql-value" }
+          ]
+        }
+      ]
+    },
+    "graphql-object-field": {
+      "match": "\\s*(([_A-Za-z][_0-9A-Za-z]*))\\s*(:)",
+      "captures": {
+        "1": { "name": "constant.object.key.graphql" },
+        "2": { "name": "string.unquoted.graphql" },
+        "3": { "name": "punctuation.graphql" }
+      }
+    },
+    "graphql-union": {
+      "begin": "\\s*\\b(union)\\b\\s*([_A-Za-z][_0-9A-Za-z]*)",
+      "end": "(?=.)",
+      "applyEndPatternLast": 1,
+      "captures": {
+        "1": { "name": "keyword.union.graphql" },
+        "2": { "name": "support.type.graphql" }
+      },
+      "patterns": [
+        {
+          "begin": "\\s*(=)\\s*([_A-Za-z][_0-9A-Za-z]*)",
+          "end": "(?=.)",
+          "applyEndPatternLast": 1,
+          "captures": {
+            "1": { "name": "punctuation.assignment.graphql" },
+            "2": { "name": "support.type.graphql" }
+          },
+          "patterns": [
+            { "include": "#graphql-comment" },
+            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-skip-newlines" },
+            { "include": "#literal-quasi-embedded" },
+            {
+              "match": "\\s*(\\|)\\s*([_A-Za-z][_0-9A-Za-z]*)",
+              "captures": {
+                "1": { "name": "punctuation.or.graphql" },
+                "2": { "name": "support.type.graphql" }
+              }
+            }
+          ]
+        },
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-skip-newlines" },
+        { "include": "#literal-quasi-embedded" }
+      ]
+    },
+    "native-interpolation": {
+      "name": "native.interpolation",
+      "begin": "\\s*(\\${)",
+      "end": "(})",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.substitution.begin" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.other.substitution.end" }
+      },
+      "patterns": [
+        { "include": "source.js" },
+        { "include": "source.ts" },
+        { "include": "source.js.jsx" },
+        { "include": "source.tsx" }
+      ]
+    },
+    "graphql-skip-newlines": {
+      "match": "\\s*\n"
+    }
+  }
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/handlebars.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/handlebars.tmLanguage.json
@@ -1,0 +1,852 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/daaain/Handlebars/blob/master/grammars/Handlebars.json",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/daaain/Handlebars/commit/85a153a6f759df4e8da7533e1b3651f007867c51",
+	"name": "Handlebars",
+	"scopeName": "text.html.handlebars",
+	"patterns": [
+		{
+			"include": "#yfm"
+		},
+		{
+			"include": "#extends"
+		},
+		{
+			"include": "#block_comments"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#block_helper"
+		},
+		{
+			"include": "#end_block"
+		},
+		{
+			"include": "#else_token"
+		},
+		{
+			"include": "#partial_and_var"
+		},
+		{
+			"include": "#inline_script"
+		},
+		{
+			"include": "#html_tags"
+		},
+		{
+			"include": "text.html.basic"
+		}
+	],
+	"repository": {
+		"html_tags": {
+			"patterns": [
+				{
+					"begin": "(<)([a-zA-Z0-9:-]+)(?=[^>]*></\\2>)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.html"
+						}
+					},
+					"end": "(>(<)/)(\\2)(>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "meta.scope.between-tag-pair.html"
+						},
+						"3": {
+							"name": "entity.name.tag.html"
+						},
+						"4": {
+							"name": "punctuation.definition.tag.html"
+						}
+					},
+					"name": "meta.tag.any.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						}
+					]
+				},
+				{
+					"begin": "(<\\?)(xml)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.xml.html"
+						}
+					},
+					"end": "(\\?>)",
+					"name": "meta.tag.preprocessor.xml.html",
+					"patterns": [
+						{
+							"include": "#tag_generic_attribute"
+						},
+						{
+							"include": "#string"
+						}
+					]
+				},
+				{
+					"begin": "<!--",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.html"
+						}
+					},
+					"end": "--\\s*>",
+					"name": "comment.block.html",
+					"patterns": [
+						{
+							"match": "--",
+							"name": "invalid.illegal.bad-comments-or-CDATA.html"
+						}
+					]
+				},
+				{
+					"begin": "<!",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.tag.html"
+						}
+					},
+					"end": ">",
+					"name": "meta.tag.sgml.html",
+					"patterns": [
+						{
+							"begin": "(DOCTYPE|doctype)",
+							"captures": {
+								"1": {
+									"name": "entity.name.tag.doctype.html"
+								}
+							},
+							"end": "(?=>)",
+							"name": "meta.tag.sgml.doctype.html",
+							"patterns": [
+								{
+									"match": "\"[^\">]*\"",
+									"name": "string.quoted.double.doctype.identifiers-and-DTDs.html"
+								}
+							]
+						},
+						{
+							"begin": "\\[CDATA\\[",
+							"end": "]](?=>)",
+							"name": "constant.other.inline-data.html"
+						},
+						{
+							"match": "(\\s*)(?!--|>)\\S(\\s*)",
+							"name": "invalid.illegal.bad-comments-or-CDATA.html"
+						}
+					]
+				},
+				{
+					"begin": "(?:^\\s+)?(<)((?i:style))\\b(?![^>]*/>)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.style.html"
+						},
+						"3": {
+							"name": "punctuation.definition.tag.html"
+						}
+					},
+					"end": "(</)((?i:style))(>)(?:\\s*\\n)?",
+					"name": "source.css.embedded.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(>)",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.definition.tag.html"
+								}
+							},
+							"end": "(?=</(?i:style))",
+							"patterns": [
+								{
+									"include": "source.css"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?:^\\s+)?(<)((?i:script))\\b(?![^>]*/>)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.script.html"
+						}
+					},
+					"end": "(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?",
+					"endCaptures": {
+						"2": {
+							"name": "punctuation.definition.tag.html"
+						}
+					},
+					"name": "source.js.embedded.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<!</(?:script|SCRIPT))(>)",
+							"captures": {
+								"1": {
+									"name": "punctuation.definition.tag.html"
+								},
+								"2": {
+									"name": "entity.name.tag.script.html"
+								}
+							},
+							"end": "(</)((?i:script))",
+							"patterns": [
+								{
+									"captures": {
+										"1": {
+											"name": "punctuation.definition.comment.js"
+										}
+									},
+									"match": "(//).*?((?=</script)|$\\n?)",
+									"name": "comment.line.double-slash.js"
+								},
+								{
+									"begin": "/\\*",
+									"captures": {
+										"0": {
+											"name": "punctuation.definition.comment.js"
+										}
+									},
+									"end": "\\*/|(?=</script)",
+									"name": "comment.block.js"
+								},
+								{
+									"include": "source.js"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(</?)((?i:body|head|html)\\b)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.structure.any.html"
+						}
+					},
+					"end": "(>)",
+					"name": "meta.tag.structure.any.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						}
+					]
+				},
+				{
+					"begin": "(</?)((?i:address|blockquote|dd|div|header|section|footer|aside|nav|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|menu|pre)\\b)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.block.any.html"
+						}
+					},
+					"end": "(>)",
+					"name": "meta.tag.block.any.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						}
+					]
+				},
+				{
+					"begin": "(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.inline.any.html"
+						}
+					},
+					"end": "((?: ?/)?>)",
+					"name": "meta.tag.inline.any.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						}
+					]
+				},
+				{
+					"begin": "(</?)([a-zA-Z0-9:-]+)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.other.html"
+						}
+					},
+					"end": "(>)",
+					"name": "meta.tag.other.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						}
+					]
+				},
+				{
+					"begin": "(</?)([a-zA-Z0-9{}:-]+)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.tokenised.html"
+						}
+					},
+					"end": "(>)",
+					"name": "meta.tag.tokenised.html",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						}
+					]
+				},
+				{
+					"include": "#entities"
+				},
+				{
+					"match": "<>",
+					"name": "invalid.illegal.incomplete.html"
+				},
+				{
+					"match": "<",
+					"name": "invalid.illegal.bad-angle-bracket.html"
+				}
+			]
+		},
+		"entities": {
+			"patterns": [
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.entity.html"
+						},
+						"3": {
+							"name": "punctuation.definition.entity.html"
+						}
+					},
+					"name": "constant.character.entity.html",
+					"match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)"
+				},
+				{
+					"name": "invalid.illegal.bad-ampersand.html",
+					"match": "&"
+				}
+			]
+		},
+		"end_block": {
+			"begin": "(\\{\\{)(~?/)([a-zA-Z0-9/_\\.-]+)\\s*",
+			"end": "(~?\\}\\})",
+			"name": "meta.function.block.end.handlebars",
+			"endCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				}
+			},
+			"beginCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				},
+				"2": {
+					"name": "support.constant.handlebars keyword.control"
+				},
+				"3": {
+					"name": "support.constant.handlebars keyword.control"
+				}
+			},
+			"patterns": []
+		},
+		"yfm": {
+			"patterns": [
+				{
+					"patterns": [
+						{
+							"include": "source.yaml"
+						}
+					],
+					"begin": "(?<!\\s)---\\n$",
+					"end": "^---\\s",
+					"name": "markup.raw.yaml.front-matter"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"patterns": [
+						{
+							"name": "keyword.annotation.handlebars",
+							"match": "@\\w*"
+						},
+						{
+							"include": "#comments"
+						}
+					],
+					"begin": "\\{\\{!",
+					"end": "\\}\\}",
+					"name": "comment.block.handlebars"
+				},
+				{
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.html"
+						}
+					},
+					"begin": "<!--",
+					"end": "-{2,3}\\s*>",
+					"name": "comment.block.html",
+					"patterns": [
+						{
+							"name": "invalid.illegal.bad-comments-or-CDATA.html",
+							"match": "--"
+						}
+					]
+				}
+			]
+		},
+		"block_comments": {
+			"patterns": [
+				{
+					"patterns": [
+						{
+							"name": "keyword.annotation.handlebars",
+							"match": "@\\w*"
+						},
+						{
+							"include": "#comments"
+						}
+					],
+					"begin": "\\{\\{!--",
+					"end": "--\\}\\}",
+					"name": "comment.block.handlebars"
+				},
+				{
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.html"
+						}
+					},
+					"begin": "<!--",
+					"end": "-{2,3}\\s*>",
+					"name": "comment.block.html",
+					"patterns": [
+						{
+							"name": "invalid.illegal.bad-comments-or-CDATA.html",
+							"match": "--"
+						}
+					]
+				}
+			]
+		},
+		"block_helper": {
+			"begin": "(\\{\\{)(~?\\#)([-a-zA-Z0-9_\\./>]+)\\s?(@?[-a-zA-Z0-9_\\./]+)*\\s?(@?[-a-zA-Z0-9_\\./]+)*\\s?(@?[-a-zA-Z0-9_\\./]+)*",
+			"end": "(~?\\}\\})",
+			"name": "meta.function.block.start.handlebars",
+			"endCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				}
+			},
+			"beginCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				},
+				"2": {
+					"name": "support.constant.handlebars keyword.control"
+				},
+				"3": {
+					"name": "support.constant.handlebars keyword.control"
+				},
+				"4": {
+					"name": "variable.parameter.handlebars"
+				},
+				"5": {
+					"name": "support.constant.handlebars"
+				},
+				"6": {
+					"name": "variable.parameter.handlebars"
+				},
+				"7": {
+					"name": "support.constant.handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#handlebars_attribute"
+				}
+			]
+		},
+		"string-single-quoted": {
+			"begin": "'",
+			"end": "'",
+			"name": "string.quoted.single.handlebars",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.html"
+				}
+			},
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.html"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#escaped-single-quote"
+				},
+				{
+					"include": "#block_comments"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#block_helper"
+				},
+				{
+					"include": "#else_token"
+				},
+				{
+					"include": "#end_block"
+				},
+				{
+					"include": "#partial_and_var"
+				}
+			]
+		},
+		"string": {
+			"patterns": [
+				{
+					"include": "#string-single-quoted"
+				},
+				{
+					"include": "#string-double-quoted"
+				}
+			]
+		},
+		"escaped-single-quote": {
+			"name": "constant.character.escape.js",
+			"match": "\\\\'"
+		},
+		"escaped-double-quote": {
+			"name": "constant.character.escape.js",
+			"match": "\\\\\""
+		},
+		"partial_and_var": {
+			"begin": "(\\{\\{~?\\{*(>|!<)*)\\s*(@?[-a-zA-Z0-9$_\\./]+)*",
+			"end": "(~?\\}\\}\\}*)",
+			"name": "meta.function.inline.other.handlebars",
+			"beginCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				},
+				"3": {
+					"name": "variable.parameter.handlebars"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#handlebars_attribute"
+				}
+			]
+		},
+		"handlebars_attribute_name": {
+			"begin": "\\b([-a-zA-Z0-9_\\.]+)\\b=",
+			"captures": {
+				"1": {
+					"name": "variable.parameter.handlebars"
+				}
+			},
+			"end": "(?='|\"|)",
+			"name": "entity.other.attribute-name.handlebars"
+		},
+		"handlebars_attribute_value": {
+			"begin": "([-a-zA-Z0-9_\\./]+)\\b",
+			"captures": {
+				"1": {
+					"name": "variable.parameter.handlebars"
+				}
+			},
+			"end": "('|\"|)",
+			"name": "entity.other.attribute-value.handlebars",
+			"patterns": [
+				{
+					"include": "#string"
+				}
+			]
+		},
+		"handlebars_attribute": {
+			"patterns": [
+				{
+					"include": "#handlebars_attribute_name"
+				},
+				{
+					"include": "#handlebars_attribute_value"
+				}
+			]
+		},
+		"extends": {
+			"patterns": [
+				{
+					"end": "(\\}\\})",
+					"begin": "(\\{\\{!<)\\s([-a-zA-Z0-9_\\./]+)",
+					"beginCaptures": {
+						"1": {
+							"name": "support.function.handlebars"
+						},
+						"2": {
+							"name": "support.class.handlebars"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "support.function.handlebars"
+						}
+					},
+					"name": "meta.preprocessor.handlebars"
+				}
+			]
+		},
+		"else_token": {
+			"begin": "(\\{\\{)(~?else)(@?\\s(if)\\s([-a-zA-Z0-9_\\.\\(\\s\\)/]+))?",
+			"end": "(~?\\}\\}\\}*)",
+			"name": "meta.function.inline.else.handlebars",
+			"beginCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				},
+				"2": {
+					"name": "support.constant.handlebars keyword.control"
+				},
+				"3": {
+					"name": "support.constant.handlebars"
+				},
+				"4": {
+					"name": "variable.parameter.handlebars"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.constant.handlebars"
+				}
+			}
+		},
+		"string-double-quoted": {
+			"begin": "\"",
+			"end": "\"",
+			"name": "string.quoted.double.handlebars",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.html"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.html"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#escaped-double-quote"
+				},
+				{
+					"include": "#block_comments"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#block_helper"
+				},
+				{
+					"include": "#else_token"
+				},
+				{
+					"include": "#end_block"
+				},
+				{
+					"include": "#partial_and_var"
+				}
+			]
+		},
+		"inline_script": {
+			"begin": "(?:^\\s+)?(<)((?i:script))\\b(?:.*(type)=([\"'](?:text/x-handlebars-template|text/x-handlebars|text/template|x-tmpl-handlebars)[\"']))(?![^>]*/>)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.html"
+				},
+				"2": {
+					"name": "entity.name.tag.script.html"
+				},
+				"3": {
+					"name": "entity.other.attribute-name.html"
+				},
+				"4": {
+					"name": "string.quoted.double.html"
+				}
+			},
+			"end": "(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?",
+			"endCaptures": {
+				"2": {
+					"name": "punctuation.definition.tag.html"
+				}
+			},
+			"name": "source.handlebars.embedded.html",
+			"patterns": [
+				{
+					"include": "#tag-stuff"
+				},
+				{
+					"begin": "(?<!</(?:script|SCRIPT))(>)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.tag.html"
+						},
+						"2": {
+							"name": "entity.name.tag.script.html"
+						}
+					},
+					"end": "(</)((?i:script))",
+					"patterns": [
+						{
+							"include": "#block_comments"
+						},
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#block_helper"
+						},
+						{
+							"include": "#end_block"
+						},
+						{
+							"include": "#else_token"
+						},
+						{
+							"include": "#partial_and_var"
+						},
+						{
+							"include": "#html_tags"
+						},
+						{
+							"include": "text.html.basic"
+						}
+					]
+				}
+			]
+		},
+		"tag_generic_attribute": {
+			"begin": "\\b([a-zA-Z0-9_-]+)\\b\\s*(=)",
+			"captures": {
+				"1": {
+					"name": "entity.other.attribute-name.generic.html"
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string"
+				}
+			],
+			"name": "entity.other.attribute-name.html",
+			"end": "(?<='|\"|)"
+		},
+		"tag_id_attribute": {
+			"begin": "\\b(id)\\b\\s*(=)",
+			"captures": {
+				"1": {
+					"name": "entity.other.attribute-name.id.html"
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html"
+				}
+			},
+			"end": "(?<='|\"|)",
+			"name": "meta.attribute-with-value.id.html",
+			"patterns": [
+				{
+					"include": "#string"
+				}
+			]
+		},
+		"tag-stuff": {
+			"patterns": [
+				{
+					"include": "#tag_id_attribute"
+				},
+				{
+					"include": "#tag_generic_attribute"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#block_comments"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#block_helper"
+				},
+				{
+					"include": "#end_block"
+				},
+				{
+					"include": "#else_token"
+				},
+				{
+					"include": "#partial_and_var"
+				}
+			]
+		}
+	}
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/ignore.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/ignore.tmLanguage.json
@@ -1,0 +1,10 @@
+{
+	"name": "Ignore",
+	"scopeName": "source.ignore",
+	"patterns": [
+		{
+			"match": "^#.*",
+			"name": "comment.line.number-sign.ignore"
+		}
+	]
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/ini.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/ini.tmLanguage.json
@@ -1,0 +1,113 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/textmate/ini.tmbundle/blob/master/Syntaxes/Ini.plist",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/textmate/ini.tmbundle/commit/2af0cbb0704940f967152616f2f1ff0aae6287a6",
+	"name": "Ini",
+	"scopeName": "source.ini",
+	"patterns": [
+		{
+			"begin": "(^[ \\t]+)?(?=#)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.whitespace.comment.leading.ini"
+				}
+			},
+			"end": "(?!\\G)",
+			"patterns": [
+				{
+					"begin": "#",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.ini"
+						}
+					},
+					"end": "\\n",
+					"name": "comment.line.number-sign.ini"
+				}
+			]
+		},
+		{
+			"begin": "(^[ \\t]+)?(?=;)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.whitespace.comment.leading.ini"
+				}
+			},
+			"end": "(?!\\G)",
+			"patterns": [
+				{
+					"begin": ";",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.ini"
+						}
+					},
+					"end": "\\n",
+					"name": "comment.line.semicolon.ini"
+				}
+			]
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.definition.ini"
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.ini"
+				}
+			},
+			"match": "\\b([a-zA-Z0-9_.-]+)\\b\\s*(=)"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.entity.ini"
+				},
+				"3": {
+					"name": "punctuation.definition.entity.ini"
+				}
+			},
+			"match": "^(\\[)(.*?)(\\])",
+			"name": "entity.name.section.group-title.ini"
+		},
+		{
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ini"
+				}
+			},
+			"end": "'",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.ini"
+				}
+			},
+			"name": "string.quoted.single.ini",
+			"patterns": [
+				{
+					"match": "\\\\.",
+					"name": "constant.character.escape.ini"
+				}
+			]
+		},
+		{
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ini"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.ini"
+				}
+			},
+			"name": "string.quoted.double.ini"
+		}
+	]
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/liquid.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/liquid.tmLanguage.json
@@ -1,0 +1,1100 @@
+{
+  "name": "Liquid HTML",
+  "scopeName": "text.html.liquid",
+  "fileTypes": [
+    "liquid"
+  ],
+  "foldingStartMarker": "(?x)\n{%\n  -?\n  \\s*\n  (capture|case|comment|for|form|if|javascript|paginate|schema|style)\n  [^(%})]+\n%}\n",
+  "foldingStopMarker": "(?x)\n{%\n  \\s*\n  (endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endstyle)\n  [^(%})]+\n%}\n",
+  "injections": {
+    "L:meta.embedded.block.js, L:meta.embedded.block.css, L:meta.embedded.block.html, L:string.quoted": {
+      "patterns": [
+        {
+          "include": "#injection"
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "include": "#core"
+    }
+  ],
+  "repository": {
+    "core": {
+      "patterns": [
+        {
+          "include": "#raw_tag"
+        },
+        {
+          "include": "#doc_tag"
+        },
+        {
+          "include": "#comment_block"
+        },
+        {
+          "include": "#style_codefence"
+        },
+        {
+          "include": "#stylesheet_codefence"
+        },
+        {
+          "include": "#json_codefence"
+        },
+        {
+          "include": "#javascript_codefence"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#tag"
+        },
+        {
+          "include": "text.html.basic"
+        }
+      ]
+    },
+    "injection": {
+      "patterns": [
+        {
+          "include": "#raw_tag"
+        },
+        {
+          "include": "#comment_block"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#tag_injection"
+        }
+      ]
+    },
+    "raw_tag": {
+      "begin": "{%-?\\s*(raw)\\s*-?%}",
+      "end": "{%-?\\s*(endraw)\\s*-?%}",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "name": "meta.entity.tag.raw.liquid",
+      "contentName": "string.unquoted.liquid",
+      "patterns": [
+        {
+          "match": "(.(?!{%-?\\s*endraw\\s*-?%}))*."
+        }
+      ]
+    },
+    "doc_tag": {
+      "begin": "{%-?\\s*(doc)\\s*-?%}",
+      "end": "{%-?\\s*(enddoc)\\s*-?%}",
+      "name": "meta.block.doc.liquid",
+      "contentName": "comment.block.documentation.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.liquid"
+        },
+        "1": {
+          "name": "entity.name.tag.doc.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.liquid"
+        },
+        "1": {
+          "name": "entity.name.tag.doc.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#liquid_doc_description_tag"
+        },
+        {
+          "include": "#liquid_doc_param_tag"
+        },
+        {
+          "include": "#liquid_doc_example_tag"
+        },
+        {
+          "include": "#liquid_doc_prompt_tag"
+        },
+        {
+          "include": "#liquid_doc_fallback_tag"
+        }
+      ]
+    },
+    "liquid_doc_description_tag": {
+      "begin": "(@description)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "string.quoted.single.liquid"
+    },
+    "liquid_doc_param_tag": {
+      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?(\\[?[a-zA-Z_][\\w-]*\\]?)?(?:\\s+(.*))?",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        },
+        "2": {
+          "name": "entity.name.type.instance.liquid"
+        },
+        "3": {
+          "name": "variable.other.liquid"
+        },
+        "4": {
+          "name": "string.quoted.single.liquid"
+        }
+      }
+    },
+    "liquid_doc_example_tag": {
+      "begin": "(@example)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "meta.embedded.block.liquid",
+      "patterns": [
+        {
+          "include": "#core"
+        }
+      ]
+    },
+    "liquid_doc_prompt_tag": {
+      "begin": "(@prompt)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "string.quoted.single.liquid"
+    },
+    "liquid_doc_fallback_tag": {
+      "match": "(@\\w+)\\b",
+      "captures": {
+        "1": {
+          "name": "comment.block.liquid"
+        }
+      }
+    },
+    "comment_block": {
+      "begin": "{%-?\\s*comment\\s*-?%}",
+      "end": "{%-?\\s*endcomment\\s*-?%}",
+      "name": "comment.block.liquid",
+      "patterns": [
+        {
+          "include": "#comment_block"
+        },
+        {
+          "match": "(.(?!{%-?\\s*(comment|endcomment)\\s*-?%}))*."
+        }
+      ]
+    },
+    "style_codefence": {
+      "begin": "({%-?)\\s*(style)\\s*(-?%})",
+      "end": "({%-?)\\s*(endstyle)\\s*(-?%})",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.style.start.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.style.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.style.end.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.end.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.style.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "name": "meta.block.style.liquid",
+      "contentName": "meta.embedded.block.css",
+      "patterns": [
+        {
+          "include": "source.css"
+        }
+      ]
+    },
+    "stylesheet_codefence": {
+      "begin": "({%-?)\\s*(stylesheet)\\s*(-?%})",
+      "end": "({%-?)\\s*(endstylesheet)\\s*(-?%})",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.style.start.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.style.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.style.end.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.end.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.style.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "name": "meta.block.style.liquid",
+      "contentName": "meta.embedded.block.css",
+      "patterns": [
+        {
+          "include": "source.css"
+        }
+      ]
+    },
+    "json_codefence": {
+      "begin": "({%-?)\\s*(schema)\\s*(-?%})",
+      "end": "({%-?)\\s*(endschema)\\s*(-?%})",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.schema.start.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.schema.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.schema.end.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.end.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.schema.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "name": "meta.block.schema.liquid",
+      "contentName": "meta.embedded.block.json",
+      "patterns": [
+        {
+          "include": "source.json"
+        }
+      ]
+    },
+    "javascript_codefence": {
+      "begin": "({%-?)\\s*(javascript)\\s*(-?%})",
+      "end": "({%-?)\\s*(endjavascript)\\s*(-?%})",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.javascript.start.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.javascript.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.javascript.end.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.end.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.javascript.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "name": "meta.block.javascript.liquid",
+      "contentName": "meta.embedded.block.js",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+    },
+    "tag": {
+      "begin": "(?<!comment %})(?<!comment -%})(?<!comment%})(?<!comment-%})(?<!raw %})(?<!raw -%})(?<!raw%})(?<!raw-%}){%-?",
+      "end": "-?%}",
+      "name": "meta.tag.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#tag_body"
+        }
+      ]
+    },
+    "tag_injection": {
+      "begin": "(?<!comment %})(?<!comment -%})(?<!comment%})(?<!comment-%})(?<!raw %})(?<!raw -%})(?<!raw%})(?<!raw-%}){%-?(?!-?\\s*(endstyle|endjavascript|endcomment|endraw))",
+      "end": "-?%}",
+      "name": "meta.tag.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#tag_body"
+        }
+      ]
+    },
+    "tag_body": {
+      "patterns": [
+        {
+          "include": "#tag_liquid"
+        },
+        {
+          "include": "#tag_assign"
+        },
+        {
+          "include": "#tag_comment_inline"
+        },
+        {
+          "include": "#tag_case"
+        },
+        {
+          "include": "#tag_conditional"
+        },
+        {
+          "include": "#tag_for"
+        },
+        {
+          "include": "#tag_paginate"
+        },
+        {
+          "include": "#tag_render"
+        },
+        {
+          "include": "#tag_tablerow"
+        },
+        {
+          "include": "#tag_expression"
+        }
+      ]
+    },
+    "tag_liquid": {
+      "name": "meta.entity.tag.liquid.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(liquid)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.liquid.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_comment_block_liquid"
+        },
+        {
+          "include": "#tag_comment_inline_liquid"
+        },
+        {
+          "include": "#tag_assign_liquid"
+        },
+        {
+          "include": "#tag_case_liquid"
+        },
+        {
+          "include": "#tag_conditional_liquid"
+        },
+        {
+          "include": "#tag_for_liquid"
+        },
+        {
+          "include": "#tag_paginate_liquid"
+        },
+        {
+          "include": "#tag_render_liquid"
+        },
+        {
+          "include": "#tag_tablerow_liquid"
+        },
+        {
+          "include": "#tag_expression_liquid"
+        }
+      ]
+    },
+    "tag_comment_block_liquid": {
+      "name": "comment.block.liquid",
+      "begin": "(?:^\\s*)(comment)\\b",
+      "end": "(?:^\\s*)(endcomment)\\b",
+      "patterns": [
+        {
+          "include": "#tag_comment_block_liquid"
+        },
+        {
+          "match": "(?:^\\s*)(?!(comment|endcomment)).*"
+        }
+      ]
+    },
+    "tag_comment_inline": {
+      "name": "comment.line.number-sign.liquid",
+      "begin": "#",
+      "end": "(?=%})"
+    },
+    "tag_comment_inline_liquid": {
+      "name": "comment.line.number-sign.liquid",
+      "begin": "(?:^\\s*)#.*",
+      "end": "$"
+    },
+    "tag_tablerow": {
+      "name": "meta.entity.tag.tablerow.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(tablerow)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.tablerow.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_tablerow_body"
+        }
+      ]
+    },
+    "tag_tablerow_liquid": {
+      "name": "meta.entity.tag.tablerow.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(tablerow)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.tablerow.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_tablerow_body"
+        }
+      ]
+    },
+    "tag_tablerow_body": {
+      "patterns": [
+        {
+          "match": "\\b(in)\\b",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "match": "\\b(cols|offset|limit):",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_for": {
+      "name": "meta.entity.tag.for.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(for)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.for.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_for_body"
+        }
+      ]
+    },
+    "tag_for_liquid": {
+      "name": "meta.entity.tag.for.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(for)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.for.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_for_body"
+        }
+      ]
+    },
+    "tag_for_body": {
+      "patterns": [
+        {
+          "match": "\\b(in|reversed)\\b",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "match": "\\b(offset|limit):",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_assign": {
+      "name": "meta.entity.tag.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(assign|echo)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#filter"
+        },
+        {
+          "include": "#attribute"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_assign_liquid": {
+      "name": "meta.entity.tag.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(assign|echo)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#filter"
+        },
+        {
+          "include": "#attribute_liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_render": {
+      "name": "meta.entity.tag.render.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(render)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.render.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_render_special_keywords"
+        },
+        {
+          "include": "#attribute"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_render_liquid": {
+      "name": "meta.entity.tag.render.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(render)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.render.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_render_special_keywords"
+        },
+        {
+          "include": "#attribute_liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_render_special_keywords": {
+      "match": "\\b(with|as|for)\\b",
+      "name": "keyword.control.other.liquid"
+    },
+    "tag_paginate": {
+      "name": "meta.entity.tag.paginate.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(paginate)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.paginate.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_paginate_body"
+        }
+      ]
+    },
+    "tag_paginate_liquid": {
+      "name": "meta.entity.tag.paginate.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(paginate)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.paginate.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_paginate_body"
+        }
+      ]
+    },
+    "tag_paginate_body": {
+      "patterns": [
+        {
+          "match": "\\b(by)\\b",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_conditional": {
+      "name": "meta.entity.tag.conditional.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(if|elsif|unless)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.conditional.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_conditional_liquid": {
+      "name": "meta.entity.tag.conditional.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(if|elsif|unless)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.conditional.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_case": {
+      "name": "meta.entity.tag.case.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(case|when)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.case.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_case_liquid": {
+      "name": "meta.entity.tag.case.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(case|when)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.case.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_expression_without_arguments": {
+      "patterns": [
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endunless|endif)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.conditional.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endfor|endtablerow|endpaginate)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.loop.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcase)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.case.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(capture|case|comment|for|form|if|javascript|paginate|schema|style)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.other.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endstyle)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.other.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(else|break|continue)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.other.liquid"
+            }
+          }
+        }
+      ]
+    },
+    "tag_expression": {
+      "patterns": [
+        {
+          "include": "#tag_expression_without_arguments"
+        },
+        {
+          "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(\\w+)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.liquid"
+            }
+          },
+          "end": "(?=%})",
+          "name": "meta.entity.tag.liquid",
+          "patterns": [
+            {
+              "include": "#value_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "tag_expression_liquid": {
+      "patterns": [
+        {
+          "include": "#tag_expression_without_arguments"
+        },
+        {
+          "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(\\w+)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.liquid"
+            }
+          },
+          "end": "$",
+          "name": "meta.entity.tag.liquid",
+          "patterns": [
+            {
+              "include": "#value_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "object": {
+      "begin": "(?<!comment %})(?<!comment -%})(?<!comment%})(?<!comment-%})(?<!raw %})(?<!raw -%})(?<!raw%})(?<!raw-%}){{-?",
+      "end": "-?}}",
+      "name": "meta.object.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#filter"
+        },
+        {
+          "include": "#attribute"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "invalid_range": {
+      "match": "\\((.(?!\\.\\.))+\\)",
+      "name": "invalid.illegal.range.liquid"
+    },
+    "range": {
+      "begin": "\\(",
+      "end": "\\)",
+      "name": "meta.range.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\.\\.",
+          "name": "punctuation.range.liquid"
+        },
+        {
+          "include": "#variable_lookup"
+        },
+        {
+          "include": "#number"
+        }
+      ]
+    },
+    "number": {
+      "match": "((-|\\+)\\s*)?[0-9]+(\\.[0-9]+)?",
+      "name": "constant.numeric.liquid"
+    },
+    "string": {
+      "patterns": [
+        {
+          "include": "#string_single"
+        },
+        {
+          "include": "#string_double"
+        }
+      ]
+    },
+    "string_double": {
+      "begin": "\"",
+      "end": "\"",
+      "name": "string.quoted.double.liquid"
+    },
+    "string_single": {
+      "begin": "'",
+      "end": "'",
+      "name": "string.quoted.single.liquid"
+    },
+    "operator": {
+      "match": "(?:(?<=\\s)|\\b)(\\=\\=|!\\=|\\>|\\<|\\>\\=|\\<\\=|or|and|contains)(?:(?=\\s)|\\b)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.expression.liquid"
+        }
+      }
+    },
+    "language_constant": {
+      "match": "\\b(false|true|nil|blank)\\b|empty(?!\\?)",
+      "name": "constant.language.liquid"
+    },
+    "attribute": {
+      "begin": "\\w+:",
+      "end": "(?=,|%}|}}|\\|)",
+      "beginCaptures": {
+        "0": {
+          "name": "entity.other.attribute-name.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "attribute_liquid": {
+      "begin": "\\w+:",
+      "end": "(?=,|\\|)|$",
+      "beginCaptures": {
+        "0": {
+          "name": "entity.other.attribute-name.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "filter": {
+      "match": "\\|\\s*((?![\\.0-9])[a-zA-Z0-9_-]+\\:?)\\s*",
+      "captures": {
+        "1": {
+          "name": "support.function.liquid"
+        }
+      }
+    },
+    "value_expression": {
+      "patterns": [
+        {
+          "match": "(\\[)(\\|)(?=[^\\]]*)(?=\\])",
+          "captures": {
+            "2": {
+              "name": "invalid.illegal.filter.liquid"
+            },
+            "3": {
+              "name": "invalid.illegal.filter.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?<=\\s)(\\+|\\-|\\/|\\*)(?=\\s)",
+          "name": "invalid.illegal.filter.liquid"
+        },
+        {
+          "include": "#language_constant"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#invalid_range"
+        },
+        {
+          "include": "#range"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#variable_lookup"
+        }
+      ]
+    },
+    "variable_lookup": {
+      "patterns": [
+        {
+          "match": "\\b(additional_checkout_buttons|address|all_country_option_tags|all_products|article|articles|block|blog|blogs|canonical_url|cart|checkout|collection|collections|comment|content_for_additional_checkout_buttons|content_for_header|content_for_index|content_for_layout|country_option_tags|currency|current_page|current_tags|customer|customer_address|discount_allocation|discount_application|external_video|font|forloop|form|fulfillment|gift_card|handle|image|images|line_item|link|linklist|linklists|location|localization|metafield|model|model_source|order|page|page_description|page_image|page_title|pages|paginate|part|policy|powered_by_link|predictive_search|product|product_option|product_variant|recommendations|request|routes|script|scripts|search|section|selling_plan|selling_plan_allocation|selling_plan_group|settings|shipping_method|shop|shop_locale|store_availability|tablerow|tax_line|template|theme|transaction|unit_price_measurement|variant|video|video_source)\\b",
+          "name": "variable.language.liquid"
+        },
+        {
+          "match": "((?<=\\w\\:\\s)\\w+)",
+          "name": "variable.parameter.liquid"
+        },
+        {
+          "begin": "(?<=\\w)\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.brackets.begin.liquid"
+            }
+          },
+          "end": "\\]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.brackets.end.liquid"
+            }
+          },
+          "name": "meta.brackets.liquid",
+          "patterns": [
+            {
+              "include": "#string"
+            }
+          ]
+        },
+        {
+          "match": "(?<=(\\w|\\])\\.)([-\\w]+\\??)",
+          "name": "variable.other.member.liquid"
+        },
+        {
+          "match": "(?<=\\w)\\.(?=\\w)",
+          "name": "punctuation.accessor.liquid"
+        },
+        {
+          "match": "(?i)[a-z_](\\w|(?:-(?!\\}\\})))*",
+          "name": "variable.other.liquid"
+        }
+      ]
+    }
+  }
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/makefile.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/makefile.tmLanguage.json
@@ -1,0 +1,634 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/fadeevab/make.tmbundle/blob/master/Syntaxes/Makefile.plist",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/fadeevab/make.tmbundle/commit/1d4c0b541959995db098df751ffc129da39a294b",
+	"name": "Makefile",
+	"scopeName": "source.makefile",
+	"patterns": [
+		{
+			"include": "#comment"
+		},
+		{
+			"include": "#variables"
+		},
+		{
+			"include": "#variable-assignment"
+		},
+		{
+			"include": "#directives"
+		},
+		{
+			"include": "#recipe"
+		},
+		{
+			"include": "#target"
+		}
+	],
+	"repository": {
+		"comma": {
+			"match": ",",
+			"name": "punctuation.separator.delimeter.comma.makefile"
+		},
+		"comment": {
+			"begin": "(^[ ]+)?((?<!\\\\)(\\\\\\\\)*)(?=#)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.whitespace.comment.leading.makefile"
+				}
+			},
+			"end": "(?!\\G)",
+			"patterns": [
+				{
+					"begin": "#",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.makefile"
+						}
+					},
+					"end": "(?=[^\\\\])$",
+					"name": "comment.line.number-sign.makefile",
+					"patterns": [
+						{
+							"match": "\\\\\\n",
+							"name": "constant.character.escape.continuation.makefile"
+						}
+					]
+				}
+			]
+		},
+		"directives": {
+			"patterns": [
+				{
+					"begin": "^[ ]*([s\\-]?include)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.include.makefile"
+						}
+					},
+					"end": "^",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#variables"
+						},
+						{
+							"match": "%",
+							"name": "constant.other.placeholder.makefile"
+						}
+					]
+				},
+				{
+					"begin": "^[ ]*(vpath)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.vpath.makefile"
+						}
+					},
+					"end": "^",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#variables"
+						},
+						{
+							"match": "%",
+							"name": "constant.other.placeholder.makefile"
+						}
+					]
+				},
+				{
+					"begin": "^\\s*(?:(override)\\s*)?(define)\\s*([^\\s]+)\\s*(=|\\?=|:=|\\+=)?(?=\\s)",
+					"captures": {
+						"1": {
+							"name": "keyword.control.override.makefile"
+						},
+						"2": {
+							"name": "keyword.control.define.makefile"
+						},
+						"3": {
+							"name": "variable.other.makefile"
+						},
+						"4": {
+							"name": "punctuation.separator.key-value.makefile"
+						}
+					},
+					"end": "^\\s*(endef)\\b",
+					"name": "meta.scope.conditional.makefile",
+					"patterns": [
+						{
+							"begin": "\\G(?!\\n)",
+							"end": "^",
+							"patterns": [
+								{
+									"include": "#comment"
+								}
+							]
+						},
+						{
+							"include": "#variables"
+						},
+						{
+							"include": "#directives"
+						}
+					]
+				},
+				{
+					"begin": "^[ ]*(export)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.$1.makefile"
+						}
+					},
+					"end": "^",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#variable-assignment"
+						},
+						{
+							"match": "[^\\s]+",
+							"name": "variable.other.makefile"
+						}
+					]
+				},
+				{
+					"begin": "^[ ]*(override|private)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.$1.makefile"
+						}
+					},
+					"end": "^",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#variable-assignment"
+						}
+					]
+				},
+				{
+					"begin": "^[ ]*(unexport|undefine)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.$1.makefile"
+						}
+					},
+					"end": "^",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"match": "[^\\s]+",
+							"name": "variable.other.makefile"
+						}
+					]
+				},
+				{
+					"begin": "^\\s*(ifeq|ifneq|ifdef|ifndef)(?=\\s)",
+					"captures": {
+						"1": {
+							"name": "keyword.control.$1.makefile"
+						}
+					},
+					"end": "^\\s*(endif)\\b",
+					"name": "meta.scope.conditional.makefile",
+					"patterns": [
+						{
+							"begin": "\\G",
+							"end": "^",
+							"name": "meta.scope.condition.makefile",
+							"patterns": [
+								{
+									"include": "#comma"
+								},
+								{
+									"include": "#variables"
+								},
+								{
+									"include": "#comment"
+								}
+							]
+						},
+						{
+							"begin": "^\\s*else(?=\\s)\\s*(ifeq|ifneq|ifdef|ifndef)*(?=\\s)",
+							"beginCaptures": {
+								"0": {
+									"name": "keyword.control.else.makefile"
+								}
+							},
+							"end": "^",
+							"patterns": [
+								{
+									"include": "#comma"
+								},
+								{
+									"include": "#variables"
+								},
+								{
+									"include": "#comment"
+								}
+							]
+						},
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"target": {
+			"begin": "^(?!\\t)([^:]*)(:)(?!\\=)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"captures": {
+								"1": {
+									"name": "support.function.target.$1.makefile"
+								}
+							},
+							"match": "^\\s*(\\.(PHONY|SUFFIXES|DEFAULT|PRECIOUS|INTERMEDIATE|SECONDARY|SECONDEXPANSION|DELETE_ON_ERROR|IGNORE|LOW_RESOLUTION_TIME|SILENT|EXPORT_ALL_VARIABLES|NOTPARALLEL|ONESHELL|POSIX))\\s*$"
+						},
+						{
+							"begin": "(?=\\S)",
+							"end": "(?=\\s|$)",
+							"name": "entity.name.function.target.makefile",
+							"patterns": [
+								{
+									"include": "#variables"
+								},
+								{
+									"match": "%",
+									"name": "constant.other.placeholder.makefile"
+								}
+							]
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.makefile"
+				}
+			},
+			"end": "[^\\\\]$",
+			"name": "meta.scope.target.makefile",
+			"patterns": [
+				{
+					"begin": "\\G",
+					"end": "(?=[^\\\\])$",
+					"name": "meta.scope.prerequisites.makefile",
+					"patterns": [
+						{
+							"match": "\\\\\\n",
+							"name": "constant.character.escape.continuation.makefile"
+						},
+						{
+							"match": "%|\\*",
+							"name": "constant.other.placeholder.makefile"
+						},
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#variables"
+						}
+					]
+				}
+			]
+		},
+		"recipe": {
+			"begin": "^\\t([+\\-@]*)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.$1.makefile"
+				}
+			},
+			"end": "[^\\\\]$",
+			"name": "meta.scope.recipe.makefile",
+			"patterns": [
+				{
+					"match": "\\\\\\n",
+					"name": "constant.character.escape.continuation.makefile"
+				},
+				{
+					"include": "#variables"
+				}
+			]
+		},
+		"variable-assignment": {
+			"begin": "(^[ ]*|\\G\\s*)([^\\s:#=]+)\\s*((?<![?:+!])=|\\?=|:=|\\+=|!=)",
+			"beginCaptures": {
+				"2": {
+					"name": "variable.other.makefile",
+					"patterns": [
+						{
+							"include": "#variables"
+						}
+					]
+				},
+				"3": {
+					"name": "punctuation.separator.key-value.makefile"
+				}
+			},
+			"end": "\\n",
+			"patterns": [
+				{
+					"match": "\\\\\\n",
+					"name": "constant.character.escape.continuation.makefile"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#variables"
+				}
+			]
+		},
+		"interpolation": {
+			"patterns": [
+				{
+					"include": "#parentheses-interpolation"
+				},
+				{
+					"include": "#braces-interpolation"
+				}
+			]
+		},
+		"parentheses-interpolation": {
+			"begin": "\\(",
+			"end": "\\)",
+			"patterns": [
+				{
+					"include": "#variables"
+				},
+				{
+					"include": "#interpolation"
+				}
+			]
+		},
+		"braces-interpolation": {
+			"begin": "{",
+			"end": "}",
+			"patterns": [
+				{
+					"include": "#variables"
+				},
+				{
+					"include": "#interpolation"
+				}
+			]
+		},
+		"variables": {
+			"patterns": [
+				{
+					"include": "#simple-variable"
+				},
+				{
+					"include": "#variable-parentheses"
+				},
+				{
+					"include": "#variable-braces"
+				}
+			]
+		},
+		"simple-variable": {
+			"patterns": [
+				{
+					"match": "\\$[^(){}]",
+					"name": "variable.language.makefile"
+				}
+			]
+		},
+		"variable-parentheses": {
+			"patterns": [
+				{
+					"begin": "\\$\\(",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.variable.makefile"
+						}
+					},
+					"end": "\\)|((?<!\\\\)\\n)",
+					"name": "string.interpolated.makefile",
+					"patterns": [
+						{
+							"include": "#variables"
+						},
+						{
+							"include": "#builtin-variable-parentheses"
+						},
+						{
+							"include": "#function-variable-parentheses"
+						},
+						{
+							"include": "#flavor-variable-parentheses"
+						},
+						{
+							"include": "#another-variable-parentheses"
+						}
+					]
+				}
+			]
+		},
+		"variable-braces": {
+			"patterns": [
+				{
+					"begin": "\\${",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.variable.makefile"
+						}
+					},
+					"end": "}|((?<!\\\\)\\n)",
+					"name": "string.interpolated.makefile",
+					"patterns": [
+						{
+							"include": "#variables"
+						},
+						{
+							"include": "#builtin-variable-braces"
+						},
+						{
+							"include": "#function-variable-braces"
+						},
+						{
+							"include": "#flavor-variable-braces"
+						},
+						{
+							"include": "#another-variable-braces"
+						}
+					]
+				}
+			]
+		},
+		"builtin-variable-parentheses": {
+			"patterns": [
+				{
+					"match": "(?<=\\()(MAKEFILES|VPATH|SHELL|MAKESHELL|MAKE|MAKELEVEL|MAKEFLAGS|MAKECMDGOALS|CURDIR|SUFFIXES|\\.LIBPATTERNS)(?=\\s*\\))",
+					"name": "variable.language.makefile"
+				}
+			]
+		},
+		"builtin-variable-braces": {
+			"patterns": [
+				{
+					"match": "(?<={)(MAKEFILES|VPATH|SHELL|MAKESHELL|MAKE|MAKELEVEL|MAKEFLAGS|MAKECMDGOALS|CURDIR|SUFFIXES|\\.LIBPATTERNS)(?=\\s*})",
+					"name": "variable.language.makefile"
+				}
+			]
+		},
+		"function-variable-parentheses": {
+			"patterns": [
+				{
+					"begin": "(?<=\\()(subst|patsubst|strip|findstring|filter(-out)?|sort|word(list)?|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|wildcard|realpath|abspath|info|error|warning|shell|foreach|if|or|and|call|eval|value|file|guile)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "support.function.$1.makefile"
+						}
+					},
+					"end": "(?=\\)|((?<!\\\\)\\n))",
+					"name": "meta.scope.function-call.makefile",
+					"patterns": [
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#variables"
+						},
+						{
+							"include": "#interpolation"
+						},
+						{
+							"match": "%|\\*",
+							"name": "constant.other.placeholder.makefile"
+						},
+						{
+							"match": "\\\\\\n",
+							"name": "constant.character.escape.continuation.makefile"
+						}
+					]
+				}
+			]
+		},
+		"function-variable-braces": {
+			"patterns": [
+				{
+					"begin": "(?<={)(subst|patsubst|strip|findstring|filter(-out)?|sort|word(list)?|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|wildcard|realpath|abspath|info|error|warning|shell|foreach|if|or|and|call|eval|value|file|guile)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "support.function.$1.makefile"
+						}
+					},
+					"end": "(?=}|((?<!\\\\)\\n))",
+					"name": "meta.scope.function-call.makefile",
+					"patterns": [
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#variables"
+						},
+						{
+							"include": "#interpolation"
+						},
+						{
+							"match": "%|\\*",
+							"name": "constant.other.placeholder.makefile"
+						},
+						{
+							"match": "\\\\\\n",
+							"name": "constant.character.escape.continuation.makefile"
+						}
+					]
+				}
+			]
+		},
+		"flavor-variable-parentheses": {
+			"patterns": [
+				{
+					"begin": "(?<=\\()(origin|flavor)\\s(?=[^\\s)]+\\s*\\))",
+					"contentName": "variable.other.makefile",
+					"beginCaptures": {
+						"1": {
+							"name": "support.function.$1.makefile"
+						}
+					},
+					"end": "(?=\\))",
+					"name": "meta.scope.function-call.makefile",
+					"patterns": [
+						{
+							"include": "#variables"
+						}
+					]
+				}
+			]
+		},
+		"flavor-variable-braces": {
+			"patterns": [
+				{
+					"begin": "(?<={)(origin|flavor)\\s(?=[^\\s}]+\\s*})",
+					"contentName": "variable.other.makefile",
+					"beginCaptures": {
+						"1": {
+							"name": "support.function.$1.makefile"
+						}
+					},
+					"end": "(?=})",
+					"name": "meta.scope.function-call.makefile",
+					"patterns": [
+						{
+							"include": "#variables"
+						}
+					]
+				}
+			]
+		},
+		"another-variable-parentheses": {
+			"patterns": [
+				{
+					"begin": "(?<=\\()(?!\\))",
+					"end": "(?=\\)|((?<!\\\\)\\n))",
+					"name": "variable.other.makefile",
+					"patterns": [
+						{
+							"include": "#variables"
+						},
+						{
+							"match": "\\\\\\n",
+							"name": "constant.character.escape.continuation.makefile"
+						}
+					]
+				}
+			]
+		},
+		"another-variable-braces": {
+			"patterns": [
+				{
+					"begin": "(?<={)(?!})",
+					"end": "(?=}|((?<!\\\\)\\n))",
+					"name": "variable.other.makefile",
+					"patterns": [
+						{
+							"include": "#variables"
+						},
+						{
+							"match": "\\\\\\n",
+							"name": "constant.character.escape.continuation.makefile"
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/nginx.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/nginx.tmLanguage.json
@@ -1,0 +1,2206 @@
+{
+ "fileTypes": [
+  "conf.erb",
+  "conf",
+  "ngx",
+  "nginx.conf",
+  "mime.types",
+  "fastcgi_params",
+  "scgi_params",
+  "uwsgi_params"
+ ],
+ "foldingStartMarker": "\\{\\s*$",
+ "foldingStopMarker": "^\\s*\\}",
+ "keyEquivalent": "^~N",
+ "name": "nginx",
+ "patterns": [
+  {
+   "name": "comment.line.number-sign",
+   "match": "\\#.*"
+  },
+  {
+   "name": "meta.context.lua.nginx",
+   "begin": "\\b((?:content|rewrite|access|init_worker|init|set|log|balancer|ssl_(?:client_hello|session_fetch|certificate))_by_lua(?:_block)?)\\s*\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "contentName": "meta.embedded.block.lua",
+   "patterns": [
+    {
+     "include": "source.lua"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.lua.nginx",
+   "begin": "\\b((?:content|rewrite|access|init_worker|init|set|log|balancer|ssl_(?:client_hello|session_fetch|certificate))_by_lua)\\s*'",
+   "end": "'",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "contentName": "meta.embedded.block.lua",
+   "patterns": [
+    {
+     "include": "source.lua"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.events.nginx",
+   "begin": "\\b(events) +\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.http.nginx",
+   "begin": "\\b(http) +\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.mail.nginx",
+   "begin": "\\b(mail) +\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.stream.nginx",
+   "begin": "\\b(stream) +\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.server.nginx",
+   "begin": "\\b(server) +\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.location.nginx",
+   "begin": "\\b(location) +([\\^]?~[\\*]?|=) +(.*?)\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    },
+    "2": {
+     "name": "keyword.operator.nginx"
+    },
+    "3": {
+     "name": "string.regexp.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.location.nginx",
+   "begin": "\\b(location) +(.*?)\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    },
+    "2": {
+     "name": "entity.name.context.location.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.limit_except.nginx",
+   "begin": "\\b(limit_except) +\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.if.nginx",
+   "begin": "\\b(if) +\\(",
+   "end": "\\)",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.control.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#if_condition"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.upstream.nginx",
+   "begin": "\\b(upstream) +(.*?)\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    },
+    "2": {
+     "name": "entity.name.context.location.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.types.nginx",
+   "begin": "\\b(types) +\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "name": "meta.context.map.nginx",
+   "begin": "\\b(map) +(\\$)([A-Za-z0-9\\_]+) +(\\$)([A-Za-z0-9\\_]+) *\\{",
+   "end": "\\}",
+   "beginCaptures": {
+    "1": {
+     "name": "storage.type.directive.context.nginx"
+    },
+    "2": {
+     "name": "punctuation.definition.variable.nginx"
+    },
+    "3": {
+     "name": "variable.parameter.nginx"
+    },
+    "4": {
+     "name": "punctuation.definition.variable.nginx"
+    },
+    "5": {
+     "name": "variable.other.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    },
+    {
+     "name": "punctuation.terminator.nginx",
+     "match": ";"
+    },
+    {
+     "name": "comment.line.number-sign",
+     "match": "\\#.*"
+    }
+   ]
+  },
+  {
+   "name": "meta.block.nginx",
+   "begin": "\\{",
+   "end": "\\}",
+   "patterns": [
+    {
+     "include": "$self"
+    }
+   ]
+  },
+  {
+   "begin": "\\b(return)\\b",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.control.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "\\b(rewrite)\\s+",
+   "end": "(last|break|redirect|permanent)?(;)",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "keyword.other.nginx"
+    },
+    "2": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "\\b(server)\\s+",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#server_parameters"
+    }
+   ]
+  },
+  {
+   "begin": "\\b(internal|empty_gif|f4f|flv|hls|mp4|break|status|stub_status|ip_hash|ntlm|least_conn|upstream_conf|least_conn|zone_sync)\\b",
+   "end": "(;|$)",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "punctuation.terminator.nginx"
+    }
+   }
+  },
+  {
+   "begin": "([\"'\\s]|^)(accept_)(mutex|mutex_delay)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(debug_)(connection|points)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(error_)(log|page)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(ssl_)(engine|buffer_size|certificate|certificate_key|ciphers|client_certificate|conf_command|crl|dhparam|early_data|ecdh_curve|ocsp|ocsp_cache|ocsp_responder|password_file|prefer_server_ciphers|protocols|reject_handshake|session_cache|session_ticket_key|session_tickets|session_timeout|stapling|stapling_file|stapling_responder|stapling_verify|trusted_certificate|verify_client|verify_depth|alpn|handshake_timeout|preread)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(worker_)(aio_requests|connections|cpu_affinity|priority|processes|rlimit_core|rlimit_nofile|shutdown_timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(auth_)(delay|basic|basic_user_file|jwt|jwt_claim_set|jwt_header_set|jwt_key_cache|jwt_key_file|jwt_key_request|jwt_leeway|jwt_type|jwt_require|request|request_set|http|http_header|http_pass_client_cert|http_timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(client_)(body_buffer_size|body_in_file_only|body_in_single_buffer|body_temp_path|body_timeout|header_buffer_size|header_timeout|max_body_size)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(keepalive_)(disable|requests|time|timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(limit_)(rate|rate_after|conn|conn_dry_run|conn_log_level|conn_status|conn_zone|zone|req|req_dry_run|req_log_level|req_status|req_zone)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(lingering_)(close|time|timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(log_)(not_found|subrequest|format)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(max_)(ranges|errors)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(msie_)(padding|refresh)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(open_)(file_cache|file_cache_errors|file_cache_min_uses|file_cache_valid|log_file_cache)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(send_)(lowat|timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(server_)(name|name_in_redirect|names_hash_bucket_size|names_hash_max_size|tokens)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(tcp_)(nodelay|nopush)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(types_)(hash_bucket_size|hash_max_size)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(variables_)(hash_bucket_size|hash_max_size)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(add_)(before_body|after_body|header|trailer)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(status_)(zone|format)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(autoindex_)(exact_size|format|localtime)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(ancient_)(browser|browser_value)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(modern_)(browser|browser_value)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(charset_)(map|types)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(dav_)(access|methods)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(fastcgi_)(bind|buffer_size|buffering|buffers|busy_buffers_size|cache|cache_background_update|cache_bypass|cache_key|cache_lock|cache_lock_age|cache_lock_timeout|cache_max_range_offset|cache_methods|cache_min_uses|cache_path|cache_purge|cache_revalidate|cache_use_stale|cache_valid|catch_stderr|connect_timeout|force_ranges|hide_header|ignore_client_abort|ignore_headers|index|intercept_errors|keep_conn|limit_rate|max_temp_file_size|next_upstream|next_upstream_timeout|next_upstream_tries|no_cache|param|pass|pass_header|pass_request_body|pass_request_headers|read_timeout|request_buffering|send_lowat|send_timeout|socket_keepalive|split_path_info|store|store_access|temp_file_write_size|temp_path)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(geoip_)(country|city|org|proxy|proxy_recursive)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(grpc_)(bind|buffer_size|connect_timeout|hide_header|ignore_headers|intercept_errors|next_upstream|next_upstream_timeout|next_upstream_tries|pass|pass_header|read_timeout|send_timeout|set_header|socket_keepalive|ssl_certificate|ssl_certificate_key|ssl_ciphers|ssl_conf_command|ssl_crl|ssl_name|ssl_password_file|ssl_protocols|ssl_server_name|ssl_session_reuse|ssl_trusted_certificate|ssl_verify|ssl_verify_depth)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(gzip_)(buffers|comp_level|disable|http_version|min_length|proxied|types|vary|static)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(hls_)(buffers|forward_args|fragment|mp4_buffer_size|mp4_max_buffer_size)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(image_)(filter|filter_buffer|filter_interlace|filter_jpeg_quality|filter_sharpen|filter_transparency|filter_webp_quality)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(map_)(hash_bucket_size|hash_max_size)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(memcached_)(bind|buffer_size|connect_timeout|gzip_flag|next_upstream|next_upstream_timeout|next_upstream_tries|pass|read_timeout|send_timeout|socket_keepalive)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(mp4_)(buffer_size|max_buffer_size|limit_rate|limit_rate_after|start_key_frame)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(perl_)(modules|require|set)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(proxy_)(bind|buffer_size|buffering|buffers|busy_buffers_size|cache|cache_background_update|cache_bypass|cache_convert_head|cache_key|cache_lock|cache_lock_age|cache_lock_timeout|cache_max_range_offset|cache_methods|cache_min_uses|cache_path|cache_purge|cache_revalidate|cache_use_stale|cache_valid|connect_timeout|cookie_domain|cookie_flags|cookie_path|force_ranges|headers_hash_bucket_size|headers_hash_max_size|hide_header|http_version|ignore_client_abort|ignore_headers|intercept_errors|limit_rate|max_temp_file_size|method|next_upstream|next_upstream_timeout|next_upstream_tries|no_cache|pass|pass_header|pass_request_body|pass_request_headers|read_timeout|redirect|request_buffering|send_lowat|send_timeout|set_body|set_header|socket_keepalive|ssl_certificate|ssl_certificate_key|ssl_ciphers|ssl_conf_command|ssl_crl|ssl_name|ssl_password_file|ssl_protocols|ssl_server_name|ssl_session_reuse|ssl_trusted_certificate|ssl_verify|ssl_verify_depth|store|store_access|temp_file_write_size|temp_path|buffer|pass_error_message|protocol|smtp_auth|timeout|protocol_timeout|download_rate|half_close|requests|responses|session_drop|ssl|upload_rate)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(real_)(ip_header|ip_recursive)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(referer_)(hash_bucket_size|hash_max_size)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(scgi_)(bind|buffer_size|buffering|buffers|busy_buffers_size|cache|cache_background_update|cache_bypass|cache_key|cache_lock|cache_lock_age|cache_lock_timeout|cache_max_range_offset|cache_methods|cache_min_uses|cache_path|cache_purge|cache_revalidate|cache_use_stale|cache_valid|connect_timeout|force_ranges|hide_header|ignore_client_abort|ignore_headers|intercept_errors|limit_rate|max_temp_file_size|next_upstream|next_upstream_timeout|next_upstream_tries|no_cache|param|pass|pass_header|pass_request_body|pass_request_headers|read_timeout|request_buffering|send_timeout|socket_keepalive|store|store_access|temp_file_write_size|temp_path)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(secure_)(link|link_md5|link_secret)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(session_)(log|log_format|log_zone)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(ssi_)(last_modified|min_file_chunk|silent_errors|types|value_length)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(sub_)(filter|filter_last_modified|filter_once|filter_types)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(health_)(check|check_timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(userid_)(domain|expires|flags|mark|name|p3p|path|service)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(uwsgi_)(bind|buffer_size|buffering|buffers|busy_buffers_size|cache|cache_background_update|cache_bypass|cache_key|cache_lock|cache_lock_age|cache_lock_timeout|cache_max_range_offset|cache_methods|cache_min_uses|cache_path|cache_purge|cache_revalidate|cache_use_stale|cache_valid|connect_timeout|force_ranges|hide_header|ignore_client_abort|ignore_headers|intercept_errors|limit_rate|max_temp_file_size|modifier1|modifier2|next_upstream|next_upstream_timeout|next_upstream_tries|no_cache|param|pass|pass_header|pass_request_body|pass_request_headers|read_timeout|request_buffering|send_timeout|socket_keepalive|ssl_certificate|ssl_certificate_key|ssl_ciphers|ssl_conf_command|ssl_crl|ssl_name|ssl_password_file|ssl_protocols|ssl_server_name|ssl_session_reuse|ssl_trusted_certificate|ssl_verify|ssl_verify_depth|store|store_access|temp_file_write_size|temp_path)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(http2_)(body_preread_size|chunk_size|idle_timeout|max_concurrent_pushes|max_concurrent_streams|max_field_size|max_header_size|max_requests|push|push_preload|recv_buffer_size|recv_timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(http3_)(hq|max_concurrent_streams|stream_buffer_size)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(quic_)(active_connection_id_limit|bpf|gso|host_key|retry)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(xslt_)(last_modified|param|string_param|stylesheet|types)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(imap_)(auth|capabilities|client_buffer)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(pop3_)(auth|capabilities)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(smtp_)(auth|capabilities|client_buffer|greeting_delay)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(preread_)(buffer_size|timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(mqtt_)(preread|buffers|rewrite_buffer_size|set_connect)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(zone_)(sync_buffers|sync_connect_retry_interval|sync_connect_timeout|sync_interval|sync_recv_buffer_size|sync_server|sync_ssl|sync_ssl_certificate|sync_ssl_certificate_key|sync_ssl_ciphers|sync_ssl_conf_command|sync_ssl_crl|sync_ssl_name|sync_ssl_password_file|sync_ssl_protocols|sync_ssl_server_name|sync_ssl_trusted_certificate|sync_ssl_verify|sync_ssl_verify_depth|sync_timeout)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(otel_)(exporter|service_name|trace|trace_context|span_name|span_attr)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(js_)(body_filter|content|fetch_buffer_size|fetch_ciphers|fetch_max_response_buffer_size|fetch_protocols|fetch_timeout|fetch_trusted_certificate|fetch_verify|fetch_verify_depth|header_filter|import|include|path|periodic|preload_object|set|shared_dict_zone|var|access|filter|preread)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    },
+    "4": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "([\"'\\s]|^)(daemon|env|include|pid|use|user|aio|alias|directio|etag|listen|resolver|root|satisfy|sendfile|allow|deny|api|autoindex|charset|geo|gunzip|gzip|expires|index|keyval|mirror|perl|set|slice|ssi|ssl|zone|state|hash|keepalive|queue|random|sticky|match|userid|http2|http3|protocol|timeout|xclient|starttls|mqtt|load_module|lock_file|master_process|multi_accept|pcre_jit|thread_pool|timer_resolution|working_directory|absolute_redirect|aio_write|chunked_transfer_encoding|connection_pool_size|default_type|directio_alignment|disable_symlinks|if_modified_since|ignore_invalid_headers|large_client_header_buffers|merge_slashes|output_buffers|port_in_redirect|postpone_output|read_ahead|recursive_error_pages|request_pool_size|reset_timedout_connection|resolver_timeout|sendfile_max_chunk|subrequest_output_buffer_size|try_files|underscores_in_headers|addition_types|override_charset|source_charset|create_full_put_path|min_delete_depth|f4f_buffer_size|gunzip_buffers|internal_redirect|keyval_zone|access_log|mirror_request_body|random_index|set_real_ip_from|valid_referers|rewrite_log|uninitialized_variable_warn|split_clients|least_time|sticky_cookie_insert|xml_entities|google_perftools_profiles)([\"'\\s]|$)",
+   "end": ";",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.nginx"
+    },
+    "2": {
+     "name": "keyword.directive.nginx"
+    },
+    "3": {
+     "name": "keyword.directive.nginx"
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "\\b([a-zA-Z0-9\\_]+)\\s+",
+   "end": "(;|$)",
+   "beginCaptures": {
+    "1": {
+     "name": "keyword.directive.unknown.nginx"
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  {
+   "begin": "\\b([a-z]+\\/[A-Za-z0-9\\-\\.\\+]+)\\b",
+   "end": "(;)",
+   "beginCaptures": {
+    "1": {
+     "name": "constant.other.mediatype.nginx"
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "punctuation.terminator.nginx"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#values"
+    }
+   ]
+  }
+ ],
+ "repository": {
+  "if_condition": {
+   "patterns": [
+    {
+     "include": "#variables"
+    },
+    {
+     "name": "keyword.operator.nginx",
+     "match": "\\!?\\~\\*?\\s"
+    },
+    {
+     "name": "keyword.operator.nginx",
+     "match": "\\!?\\-[fdex]\\s"
+    },
+    {
+     "name": "keyword.operator.nginx",
+     "match": "\\!?=[^=]"
+    },
+    {
+     "include": "#regexp_and_string"
+    }
+   ]
+  },
+  "server_parameters": {
+   "patterns": [
+    {
+     "match": "(?:^|\\s)(weight|max_conn|max_fails|fail_timeout|slow_start)(=)(\\d[\\d\\.]*[bBkKmMgGtTsShHdD]?)(?:\\s|;|$)",
+     "captures": {
+      "1": {
+       "name": "variable.parameter.nginx"
+      },
+      "2": {
+       "name": "keyword.operator.nginx"
+      },
+      "3": {
+       "name": "constant.numeric.nginx"
+      }
+     }
+    },
+    {
+     "include": "#values"
+    }
+   ]
+  },
+  "variables": {
+   "patterns": [
+    {
+     "match": "(\\$)([A-Za-z0-9\\_]+)\\b",
+     "captures": {
+      "1": {
+       "name": "punctuation.definition.variable.nginx"
+      },
+      "2": {
+       "name": "variable.other.nginx"
+      }
+     }
+    },
+    {
+     "match": "(\\$\\{)([A-Za-z0-9\\_]+)(\\})",
+     "captures": {
+      "1": {
+       "name": "punctuation.definition.variable.nginx"
+      },
+      "2": {
+       "name": "variable.other.nginx"
+      },
+      "3": {
+       "name": "punctuation.definition.variable.nginx"
+      }
+     }
+    }
+   ]
+  },
+  "regexp_and_string": {
+   "patterns": [
+    {
+     "name": "string.regexp.nginx",
+     "match": "\\^.*?\\$"
+    },
+    {
+     "name": "string.quoted.double.nginx",
+     "begin": "\"",
+     "end": "\"",
+     "patterns": [
+      {
+       "name": "constant.character.escape.nginx",
+       "match": "\\\\[\"'nt\\\\]"
+      },
+      {
+       "include": "#variables"
+      }
+     ]
+    },
+    {
+     "name": "string.quoted.single.nginx",
+     "begin": "'",
+     "end": "'",
+     "patterns": [
+      {
+       "name": "constant.character.escape.nginx",
+       "match": "\\\\[\"'nt\\\\]"
+      },
+      {
+       "include": "#variables"
+      }
+     ]
+    }
+   ]
+  },
+  "values": {
+   "patterns": [
+    {
+     "include": "#variables"
+    },
+    {
+     "name": "comment.line.number-sign",
+     "match": "\\#.*"
+    },
+    {
+     "match": "(?<=\\G|\\s)(=?[0-9][0-9\\.]*[bBkKmMgGtTsShHdD]?)(?=[\\t ;])",
+     "captures": {
+      "1": {
+       "name": "constant.numeric.nginx"
+      }
+     }
+    },
+    {
+     "name": "constant.language.nginx",
+     "match": "(?<=\\G|\\s)(on|off|true|false)(?=[\\t ;])"
+    },
+    {
+     "name": "constant.language.nginx",
+     "match": "(?<=\\G|\\s)(kqueue|rtsig|epoll|\\/dev\\/poll|select|poll|eventport|max|all|default_server|default|main|crit|error|debug|warn|notice|last)(?=[\\t ;])"
+    },
+    {
+     "name": "keyword.operator.nginx",
+     "match": "\\\\.*\\ |\\~\\*|\\~|\\!\\~\\*|\\!\\~"
+    },
+    {
+     "include": "#regexp_and_string"
+    }
+   ]
+  }
+ },
+ "scopeName": "source.nginx",
+ "uuid": "0C04066A-12D2-43CA-8238-00A12CE4C12D"
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/prisma.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/prisma.tmLanguage.json
@@ -1,0 +1,561 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Prisma",
+  "scopeName": "source.prisma",
+  "fileTypes": ["prisma"],
+  "patterns": [
+    {
+      "include": "#triple_comment"
+    },
+    {
+      "include": "#double_comment"
+    },
+    {
+      "include": "#multi_line_comment"
+    },
+    {
+      "include": "#types_block_definition"
+    },
+    {
+      "include": "#namespace_block_definition"
+    },
+    {
+      "include": "#model_block_definition"
+    },
+    {
+      "include": "#config_block_definition"
+    },
+    {
+      "include": "#enum_block_definition"
+    },
+    {
+      "include": "#type_definition"
+    }
+  ],
+  "repository": {
+    "namespace_block_definition": {
+      "begin": "^\\s*(namespace)\\s+([A-Za-z][\\w]*)\\s*({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.namespace.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.namespace.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#multi_line_comment"
+        },
+        {
+          "include": "#model_block_definition"
+        },
+        {
+          "include": "#enum_block_definition"
+        },
+        {
+          "include": "#type_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "model_block_definition": {
+      "begin": "^\\s*(model|type|view)\\s+([A-Za-z][\\w]*)\\s*({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.model.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.model.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#multi_line_comment"
+        },
+        {
+          "include": "#field_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "enum_block_definition": {
+      "begin": "^\\s*(enum)\\s+([A-Za-z][\\w]*)\\s+({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.enum.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.enum.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#multi_line_comment"
+        },
+        {
+          "include": "#enum_value_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "config_block_definition": {
+      "begin": "^\\s*(generator|datasource)\\s+([A-Za-z][\\w]*)\\s+({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.config.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.config.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#multi_line_comment"
+        },
+        {
+          "include": "#assignment"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "assignment": {
+      "patterns": [
+        {
+          "begin": "^\\s*(\\w+)\\s*(=)\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "variable.other.assignment.prisma"
+            },
+            "2": {
+              "name": "keyword.operator.terraform"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#value"
+            },
+            {
+              "include": "#double_comment_inline"
+            }
+          ],
+          "end": "\\n"
+        }
+      ]
+    },
+    "field_definition": {
+      "name": "scalar.field",
+      "patterns": [
+        {
+          "match": "^\\s*(\\w+)(\\s*:)?\\s+((?!(?:Int|BigInt|String|DateTime|Bytes|Decimal|Float|Json|Boolean)\\b)\\b\\w+)?(Int|BigInt|String|DateTime|Bytes|Decimal|Float|Json|Boolean)?(\\[\\])?(\\?)?(\\!)?",
+          "captures": {
+            "1": {
+              "name": "variable.other.assignment.prisma"
+            },
+            "2": {
+              "name": "invalid.illegal.colon.prisma"
+            },
+            "3": {
+              "name": "variable.language.relations.prisma"
+            },
+            "4": {
+              "name": "support.type.primitive.prisma"
+            },
+            "5": {
+              "name": "keyword.operator.list_type.prisma"
+            },
+            "6": {
+              "name": "keyword.operator.optional_type.prisma"
+            },
+            "7": {
+              "name": "invalid.illegal.required_type.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "type_definition": {
+      "patterns": [
+        {
+          "match": "^\\s*(type)\\s+(\\w+)\\s*=\\s*(\\w+)",
+          "captures": {
+            "1": {
+              "name": "storage.type.type.prisma"
+            },
+            "2": {
+              "name": "entity.name.type.type.prisma"
+            },
+            "3": {
+              "name": "support.type.primitive.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "types_block_definition": {
+      "begin": "^\\s*(types)\\s*({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.types.prisma"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#multi_line_comment"
+        },
+        {
+          "include": "#type_alias_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "type_alias_definition": {
+      "patterns": [
+        {
+          "match": "^\\s*(\\w+)\\s*(=)\\s*(\\w+)",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.alias.prisma"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.prisma"
+            },
+            "3": {
+              "name": "support.type.primitive.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "enum_value_definition": {
+      "patterns": [
+        {
+          "match": "^\\s*(\\w+)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.other.assignment.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "attribute_with_arguments": {
+      "name": "source.prisma.attribute.with_arguments",
+      "begin": "(@@?[\\w\\.]+)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.attribute.prisma"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#named_argument"
+        },
+        {
+          "include": "#value"
+        }
+      ],
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "attribute": {
+      "name": "source.prisma.attribute",
+      "match": "(@@?[\\w\\.]+)",
+      "captures": {
+        "1": {
+          "name": "entity.name.function.attribute.prisma"
+        }
+      }
+    },
+    "array": {
+      "name": "source.prisma.array",
+      "begin": "\\[",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value"
+        }
+      ],
+      "end": "\\]",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "value": {
+      "name": "source.prisma.value",
+      "patterns": [
+        {
+          "include": "#array"
+        },
+        {
+          "include": "#functional"
+        },
+        {
+          "include": "#literal"
+        }
+      ]
+    },
+    "functional": {
+      "name": "source.prisma.functional",
+      "begin": "(\\w+)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.functional.prisma"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value"
+        }
+      ],
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "literal": {
+      "name": "source.prisma.literal",
+      "patterns": [
+        {
+          "include": "#boolean"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#double_quoted_string"
+        },
+        {
+          "include": "#identifier"
+        }
+      ]
+    },
+    "identifier": {
+      "patterns": [
+        {
+          "match": "\\b(\\w)+\\b",
+          "name": "support.constant.constant.prisma"
+        }
+      ]
+    },
+    "map_key": {
+      "name": "source.prisma.key",
+      "patterns": [
+        {
+          "match": "(\\w+)\\s*(:)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.key.prisma"
+            },
+            "2": {
+              "name": "punctuation.definition.separator.key-value.prisma"
+            }
+          }
+        }
+      ]
+    },
+    "named_argument": {
+      "name": "source.prisma.named_argument",
+      "patterns": [
+        {
+          "include": "#map_key"
+        },
+        {
+          "include": "#value"
+        }
+      ]
+    },
+    "triple_comment": {
+      "begin": "///",
+      "end": "$\\n?",
+      "name": "comment.prisma"
+    },
+    "double_comment": {
+      "begin": "//",
+      "end": "$\\n?",
+      "name": "comment.prisma"
+    },
+    "multi_line_comment": {
+      "begin": "/\\*",
+      "end": "\\*/",
+      "name": "comment.prisma"
+    },
+    "double_comment_inline": {
+      "match": "//[^\\n]*",
+      "name": "comment.prisma"
+    },
+    "boolean": {
+      "match": "\\b(true|false)\\b",
+      "name": "constant.language.boolean.prisma"
+    },
+    "number": {
+      "match": "((0(x|X)[0-9a-fA-F]*)|(\\+|-)?\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDdg]|UL|ul)?\\b",
+      "name": "constant.numeric.prisma"
+    },
+    "double_quoted_string": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "string.quoted.double.start.prisma"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "string.quoted.double.end.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string_interpolation"
+        },
+        {
+          "match": "([\\w\\-\\/\\._\\\\%@:\\?=]+)",
+          "name": "string.quoted.double.prisma"
+        }
+      ],
+      "name": "unnamed"
+    },
+    "string_interpolation": {
+      "patterns": [
+        {
+          "begin": "\\$\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control.interpolation.start.prisma"
+            }
+          },
+          "end": "\\s*\\}",
+          "endCaptures": {
+            "0": {
+              "name": "keyword.control.interpolation.end.prisma"
+            }
+          },
+          "name": "source.tag.embedded.source.prisma",
+          "patterns": [
+            {
+              "include": "#value"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/proto.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/proto.tmLanguage.json
@@ -1,0 +1,285 @@
+{
+  "name": "Protocol Buffer 3",
+  "scopeName": "source.proto",
+  "fileTypes": ["proto"],
+
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#syntax" },
+    { "include": "#package" },
+    { "include": "#import" },
+    { "include": "#optionStmt" },
+    { "include": "#message" },
+    { "include": "#enum" },
+    { "include": "#service" }
+  ],
+
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.block.proto",
+          "begin": "/\\*",
+          "end": "\\*/"
+        },
+        {
+          "name": "comment.line.double-slash.proto",
+          "begin": "//",
+          "end": "$\\n?"
+        }
+      ]
+    },
+    "syntax": {
+      "match": "\\s*(syntax)\\s*(=)\\s*(\"proto[23]\")\\s*(;)",
+      "captures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "keyword.operator.assignment.proto" },
+        "3": { "name": "string.quoted.double.proto.syntax" },
+        "4": { "name": "punctuation.terminator.proto" }
+      }
+    },
+    "package": {
+      "match": "\\s*(package)\\s+([\\w.]+)\\s*(;)",
+      "captures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "string.unquoted.proto.package" },
+        "3": { "name": "punctuation.terminator.proto" }
+      }
+    },
+    "import": {
+      "match": "\\s*(import)\\s+(weak|public)?\\s*(\"[^\"]+\")\\s*(;)",
+      "captures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "keyword.other.proto" },
+        "3": { "name": "string.quoted.double.proto.import" },
+        "4": { "name": "punctuation.terminator.proto" }
+      }
+    },
+    "optionStmt": {
+      "begin": "(option)\\s+(\\w+|\\(\\w+(\\.\\w+)*\\))(\\.\\w+)*\\s*(=)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "support.other.proto" },
+        "3": { "name": "support.other.proto" },
+        "4": { "name": "support.other.proto" },
+        "5": { "name": "keyword.operator.assignment.proto" }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": { "name": "punctuation.terminator.proto" }
+      },
+      "patterns": [
+        { "include": "#constants" },
+        { "include": "#number" },
+        { "include": "#string" },
+        { "include": "#subMsgOption" }
+      ]
+    },
+    "subMsgOption": {
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [{ "include": "#kv" }, { "include": "#comments" }]
+    },
+    "kv": {
+      "begin": "(\\w+)\\s*(:)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "punctuation.separator.key-value.proto" }
+      },
+      "end": "(;)|,|(?=[}/_a-zA-Z])",
+      "endCaptures": {
+        "1": { "name": "punctuation.terminator.proto" }
+      },
+      "patterns": [
+        { "include": "#constants" },
+        { "include": "#number" },
+        { "include": "#string" },
+        { "include": "#subMsgOption" }
+      ]
+    },
+    "fieldOptions": {
+      "begin": "\\[",
+      "end": "\\]",
+      "patterns": [
+        { "include": "#constants" },
+        { "include": "#number" },
+        { "include": "#string" },
+        { "include": "#subMsgOption" },
+        { "include": "#optionName" }
+      ]
+    },
+    "optionName": {
+      "match": "(\\w+|\\(\\w+(\\.\\w+)*\\))(\\.\\w+)*",
+      "captures": {
+        "1": { "name": "support.other.proto" },
+        "2": { "name": "support.other.proto" },
+        "3": { "name": "support.other.proto" }
+      }
+    },
+    "message": {
+      "begin": "(message|extend)(\\s+)([A-Za-z_][A-Za-z0-9_.]*)(\\s*)(\\{)?",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" },
+        "3": { "name": "entity.name.class.message.proto" }
+      },
+      "end": "\\}",
+      "patterns": [
+        { "include": "#reserved" },
+        { "include": "$self" },
+        { "include": "#enum" },
+        { "include": "#optionStmt" },
+        { "include": "#comments" },
+        { "include": "#oneof" },
+        { "include": "#field" },
+        { "include": "#mapfield" }
+      ]
+    },
+    "reserved": {
+      "begin": "(reserved)\\s+",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": { "name": "punctuation.terminator.proto" }
+      },
+      "patterns": [
+        {
+          "match": "(\\d+)(\\s+(to)\\s+(\\d+))?",
+          "captures": {
+            "1": { "name": "constant.numeric.proto" },
+            "3": { "name": "keyword.other.proto" },
+            "4": { "name": "constant.numeric.proto" }
+          }
+        },
+        { "include": "#string" }
+      ]
+    },
+    "field": {
+      "begin": "\\s*(optional|repeated|required)?\\s*(\\.?[\\w.]+)\\s+(\\w+)\\s*(=)\\s*(0[xX][0-9a-fA-F]+|[0-9]+)",
+      "beginCaptures": {
+        "1": { "name": "storage.modifier.proto" },
+        "2": { "name": "storage.type.proto" },
+        "3": { "name": "variable.other.proto" },
+        "4": { "name": "keyword.operator.assignment.proto" },
+        "5": { "name": "constant.numeric.proto" }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": { "name": "punctuation.terminator.proto" }
+      },
+      "patterns": [{ "include": "#fieldOptions" }]
+    },
+    "mapfield": {
+      "begin": "\\s*(map)\\s*(<)\\s*(\\.?[\\w.]+)\\s*,\\s*(\\.?[\\w.]+)\\s*(>)\\s+(\\w+)\\s*(=)\\s*(\\d+)",
+      "beginCaptures": {
+        "1": { "name": "storage.type.proto" },
+        "2": { "name": "punctuation.definition.typeparameters.begin.proto" },
+        "3": { "name": "storage.type.proto" },
+        "4": { "name": "storage.type.proto" },
+        "5": { "name": "punctuation.definition.typeparameters.end.proto" },
+        "6": { "name": "variable.other.proto" },
+        "7": { "name": "keyword.operator.assignment.proto" },
+        "8": { "name": "constant.numeric.proto" }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": { "name": "punctuation.terminator.proto" }
+      },
+      "patterns": [{ "include": "#fieldOptions" }]
+    },
+    "oneof": {
+      "begin": "(oneof)\\s+([A-Za-z][A-Za-z0-9_]*)\\s*\\{?",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "variable.other.proto" }
+      },
+      "end": "\\}",
+      "patterns": [
+        { "include": "#optionStmt" },
+        { "include": "#comments" },
+        { "include": "#field" }
+      ]
+    },
+    "enum": {
+      "begin": "(enum)(\\s+)([A-Za-z][A-Za-z0-9_]*)(\\s*)(\\{)?",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" },
+        "3": { "name": "entity.name.class.proto" }
+      },
+      "end": "\\}",
+      "patterns": [
+        { "include": "#reserved" },
+        { "include": "#optionStmt" },
+        { "include": "#comments" },
+        {
+          "begin": "([A-Za-z][A-Za-z0-9_]*)\\s*(=)\\s*(-?0[xX][0-9a-fA-F]+|-?[0-9]+)",
+          "beginCaptures": {
+            "1": { "name": "variable.other.proto" },
+            "2": { "name": "keyword.operator.assignment.proto" },
+            "3": { "name": "constant.numeric.proto" }
+          },
+          "end": "(;)",
+          "endCaptures": {
+            "1": { "name": "punctuation.terminator.proto" }
+          },
+          "patterns": [{ "include": "#fieldOptions" }]
+        }
+      ]
+    },
+    "service": {
+      "begin": "(service)\\s+([A-Za-z][A-Za-z0-9_.]*)\\s*\\{?",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "entity.name.class.message.proto" }
+      },
+      "end": "\\}",
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#optionStmt" },
+        { "include": "#method" }
+      ]
+    },
+    "method": {
+      "begin": "(rpc)\\s+([A-Za-z][A-Za-z0-9_]*)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.proto" },
+        "2": { "name": "entity.name.function" }
+      },
+      "end": "\\}|(;)",
+      "endCaptures": {
+        "1": { "name": "punctuation.terminator.proto" }
+      },
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#optionStmt" },
+        { "include": "#rpcKeywords" },
+        { "include": "#ident" }
+      ]
+    },
+    "rpcKeywords": {
+      "match": "\\b(stream|returns)\\b",
+      "name": "keyword.other.proto"
+    },
+    "ident": {
+      "match": "\\.?[A-Za-z][A-Za-z0-9_.]*",
+      "name": "entity.name.class.proto"
+    },
+    "constants": {
+      "match": "\\b(true|false|max|[A-Z_]+)\\b",
+      "name": "constant.language.proto"
+    },
+    "storagetypes": {
+      "match": "\\b(double|float|int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64|sfixed32|sfixed64|bool|string|bytes)\\b",
+      "name": "storage.type.proto"
+    },
+    "string": {
+      "match": "([\"'])(?:\\\\.|[^\\\\])*?\\1",
+      "name": "string.quoted.double.proto"
+    },
+    "number": {
+      "name": "constant.numeric.proto",
+      "match": "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)\\b"
+    }
+  }
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/pug.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/pug.tmLanguage.json
@@ -1,0 +1,1038 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/davidrios/pug-tmbundle/blob/master/Syntaxes/Pug.JSON-tmLanguage",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/davidrios/pug-tmbundle/commit/ae1dd60ca4aa4b45617f236d584216cd8d19eecf",
+	"name": "Pug",
+	"scopeName": "text.pug",
+	"patterns": [
+		{
+			"match": "^(!!!|doctype)(\\s*[a-zA-Z0-9-_]+)?",
+			"name": "meta.tag.sgml.doctype.html",
+			"comment": "Doctype declaration."
+		},
+		{
+			"begin": "^(\\s*)//-",
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "comment.unbuffered.block.pug",
+			"comment": "Unbuffered (pug-only) comments."
+		},
+		{
+			"begin": "^(\\s*)//",
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "string.comment.buffered.block.pug",
+			"comment": "Buffered (html) comments.",
+			"patterns": [
+				{
+					"captures": {
+						"1": {
+							"name": "invalid.illegal.comment.comment.block.pug"
+						}
+					},
+					"match": "^\\s*(//)(?!-)",
+					"name": "string.comment.buffered.block.pug",
+					"comment": "Buffered comments inside buffered comments will generate invalid html."
+				}
+			]
+		},
+		{
+			"begin": "<!--",
+			"end": "--\\s*>",
+			"name": "comment.unbuffered.block.pug",
+			"patterns": [
+				{
+					"match": "--",
+					"name": "invalid.illegal.comment.comment.block.pug"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*)-$",
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "source.js",
+			"comment": "Unbuffered code block.",
+			"patterns": [
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*)(script)((\\.$)|(?=[^\\n]*((text|application)/javascript|module).*\\.$))",
+			"beginCaptures": {
+				"2": {
+					"name": "entity.name.tag.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "meta.tag.other",
+			"comment": "Script tag with JavaScript code.",
+			"patterns": [
+				{
+					"begin": "\\G(?=\\()",
+					"end": "$",
+					"patterns": [
+						{
+							"include": "#tag_attributes"
+						}
+					]
+				},
+				{
+					"begin": "\\G(?=[.#])",
+					"end": "$",
+					"patterns": [
+						{
+							"include": "#complete_tag"
+						}
+					]
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*)(style)((\\.$)|(?=[.#(].*\\.$))",
+			"beginCaptures": {
+				"2": {
+					"name": "entity.name.tag.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "meta.tag.other",
+			"comment": "Style tag with CSS code.",
+			"patterns": [
+				{
+					"begin": "\\G(?=\\()",
+					"end": "$",
+					"patterns": [
+						{
+							"include": "#tag_attributes"
+						}
+					]
+				},
+				{
+					"begin": "\\G(?=[.#])",
+					"end": "$",
+					"patterns": [
+						{
+							"include": "#complete_tag"
+						}
+					]
+				},
+				{
+					"include": "source.css"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*):(sass)(?=\\(|$)",
+			"beginCaptures": {
+				"2": {
+					"name": "constant.language.name.sass.filter.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "source.sass.filter.pug",
+			"patterns": [
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "source.sass"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*):(scss)(?=\\(|$)",
+			"beginCaptures": {
+				"2": {
+					"name": "constant.language.name.scss.filter.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "source.css.scss.filter.pug",
+			"patterns": [
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "source.css.scss"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*):(less)(?=\\(|$)",
+			"beginCaptures": {
+				"2": {
+					"name": "constant.language.name.less.filter.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "source.less.filter.pug",
+			"patterns": [
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "source.less"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*):(stylus)(?=\\(|$)",
+			"beginCaptures": {
+				"2": {
+					"name": "constant.language.name.stylus.filter.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"patterns": [
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "source.stylus"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*):(coffee(-?script)?)(?=\\(|$)",
+			"beginCaptures": {
+				"2": {
+					"name": "constant.language.name.coffeescript.filter.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "source.coffeescript.filter.pug",
+			"patterns": [
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "source.coffee"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*):(uglify-js)(?=\\(|$)",
+			"beginCaptures": {
+				"2": {
+					"name": "constant.language.name.js.filter.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"name": "source.js.filter.pug",
+			"patterns": [
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*)((:(?=.))|(:$))",
+			"beginCaptures": {
+				"4": {
+					"name": "invalid.illegal.empty.generic.filter.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"comment": "Generic Pug filter.",
+			"patterns": [
+				{
+					"begin": "\\G(?<=:)(?=.)",
+					"end": "$",
+					"name": "name.generic.filter.pug",
+					"patterns": [
+						{
+							"match": "\\G\\(",
+							"name": "invalid.illegal.name.generic.filter.pug"
+						},
+						{
+							"match": "[\\w-]",
+							"name": "constant.language.name.generic.filter.pug"
+						},
+						{
+							"include": "#tag_attributes"
+						},
+						{
+							"match": "\\W",
+							"name": "invalid.illegal.name.generic.filter.pug"
+						}
+					]
+				}
+			]
+		},
+		{
+			"begin": "^(\\s*)(?:(?=\\.$)|(?:(?=[\\w.#].*?\\.$)(?=(?:(?:(?:(?:(?:#[\\w-]+)|(?:\\.[\\w-]+))|(?:(?:[#!]\\{[^}]*\\})|(?:\\w(?:(?:[\\w:-]+[\\w-])|(?:[\\w-]*)))))(?:(?:#[\\w-]+)|(?:\\.[\\w-]+)|(?:\\((?:[^()\\'\\\"]*(?:(?:\\'(?:[^\\']|(?:(?<!\\\\)\\\\\\'))*\\')|(?:\\\"(?:[^\\\"]|(?:(?<!\\\\)\\\\\\\"))*\\\")))*[^()]*\\))*)*)(?:(?:(?::\\s+)|(?<=\\)))(?:(?:(?:(?:#[\\w-]+)|(?:\\.[\\w-]+))|(?:(?:[#!]\\{[^}]*\\})|(?:\\w(?:(?:[\\w:-]+[\\w-])|(?:[\\w-]*)))))(?:(?:#[\\w-]+)|(?:\\.[\\w-]+)|(?:\\((?:[^()\\'\\\"]*(?:(?:\\'(?:[^\\']|(?:(?<!\\\\)\\\\\\'))*\\')|(?:\\\"(?:[^\\\"]|(?:(?<!\\\\)\\\\\\\"))*\\\")))*[^()]*\\))*)*))*)\\.$)(?:(?:(#[\\w-]+)|(\\.[\\w-]+))|((?:[#!]\\{[^}]*\\})|(?:\\w(?:(?:[\\w:-]+[\\w-])|(?:[\\w-]*)))))))",
+			"beginCaptures": {
+				"2": {
+					"name": "meta.selector.css entity.other.attribute-name.id.css.pug"
+				},
+				"3": {
+					"name": "meta.selector.css entity.other.attribute-name.class.css.pug"
+				},
+				"4": {
+					"name": "meta.tag.other entity.name.tag.pug"
+				}
+			},
+			"end": "^(?!(\\1\\s)|\\s*$)",
+			"comment": "Generated from dot_block_tag.py",
+			"patterns": [
+				{
+					"match": "\\.$",
+					"name": "storage.type.function.pug.dot-block-dot"
+				},
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "#complete_tag"
+				},
+				{
+					"begin": "^(?=.)",
+					"end": "$",
+					"name": "text.block.pug",
+					"patterns": [
+						{
+							"include": "#inline_pug"
+						},
+						{
+							"include": "#embedded_html"
+						},
+						{
+							"include": "#html_entity"
+						},
+						{
+							"include": "#interpolated_value"
+						},
+						{
+							"include": "#interpolated_error"
+						}
+					]
+				}
+			]
+		},
+		{
+			"begin": "^\\s*",
+			"end": "$",
+			"comment": "All constructs that generally span a single line starting with any number of white-spaces.",
+			"patterns": [
+				{
+					"include": "#inline_pug"
+				},
+				{
+					"include": "#blocks_and_includes"
+				},
+				{
+					"include": "#unbuffered_code"
+				},
+				{
+					"include": "#mixin_definition"
+				},
+				{
+					"include": "#mixin_call"
+				},
+				{
+					"include": "#flow_control"
+				},
+				{
+					"include": "#flow_control_each"
+				},
+				{
+					"include": "#case_conds"
+				},
+				{
+					"begin": "\\|",
+					"end": "$",
+					"name": "text.block.pipe.pug",
+					"comment": "Tag pipe text line.",
+					"patterns": [
+						{
+							"include": "#inline_pug"
+						},
+						{
+							"include": "#embedded_html"
+						},
+						{
+							"include": "#html_entity"
+						},
+						{
+							"include": "#interpolated_value"
+						},
+						{
+							"include": "#interpolated_error"
+						}
+					]
+				},
+				{
+					"include": "#printed_expression"
+				},
+				{
+					"begin": "\\G(?=(#[^\\{\\w-])|[^\\w.#])",
+					"end": "$",
+					"comment": "Line starting with characters incompatible with tag name/id/class is standalone text.",
+					"patterns": [
+						{
+							"begin": "</?(?=[!#])",
+							"end": ">|$",
+							"patterns": [
+								{
+									"include": "#inline_pug"
+								},
+								{
+									"include": "#interpolated_value"
+								},
+								{
+									"include": "#interpolated_error"
+								}
+							]
+						},
+						{
+							"include": "#inline_pug"
+						},
+						{
+							"include": "#embedded_html"
+						},
+						{
+							"include": "#html_entity"
+						},
+						{
+							"include": "#interpolated_value"
+						},
+						{
+							"include": "#interpolated_error"
+						}
+					]
+				},
+				{
+					"include": "#complete_tag"
+				}
+			]
+		}
+	],
+	"repository": {
+		"blocks_and_includes": {
+			"captures": {
+				"1": {
+					"name": "storage.type.import.include.pug"
+				},
+				"4": {
+					"name": "variable.control.import.include.pug"
+				}
+			},
+			"match": "(extends|include|yield|append|prepend|block( (append|prepend))?)\\s+(.*)$",
+			"name": "meta.first-class.pug",
+			"comment": "Template blocks and includes."
+		},
+		"unbuffered_code": {
+			"begin": "(-|(([a-zA-Z0-9_]+)\\s+=))",
+			"beginCaptures": {
+				"3": {
+					"name": "variable.parameter.javascript.embedded.pug"
+				}
+			},
+			"end": "(?=\\])|(({\\s*)?$)",
+			"name": "source.js",
+			"comment": "name = function() {}",
+			"patterns": [
+				{
+					"include": "#js_brackets"
+				},
+				{
+					"include": "#babel_parens"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"mixin_definition": {
+			"match": "(mixin\\s+)([\\w-]+)(?:(\\()\\s*((?:[a-zA-Z_]\\w*\\s*)(?:,\\s*[a-zA-Z_]\\w*\\s*)*)(\\)))?$",
+			"captures": {
+				"1": {
+					"name": "storage.type.function.pug"
+				},
+				"2": {
+					"name": "meta.tag.other entity.name.function.pug"
+				},
+				"3": {
+					"name": "punctuation.definition.parameters.begin.js"
+				},
+				"4": {
+					"name": "variable.parameter.function.js"
+				},
+				"5": {
+					"name": "punctuation.definition.parameters.begin.js"
+				}
+			}
+		},
+		"mixin_call": {
+			"begin": "((?:mixin\\s+)|\\+)([\\w-]+)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.function.pug"
+				},
+				"2": {
+					"name": "meta.tag.other entity.name.function.pug"
+				}
+			},
+			"end": "(?!\\()|$",
+			"patterns": [
+				{
+					"begin": "(?<!\\))\\(",
+					"end": "\\)",
+					"name": "args.mixin.pug",
+					"patterns": [
+						{
+							"include": "#js_parens"
+						},
+						{
+							"match": "([^\\s(),=/]+)\\s*=\\s*",
+							"captures": {
+								"1": {
+									"name": "meta.tag.other entity.other.attribute-name.tag.pug"
+								}
+							}
+						},
+						{
+							"include": "source.js"
+						}
+					]
+				},
+				{
+					"include": "#tag_attributes"
+				}
+			]
+		},
+		"flow_control": {
+			"begin": "(for|if|else if|else|until|while|unless|case)(\\s+|$)",
+			"captures": {
+				"1": {
+					"name": "storage.type.function.pug"
+				}
+			},
+			"end": "$",
+			"name": "meta.control.flow.pug",
+			"comment": "Pug control flow.",
+			"patterns": [
+				{
+					"begin": "",
+					"end": "$",
+					"name": "js.embedded.control.flow.pug",
+					"patterns": [
+						{
+							"include": "source.js"
+						}
+					]
+				}
+			]
+		},
+		"flow_control_each": {
+			"begin": "(each)(\\s+|$)",
+			"captures": {
+				"1": {
+					"name": "storage.type.function.pug"
+				}
+			},
+			"end": "$",
+			"name": "meta.control.flow.pug.each",
+			"patterns": [
+				{
+					"match": "([\\w$_]+)(?:\\s*,\\s*([\\w$_]+))?",
+					"name": "variable.other.pug.each-var"
+				},
+				{
+					"begin": "",
+					"end": "$",
+					"name": "js.embedded.control.flow.pug",
+					"patterns": [
+						{
+							"include": "source.js"
+						}
+					]
+				}
+			]
+		},
+		"case_when_paren": {
+			"begin": "\\(",
+			"end": "\\)",
+			"name": "js.when.control.flow.pug",
+			"patterns": [
+				{
+					"include": "#case_when_paren"
+				},
+				{
+					"match": ":",
+					"name": "invalid.illegal.name.tag.pug"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"case_conds": {
+			"begin": "(default|when)((\\s+|(?=:))|$)",
+			"captures": {
+				"1": {
+					"name": "storage.type.function.pug"
+				}
+			},
+			"end": "$",
+			"name": "meta.control.flow.pug",
+			"comment": "Pug case conditionals.",
+			"patterns": [
+				{
+					"begin": "\\G(?!:)",
+					"end": "(?=:\\s+)|$",
+					"name": "js.embedded.control.flow.pug",
+					"patterns": [
+						{
+							"include": "#case_when_paren"
+						},
+						{
+							"include": "source.js"
+						}
+					]
+				},
+				{
+					"begin": ":\\s+",
+					"end": "$",
+					"name": "tag.case.control.flow.pug",
+					"patterns": [
+						{
+							"include": "#complete_tag"
+						}
+					]
+				}
+			]
+		},
+		"complete_tag": {
+			"begin": "(?=[\\w.#])|(:\\s*)",
+			"end": "(\\.?$)|(?=:.)",
+			"endCaptures": {
+				"1": {
+					"name": "storage.type.function.pug.dot-block-dot"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#blocks_and_includes"
+				},
+				{
+					"include": "#unbuffered_code"
+				},
+				{
+					"include": "#mixin_call"
+				},
+				{
+					"include": "#flow_control"
+				},
+				{
+					"include": "#flow_control_each"
+				},
+				{
+					"match": "(?<=:)\\w.*$",
+					"name": "invalid.illegal.name.tag.pug"
+				},
+				{
+					"include": "#tag_name"
+				},
+				{
+					"include": "#tag_id"
+				},
+				{
+					"include": "#tag_classes"
+				},
+				{
+					"include": "#tag_attributes"
+				},
+				{
+					"include": "#tag_mixin_attributes"
+				},
+				{
+					"match": "((\\.)\\s+$)|((:)\\s*$)",
+					"captures": {
+						"2": {
+							"name": "invalid.illegal.end.tag.pug"
+						},
+						"4": {
+							"name": "invalid.illegal.end.tag.pug"
+						}
+					}
+				},
+				{
+					"include": "#printed_expression"
+				},
+				{
+					"include": "#tag_text"
+				}
+			]
+		},
+		"tag_name": {
+			"begin": "([#!]\\{(?=.*?\\}))|(\\w(([\\w:-]+[\\w-])|([\\w-]*)))",
+			"end": "(\\G(?<!\\5[^\\w-]))|\\}|$",
+			"name": "meta.tag.other entity.name.tag.pug",
+			"patterns": [
+				{
+					"begin": "\\G(?<=\\{)",
+					"end": "(?=\\})",
+					"name": "meta.tag.other entity.name.tag.pug",
+					"patterns": [
+						{
+							"match": "{",
+							"name": "invalid.illegal.tag.pug"
+						},
+						{
+							"include": "source.js"
+						}
+					]
+				}
+			]
+		},
+		"tag_id": {
+			"match": "#[\\w-]+",
+			"name": "meta.selector.css entity.other.attribute-name.id.css.pug"
+		},
+		"tag_classes": {
+			"match": "\\.([^\\w-])?[\\w-]*",
+			"captures": {
+				"1": {
+					"name": "invalid.illegal.tag.pug"
+				}
+			},
+			"name": "meta.selector.css entity.other.attribute-name.class.css.pug"
+		},
+		"tag_attributes": {
+			"begin": "(\\(\\s*)",
+			"captures": {
+				"1": {
+					"name": "constant.name.attribute.tag.pug"
+				}
+			},
+			"end": "(\\))",
+			"name": "meta.tag.other",
+			"patterns": [
+				{
+					"include": "#tag_attribute_name_paren"
+				},
+				{
+					"include": "#tag_attribute_name"
+				},
+				{
+					"match": "!(?!=)",
+					"name": "invalid.illegal.tag.pug"
+				},
+				{
+					"begin": "=\\s*",
+					"end": "$|(?=,|(?:\\s+[^!%&*\\-+~|<>?/])|\\))",
+					"name": "attribute_value",
+					"patterns": [
+						{
+							"include": "#js_parens"
+						},
+						{
+							"include": "#js_brackets"
+						},
+						{
+							"include": "#js_braces"
+						},
+						{
+							"include": "source.js"
+						}
+					]
+				},
+				{
+					"begin": "(?<=[%&*\\-+~|<>:?/])\\s+",
+					"end": "$|(?=,|(?:\\s+[^!%&*\\-+~|<>?/])|\\))",
+					"name": "attribute_value2",
+					"patterns": [
+						{
+							"include": "#js_parens"
+						},
+						{
+							"include": "#js_brackets"
+						},
+						{
+							"include": "#js_braces"
+						},
+						{
+							"include": "source.js"
+						}
+					]
+				}
+			]
+		},
+		"tag_attribute_name": {
+			"match": "([^\\s(),=/!]+)\\s*",
+			"captures": {
+				"1": {
+					"name": "entity.other.attribute-name.tag.pug"
+				}
+			}
+		},
+		"tag_attribute_name_paren": {
+			"begin": "\\(\\s*",
+			"end": "\\)",
+			"name": "entity.other.attribute-name.tag.pug",
+			"patterns": [
+				{
+					"include": "#tag_attribute_name_paren"
+				},
+				{
+					"include": "#tag_attribute_name"
+				}
+			]
+		},
+		"tag_mixin_attributes": {
+			"begin": "(&attributes\\()",
+			"captures": {
+				"1": {
+					"name": "entity.name.function.pug"
+				}
+			},
+			"end": "(\\))",
+			"name": "meta.tag.other",
+			"patterns": [
+				{
+					"match": "attributes(?=\\))",
+					"name": "storage.type.keyword.pug"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"tag_text": {
+			"begin": "(?=.)",
+			"end": "$",
+			"patterns": [
+				{
+					"include": "#inline_pug"
+				},
+				{
+					"include": "#embedded_html"
+				},
+				{
+					"include": "#html_entity"
+				},
+				{
+					"include": "#interpolated_value"
+				},
+				{
+					"include": "#interpolated_error"
+				}
+			]
+		},
+		"inline_pug_text": {
+			"begin": "",
+			"end": "(?=\\])",
+			"patterns": [
+				{
+					"begin": "\\[",
+					"end": "\\]",
+					"patterns": [
+						{
+							"include": "#inline_pug_text"
+						}
+					]
+				},
+				{
+					"include": "#inline_pug"
+				},
+				{
+					"include": "#embedded_html"
+				},
+				{
+					"include": "#html_entity"
+				},
+				{
+					"include": "#interpolated_value"
+				},
+				{
+					"include": "#interpolated_error"
+				}
+			]
+		},
+		"inline_pug": {
+			"begin": "(?<!\\\\)(#\\[)",
+			"captures": {
+				"1": {
+					"name": "entity.name.function.pug"
+				},
+				"2": {
+					"name": "entity.name.function.pug"
+				}
+			},
+			"end": "(\\])",
+			"name": "inline.pug",
+			"patterns": [
+				{
+					"include": "#inline_pug"
+				},
+				{
+					"include": "#mixin_call"
+				},
+				{
+					"begin": "(?<!\\])(?=[\\w.#])|(:\\s*)",
+					"end": "(?=\\]|(:.)|=|\\s)",
+					"name": "tag.inline.pug",
+					"patterns": [
+						{
+							"include": "#tag_name"
+						},
+						{
+							"include": "#tag_id"
+						},
+						{
+							"include": "#tag_classes"
+						},
+						{
+							"include": "#tag_attributes"
+						},
+						{
+							"include": "#tag_mixin_attributes"
+						},
+						{
+							"include": "#inline_pug"
+						},
+						{
+							"match": "\\[",
+							"name": "invalid.illegal.tag.pug"
+						}
+					]
+				},
+				{
+					"include": "#unbuffered_code"
+				},
+				{
+					"include": "#printed_expression"
+				},
+				{
+					"match": "\\[",
+					"name": "invalid.illegal.tag.pug"
+				},
+				{
+					"include": "#inline_pug_text"
+				}
+			]
+		},
+		"html_entity": {
+			"patterns": [
+				{
+					"match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+					"name": "constant.character.entity.html.text.pug"
+				},
+				{
+					"match": "[<>&]",
+					"name": "invalid.illegal.html_entity.text.pug"
+				}
+			]
+		},
+		"interpolated_value": {
+			"begin": "(?<!\\\\)[#!]\\{(?=.*?\\})",
+			"end": "\\}",
+			"name": "string.interpolated.pug",
+			"patterns": [
+				{
+					"match": "{",
+					"name": "invalid.illegal.tag.pug"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"interpolated_error": {
+			"match": "(?<!\\\\)[#!]\\{(?=[^}]*$)",
+			"name": "invalid.illegal.tag.pug"
+		},
+		"printed_expression": {
+			"begin": "(!?\\=)\\s*",
+			"captures": {
+				"1": {
+					"name": "constant"
+				}
+			},
+			"end": "(?=\\])|$",
+			"name": "source.js",
+			"patterns": [
+				{
+					"include": "#js_brackets"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"embedded_html": {
+			"begin": "(?=<[^>]*>)",
+			"end": "$|(?=>)",
+			"name": "html",
+			"patterns": [
+				{
+					"include": "text.html.basic"
+				},
+				{
+					"include": "#interpolated_value"
+				},
+				{
+					"include": "#interpolated_error"
+				}
+			]
+		},
+		"js_parens": {
+			"begin": "\\(",
+			"end": "\\)",
+			"patterns": [
+				{
+					"include": "#js_parens"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"js_brackets": {
+			"begin": "\\[",
+			"end": "\\]",
+			"patterns": [
+				{
+					"include": "#js_brackets"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"js_braces": {
+			"begin": "\\{",
+			"end": "\\}",
+			"patterns": [
+				{
+					"include": "#js_braces"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		},
+		"babel_parens": {
+			"begin": "\\(",
+			"end": "\\)|(({\\s*)?$)",
+			"patterns": [
+				{
+					"include": "#babel_parens"
+				},
+				{
+					"include": "source.js"
+				}
+			]
+		}
+	}
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/svelte.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/svelte.tmLanguage.json
@@ -1,0 +1,1287 @@
+{
+ "name": "Svelte Component",
+ "scopeName": "source.svelte",
+ "fileTypes": [
+  "svelte"
+ ],
+ "uuid": "7582b62f-51d9-4a84-8c8d-fc189530faf6",
+ "injections": {
+  "L:(meta.script.svelte | meta.style.svelte) (meta.lang.js | meta.lang.javascript) - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.js",
+     "patterns": [
+      {
+       "include": "source.js"
+      }
+     ]
+    }
+   ]
+  },
+  "L:(meta.script.svelte | meta.style.svelte) (meta.lang.ts | meta.lang.typescript) - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?=[^\\n]+</(script|style)[\\s>])",
+     "end": "(?=</(script|style)[\\s>])",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.ts",
+     "patterns": [
+      {
+       "include": "source.ts"
+      }
+     ]
+    },
+    {
+     "begin": "(?<=>)(?!</)",
+     "while": "^(?!\\s*</(script|style)[\\s>])",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.ts",
+     "patterns": [
+      {
+       "include": "source.ts"
+      }
+     ]
+    }
+   ]
+  },
+  "L:(meta.script.svelte | meta.style.svelte) meta.lang.coffee - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.coffee",
+     "patterns": [
+      {
+       "include": "source.coffee"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.script.svelte - meta.lang - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.js",
+     "patterns": [
+      {
+       "include": "source.js"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.style.svelte meta.lang.stylus - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.stylus",
+     "patterns": [
+      {
+       "include": "source.stylus"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.style.svelte meta.lang.sass - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.sass",
+     "patterns": [
+      {
+       "include": "source.sass"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.style.svelte meta.lang.css - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.css",
+     "patterns": [
+      {
+       "include": "source.css"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.style.svelte meta.lang.scss - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.css.scss",
+     "patterns": [
+      {
+       "include": "source.css.scss"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.style.svelte meta.lang.less - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.css.less",
+     "patterns": [
+      {
+       "include": "source.css.less"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.style.svelte meta.lang.postcss - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.css.postcss",
+     "patterns": [
+      {
+       "include": "source.css.postcss"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.style.svelte - meta.lang - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "source.css",
+     "patterns": [
+      {
+       "include": "source.css"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.template.svelte meta.lang.pug - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)(?!</)",
+     "end": "(?=</)",
+     "name": "meta.embedded.block.svelte",
+     "contentName": "text.pug",
+     "patterns": [
+      {
+       "include": "text.pug"
+      }
+     ]
+    }
+   ]
+  },
+  "L:meta.template.svelte - meta.lang - (meta source)": {
+   "patterns": [
+    {
+     "begin": "(?<=>)\\s",
+     "end": "(?=</template)",
+     "patterns": [
+      {
+       "include": "#scope"
+      }
+     ]
+    }
+   ]
+  },
+  "L:(source.ts, source.js, source.coffee)": {
+   "patterns": [
+    {
+     "match": "(?<![_$./'\"[:alnum:]])\\$(?=[_[:alpha:]][_$[:alnum:]]*)",
+     "name": "punctuation.definition.variable.svelte"
+    },
+    {
+     "match": "(?<![_$./'\"[:alnum:]])(\\$\\$)(?=props|restProps|slots)",
+     "name": "punctuation.definition.variable.svelte"
+    }
+   ]
+  }
+ },
+ "patterns": [
+  {
+   "include": "#scope"
+  }
+ ],
+ "repository": {
+  "scope": {
+   "patterns": [
+    {
+     "include": "#comments"
+    },
+    {
+     "include": "#special-tags"
+    },
+    {
+     "include": "#tags"
+    },
+    {
+     "include": "#interpolation"
+    },
+    {
+     "begin": "(?<=>|})",
+     "end": "(?=<|{)",
+     "name": "text.svelte"
+    }
+   ]
+  },
+  "comments": {
+   "begin": "<!--",
+   "end": "-->",
+   "captures": {
+    "0": {
+     "name": "punctuation.definition.comment.svelte"
+    }
+   },
+   "name": "comment.block.svelte",
+   "patterns": [
+    {
+     "begin": "(@)(component)",
+     "beginCaptures": {
+      "1": {
+       "name": "punctuation.definition.keyword.svelte"
+      },
+      "2": {
+       "name": "storage.type.class.component.svelte keyword.declaration.class.component.svelte"
+      }
+     },
+     "end": "(?=-->)",
+     "contentName": "comment.block.documentation.svelte",
+     "patterns": [
+      {
+       "match": ".*?(?=-->)",
+       "captures": {
+        "0": {
+         "patterns": [
+          {
+           "include": "text.html.markdown"
+          }
+         ]
+        }
+       }
+      },
+      {
+       "include": "text.html.markdown"
+      }
+     ]
+    },
+    {
+     "match": "\\G-?>|<!--(?!>)|<!-(?=-->)|--!>",
+     "name": "invalid.illegal.characters-not-allowed-here.svelte"
+    }
+   ]
+  },
+  "destructuring": {
+   "patterns": [
+    {
+     "begin": "(?={)",
+     "end": "(?<=})",
+     "name": "meta.embedded.expression.svelte source.ts",
+     "patterns": [
+      {
+       "include": "source.ts#object-binding-pattern"
+      }
+     ]
+    },
+    {
+     "begin": "(?=\\[)",
+     "end": "(?<=\\])",
+     "name": "meta.embedded.expression.svelte source.ts",
+     "patterns": [
+      {
+       "include": "source.ts#array-binding-pattern"
+      }
+     ]
+    }
+   ]
+  },
+  "destructuring-const": {
+   "patterns": [
+    {
+     "begin": "(?={)",
+     "end": "(?<=})",
+     "name": "meta.embedded.expression.svelte source.ts",
+     "patterns": [
+      {
+       "include": "source.ts#object-binding-pattern-const"
+      }
+     ]
+    },
+    {
+     "begin": "(?=\\[)",
+     "end": "(?<=\\])",
+     "name": "meta.embedded.expression.svelte source.ts",
+     "patterns": [
+      {
+       "include": "source.ts#array-binding-pattern-const"
+      }
+     ]
+    }
+   ]
+  },
+  "interpolation": {
+   "patterns": [
+    {
+     "begin": "\\{",
+     "end": "\\}",
+     "beginCaptures": {
+      "0": {
+       "name": "punctuation.section.embedded.begin.svelte"
+      }
+     },
+     "endCaptures": {
+      "0": {
+       "name": "punctuation.section.embedded.end.svelte"
+      }
+     },
+     "contentName": "meta.embedded.expression.svelte source.ts",
+     "patterns": [
+      {
+       "begin": "\\G\\s*(?={)",
+       "end": "(?<=})",
+       "patterns": [
+        {
+         "include": "source.ts#object-literal"
+        }
+       ]
+      },
+      {
+       "include": "source.ts"
+      }
+     ]
+    }
+   ]
+  },
+  "special-tags": {
+   "patterns": [
+    {
+     "include": "#special-tags-void"
+    },
+    {
+     "include": "#special-tags-block-begin"
+    },
+    {
+     "include": "#special-tags-block-end"
+    }
+   ]
+  },
+  "special-tags-keywords": {
+   "match": "([#@/:])(else\\s+if|[a-z]*)",
+   "captures": {
+    "1": {
+     "name": "punctuation.definition.keyword.svelte"
+    },
+    "2": {
+     "patterns": [
+      {
+       "match": "if|else\\s+if|else",
+       "name": "keyword.control.conditional.svelte"
+      },
+      {
+       "match": "each|key",
+       "name": "keyword.control.svelte"
+      },
+      {
+       "match": "await|then|catch",
+       "name": "keyword.control.flow.svelte"
+      },
+      {
+       "match": "snippet",
+       "name": "keyword.control.svelte"
+      },
+      {
+       "match": "html",
+       "name": "keyword.other.svelte"
+      },
+      {
+       "match": "render",
+       "name": "keyword.other.svelte"
+      },
+      {
+       "match": "debug",
+       "name": "keyword.other.debugger.svelte"
+      },
+      {
+       "match": "const",
+       "name": "storage.type.svelte"
+      }
+     ]
+    }
+   }
+  },
+  "special-tags-modes": {
+   "patterns": [
+    {
+     "begin": "(?<=(if|key|then|catch|html|render).*?)\\G",
+     "end": "(?=})",
+     "name": "meta.embedded.expression.svelte source.ts",
+     "patterns": [
+      {
+       "include": "source.ts"
+      }
+     ]
+    },
+    {
+     "begin": "(?<=snippet.*?)\\G",
+     "end": "(?=})",
+     "name": "meta.embedded.expression.svelte source.ts",
+     "patterns": [
+      {
+       "match": "\\G\\s*([_$[:alpha:]][_$[:alnum:]]*)\\s*(?=<)",
+       "captures": {
+        "1": {
+         "name": "entity.name.function.ts"
+        }
+       }
+      },
+      {
+       "begin": "(?<=<)",
+       "end": "(?=>)",
+       "contentName": "meta.type.parameters.ts",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      },
+      {
+       "begin": "(?<=>\\s*\\()",
+       "end": "(?=})",
+       "name": "meta.embedded.expression.svelte source.ts",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      },
+      {
+       "begin": "\\G",
+       "end": "(?=})",
+       "name": "meta.embedded.expression.svelte source.ts",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "begin": "(?<=const.*?)\\G",
+     "end": "(?=})",
+     "patterns": [
+      {
+       "include": "#destructuring-const"
+      },
+      {
+       "begin": "\\G\\s*([_$[:alpha:]][_$[:alnum:]]+)\\s*",
+       "end": "(?=[:=])",
+       "beginCaptures": {
+        "1": {
+         "name": "variable.other.constant.svelte"
+        }
+       }
+      },
+      {
+       "begin": "(?=:)",
+       "end": "(?=\\=)",
+       "name": "meta.type.annotation.svelte",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      },
+      {
+       "begin": "(?=\\=)",
+       "name": "meta.embedded.expression.svelte source.ts",
+       "end": "(?=})",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "begin": "(?<=each.*?)\\G",
+     "end": "(?=})",
+     "patterns": [
+      {
+       "begin": "\\G\\s*?(?=\\S)",
+       "end": "(?=(?:(?:^\\s*|\\s+)(as))|\\s*(}|,))",
+       "contentName": "meta.embedded.expression.svelte source.ts",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      },
+      {
+       "begin": "(as)|(?=}|,)",
+       "beginCaptures": {
+        "1": {
+         "name": "keyword.control.as.svelte"
+        }
+       },
+       "end": "(?=})",
+       "patterns": [
+        {
+         "include": "#destructuring"
+        },
+        {
+         "begin": "\\(",
+         "end": "\\)|(?=})",
+         "captures": {
+          "0": {
+           "name": "meta.brace.round.svelte"
+          }
+         },
+         "contentName": "meta.embedded.expression.svelte source.ts",
+         "patterns": [
+          {
+           "include": "source.ts"
+          }
+         ]
+        },
+        {
+         "match": "(\\s*([_$[:alpha:]][_$[:alnum:]]*)\\s*)",
+         "captures": {
+          "1": {
+           "name": "meta.embedded.expression.svelte source.ts",
+           "patterns": [
+            {
+             "include": "source.ts"
+            }
+           ]
+          }
+         }
+        },
+        {
+         "match": ",",
+         "name": "punctuation.separator.svelte"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "begin": "(?<=await.*?)\\G",
+     "end": "(?=})",
+     "patterns": [
+      {
+       "begin": "\\G\\s*?(?=\\S)",
+       "end": "\\s+(then)|(?=})",
+       "endCaptures": {
+        "1": {
+         "name": "keyword.control.flow.svelte"
+        }
+       },
+       "contentName": "meta.embedded.expression.svelte source.ts",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      },
+      {
+       "begin": "(?<=then\\b)",
+       "end": "(?=})",
+       "contentName": "meta.embedded.expression.svelte source.ts",
+       "patterns": [
+        {
+         "include": "source.ts"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "begin": "(?<=debug.*?)\\G",
+     "end": "(?=})",
+     "patterns": [
+      {
+       "match": "[_$[:alpha:]][_$[:alnum:]]*",
+       "captures": {
+        "0": {
+         "name": "meta.embedded.expression.svelte source.ts",
+         "patterns": [
+          {
+           "include": "source.ts"
+          }
+         ]
+        }
+       }
+      },
+      {
+       "match": ",",
+       "name": "punctuation.separator.svelte"
+      }
+     ]
+    }
+   ]
+  },
+  "special-tags-void": {
+   "begin": "({)\\s*((?:[@:])(else\\s+if|[a-z]*))",
+   "beginCaptures": {
+    "1": {
+     "name": "punctuation.definition.block.begin.svelte"
+    },
+    "2": {
+     "patterns": [
+      {
+       "include": "#special-tags-keywords"
+      }
+     ]
+    }
+   },
+   "end": "\\}",
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.definition.block.end.svelte"
+    }
+   },
+   "name": "meta.special.$3.svelte",
+   "patterns": [
+    {
+     "include": "#special-tags-modes"
+    }
+   ]
+  },
+  "special-tags-block-begin": {
+   "begin": "({)\\s*(#([a-z]*))",
+   "end": "(})",
+   "name": "meta.special.$3.svelte meta.special.start.svelte",
+   "beginCaptures": {
+    "1": {
+     "name": "punctuation.definition.block.begin.svelte"
+    },
+    "2": {
+     "patterns": [
+      {
+       "include": "#special-tags-keywords"
+      }
+     ]
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.definition.block.end.svelte"
+    }
+   },
+   "patterns": [
+    {
+     "include": "#special-tags-modes"
+    }
+   ]
+  },
+  "special-tags-block-end": {
+   "begin": "({)\\s*(/([a-z]*))",
+   "end": "(})",
+   "name": "meta.special.$3.svelte meta.special.end.svelte",
+   "beginCaptures": {
+    "1": {
+     "name": "punctuation.definition.block.begin.svelte"
+    },
+    "2": {
+     "patterns": [
+      {
+       "include": "#special-tags-keywords"
+      }
+     ]
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "punctuation.definition.block.end.svelte"
+    }
+   }
+  },
+  "attributes": {
+   "patterns": [
+    {
+     "include": "#attributes-comments"
+    },
+    {
+     "include": "#attributes-directives"
+    },
+    {
+     "include": "#attributes-keyvalue"
+    },
+    {
+     "include": "#attributes-attach"
+    },
+    {
+     "include": "#attributes-interpolated"
+    }
+   ]
+  },
+  "attributes-comments": {
+   "patterns": [
+    {
+     "match": "//.*$",
+     "name": "comment.line.double-slash.svelte"
+    },
+    {
+     "begin": "/\\*",
+     "end": "\\*/",
+     "name": "comment.block.svelte"
+    }
+   ]
+  },
+  "attributes-attach": {
+   "begin": "(?<!:|=)\\s*({@attach\\s)",
+   "end": "(\\})",
+   "captures": {
+    "1": {
+     "name": "entity.other.attribute-name.svelte"
+    }
+   },
+   "contentName": "meta.embedded.expression.svelte source.ts",
+   "patterns": [
+    {
+     "include": "source.ts"
+    }
+   ]
+  },
+  "attributes-interpolated": {
+   "begin": "(?<!:|=)\\s*({)",
+   "end": "(\\})",
+   "captures": {
+    "1": {
+     "name": "entity.other.attribute-name.svelte"
+    }
+   },
+   "contentName": "meta.embedded.expression.svelte source.ts",
+   "patterns": [
+    {
+     "include": "source.ts"
+    }
+   ]
+  },
+  "attributes-keyvalue": {
+   "begin": "((?:--)?[_$[:alpha:]][_\\-$[:alnum:]]*)",
+   "beginCaptures": {
+    "0": {
+     "patterns": [
+      {
+       "match": "--.*",
+       "name": "support.type.property-name.svelte"
+      },
+      {
+       "match": ".*",
+       "name": "entity.other.attribute-name.svelte"
+      }
+     ]
+    }
+   },
+   "end": "(?=\\s*+[^=\\s])",
+   "name": "meta.attribute.$1.svelte",
+   "patterns": [
+    {
+     "begin": "=",
+     "beginCaptures": {
+      "0": {
+       "name": "punctuation.separator.key-value.svelte"
+      }
+     },
+     "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+     "patterns": [
+      {
+       "include": "#attributes-value"
+      }
+     ]
+    }
+   ]
+  },
+  "attributes-value": {
+   "patterns": [
+    {
+     "include": "#interpolation"
+    },
+    {
+     "match": "(?:(['\"])([0-9._]+[\\w%]{,4})(\\1))|(?:([0-9._]+[\\w%]{,4})(?=\\s|/?>))",
+     "captures": {
+      "1": {
+       "name": "punctuation.definition.string.begin.svelte"
+      },
+      "2": {
+       "name": "constant.numeric.decimal.svelte"
+      },
+      "3": {
+       "name": "punctuation.definition.string.end.svelte"
+      },
+      "4": {
+       "name": "constant.numeric.decimal.svelte"
+      }
+     }
+    },
+    {
+     "match": "([^\\s\"'=<>`/]|/(?!>))+",
+     "name": "string.unquoted.svelte",
+     "patterns": [
+      {
+       "include": "#interpolation"
+      }
+     ]
+    },
+    {
+     "begin": "(['\"])",
+     "end": "\\1",
+     "beginCaptures": {
+      "0": {
+       "name": "punctuation.definition.string.begin.svelte"
+      }
+     },
+     "endCaptures": {
+      "0": {
+       "name": "punctuation.definition.string.end.svelte"
+      }
+     },
+     "name": "string.quoted.svelte",
+     "patterns": [
+      {
+       "include": "#interpolation"
+      }
+     ]
+    }
+   ]
+  },
+  "attributes-directives-keywords": {
+   "patterns": [
+    {
+     "match": "on|use|bind",
+     "name": "keyword.control.svelte"
+    },
+    {
+     "match": "transition|in|out|animate",
+     "name": "keyword.other.animation.svelte"
+    },
+    {
+     "match": "let",
+     "name": "storage.type.svelte"
+    },
+    {
+     "match": "class|style",
+     "name": "entity.other.attribute-name.svelte"
+    }
+   ]
+  },
+  "attributes-directives-types": {
+   "patterns": [
+    {
+     "match": "(?<=(on):).*$",
+     "name": "entity.name.type.svelte"
+    },
+    {
+     "match": "(?<=(bind):).*$",
+     "name": "variable.parameter.svelte"
+    },
+    {
+     "match": "(?<=(use|transition|in|out|animate):).*$",
+     "name": "variable.function.svelte"
+    },
+    {
+     "match": "(?<=(let|class|style):).*$",
+     "name": "variable.parameter.svelte"
+    }
+   ]
+  },
+  "attributes-directives-types-assigned": {
+   "patterns": [
+    {
+     "match": "(?<=(bind):)this$",
+     "name": "variable.language.svelte"
+    },
+    {
+     "match": "(?<=(bind):).*$",
+     "name": "entity.name.type.svelte"
+    },
+    {
+     "match": "(?<=(class):).*$",
+     "name": "entity.other.attribute-name.class.svelte"
+    },
+    {
+     "match": "(?<=(style):).*$",
+     "name": "support.type.property-name.svelte"
+    },
+    {
+     "include": "#attributes-directives-types"
+    }
+   ]
+  },
+  "attributes-directives": {
+   "begin": "(?<!<)(on|use|bind|transition|in|out|animate|let|class|style)(:)(?:((?:--)?[_$[:alpha:]][_\\-$[:alnum:]]*(?=\\s*=))|((?:--)?[_$[:alpha:]][_\\-$[:alnum:]]*))((\\|\\w+)*)",
+   "beginCaptures": {
+    "1": {
+     "patterns": [
+      {
+       "include": "#attributes-directives-keywords"
+      }
+     ]
+    },
+    "2": {
+     "name": "punctuation.definition.keyword.svelte"
+    },
+    "3": {
+     "patterns": [
+      {
+       "include": "#attributes-directives-types-assigned"
+      }
+     ]
+    },
+    "4": {
+     "patterns": [
+      {
+       "include": "#attributes-directives-types"
+      }
+     ]
+    },
+    "5": {
+     "patterns": [
+      {
+       "match": "\\w+",
+       "name": "support.function.svelte"
+      },
+      {
+       "match": "\\|",
+       "name": "punctuation.separator.svelte"
+      }
+     ]
+    }
+   },
+   "end": "(?=\\s*+[^=\\s])",
+   "name": "meta.directive.$1.svelte",
+   "patterns": [
+    {
+     "begin": "=",
+     "beginCaptures": {
+      "0": {
+       "name": "punctuation.separator.key-value.svelte"
+      }
+     },
+     "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+     "patterns": [
+      {
+       "include": "#attributes-value"
+      }
+     ]
+    }
+   ]
+  },
+  "attributes-generics": {
+   "begin": "(generics)(=)([\"'])",
+   "beginCaptures": {
+    "1": {
+     "name": "entity.other.attribute-name.svelte"
+    },
+    "2": {
+     "name": "punctuation.separator.key-value.svelte"
+    },
+    "3": {
+     "name": "punctuation.definition.string.begin.svelte"
+    }
+   },
+   "end": "(\\3)",
+   "endCaptures": {
+    "1": {
+     "name": "punctuation.definition.string.end.svelte"
+    }
+   },
+   "contentName": "meta.embedded.expression.svelte source.ts",
+   "patterns": [
+    {
+     "include": "#type-parameters"
+    }
+   ]
+  },
+  "type-parameters": {
+   "name": "meta.type.parameters.ts",
+   "patterns": [
+    {
+     "include": "source.ts#comment"
+    },
+    {
+     "name": "storage.modifier.ts",
+     "match": "(?<![_$[:alnum:]])(?:(?<=\\.\\.\\.)|(?<!\\.))(extends|in|out|const)(?![_$[:alnum:]])(?:(?=\\.\\.\\.)|(?!\\.))"
+    },
+    {
+     "include": "source.ts#type"
+    },
+    {
+     "include": "source.ts#punctuation-comma"
+    },
+    {
+     "name": "keyword.operator.assignment.ts",
+     "match": "(=)(?!>)"
+    }
+   ]
+  },
+  "tags": {
+   "patterns": [
+    {
+     "include": "#tags-lang"
+    },
+    {
+     "include": "#tags-void"
+    },
+    {
+     "include": "#tags-general-end"
+    },
+    {
+     "include": "#tags-general-start"
+    }
+   ]
+  },
+  "tags-name": {
+   "patterns": [
+    {
+     "match": "(svelte)(:)([a-z][\\w:-]*)",
+     "captures": {
+      "1": {
+       "name": "keyword.control.svelte"
+      },
+      "2": {
+       "name": "punctuation.definition.keyword.svelte"
+      },
+      "3": {
+       "name": "entity.name.tag.svelte"
+      }
+     }
+    },
+    {
+     "match": "slot",
+     "name": "keyword.control.svelte"
+    },
+    {
+     "match": "([\\w]+(?:\\.[\\w]+)+)|([A-Z][\\w]*)",
+     "captures": {
+      "1": {
+       "patterns": [
+        {
+         "match": "\\w+",
+         "name": "support.class.component.svelte"
+        },
+        {
+         "match": "\\.",
+         "name": "punctuation.definition.keyword.svelte"
+        }
+       ]
+      },
+      "2": {
+       "name": "support.class.component.svelte"
+      }
+     }
+    },
+    {
+     "match": "[a-z][\\w0-9:]*-[\\w0-9:-]*",
+     "name": "meta.tag.custom.svelte entity.name.tag.svelte"
+    },
+    {
+     "match": "[a-z][\\w0-9:-]*",
+     "name": "entity.name.tag.svelte"
+    }
+   ]
+  },
+  "tags-start-attributes": {
+   "begin": "\\G",
+   "end": "(?=/?>)",
+   "name": "meta.tag.start.svelte",
+   "patterns": [
+    {
+     "include": "#attributes"
+    }
+   ]
+  },
+  "tags-lang-start-attributes": {
+   "begin": "\\G",
+   "end": "(?=/>)|>",
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.definition.tag.end.svelte"
+    }
+   },
+   "name": "meta.tag.start.svelte",
+   "patterns": [
+    {
+     "include": "#attributes-generics"
+    },
+    {
+     "include": "#attributes"
+    }
+   ]
+  },
+  "tags-start-node": {
+   "match": "(<)([^/\\s>/]*)",
+   "captures": {
+    "1": {
+     "name": "punctuation.definition.tag.begin.svelte"
+    },
+    "2": {
+     "patterns": [
+      {
+       "include": "#tags-name"
+      }
+     ]
+    }
+   },
+   "name": "meta.tag.start.svelte"
+  },
+  "tags-end-node": {
+   "match": "(</)(.*?)\\s*(>)|(/>)",
+   "captures": {
+    "1": {
+     "name": "meta.tag.end.svelte punctuation.definition.tag.begin.svelte"
+    },
+    "2": {
+     "name": "meta.tag.end.svelte",
+     "patterns": [
+      {
+       "include": "#tags-name"
+      }
+     ]
+    },
+    "3": {
+     "name": "meta.tag.end.svelte punctuation.definition.tag.end.svelte"
+    },
+    "4": {
+     "name": "meta.tag.start.svelte punctuation.definition.tag.end.svelte"
+    }
+   }
+  },
+  "tags-lang": {
+   "begin": "<(script|style|template)",
+   "end": "</\\1\\s*>|/>",
+   "beginCaptures": {
+    "0": {
+     "patterns": [
+      {
+       "include": "#tags-start-node"
+      }
+     ]
+    }
+   },
+   "endCaptures": {
+    "0": {
+     "patterns": [
+      {
+       "include": "#tags-end-node"
+      }
+     ]
+    }
+   },
+   "name": "meta.$1.svelte",
+   "patterns": [
+    {
+     "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/)?(\\w+)\\2)",
+     "end": "(?=</|/>)",
+     "name": "meta.lang.$3.svelte",
+     "patterns": [
+      {
+       "include": "#tags-lang-start-attributes"
+      }
+     ]
+    },
+    {
+     "include": "#tags-lang-start-attributes"
+    }
+   ]
+  },
+  "tags-void": {
+   "begin": "(<)(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)(?=\\s|/?>)",
+   "beginCaptures": {
+    "1": {
+     "name": "punctuation.definition.tag.begin.svelte"
+    },
+    "2": {
+     "name": "entity.name.tag.svelte"
+    }
+   },
+   "end": "/?>",
+   "endCaptures": {
+    "0": {
+     "name": "punctuation.definition.tag.begin.svelte"
+    }
+   },
+   "name": "meta.tag.void.svelte",
+   "patterns": [
+    {
+     "include": "#attributes"
+    }
+   ]
+  },
+  "tags-general-start": {
+   "begin": "(<)([^/\\s>/]*)",
+   "end": "(/?>)",
+   "beginCaptures": {
+    "0": {
+     "patterns": [
+      {
+       "include": "#tags-start-node"
+      }
+     ]
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "meta.tag.start.svelte punctuation.definition.tag.end.svelte"
+    }
+   },
+   "name": "meta.scope.tag.$2.svelte",
+   "patterns": [
+    {
+     "include": "#tags-start-attributes"
+    }
+   ]
+  },
+  "tags-general-end": {
+   "begin": "(</)([^/\\s>]*)",
+   "end": "(>)",
+   "beginCaptures": {
+    "1": {
+     "name": "meta.tag.end.svelte punctuation.definition.tag.begin.svelte"
+    },
+    "2": {
+     "name": "meta.tag.end.svelte",
+     "patterns": [
+      {
+       "include": "#tags-name"
+      }
+     ]
+    }
+   },
+   "endCaptures": {
+    "1": {
+     "name": "meta.tag.end.svelte punctuation.definition.tag.end.svelte"
+    }
+   },
+   "name": "meta.scope.tag.$2.svelte"
+  }
+ }
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/grammars/vue.tmLanguage.json
+++ b/editor/src/main/resources/org/nmox/studio/editor/grammars/vue.tmLanguage.json
@@ -1,0 +1,1590 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Vue",
+	"scopeName": "text.html.vue",
+	"patterns": [
+		{
+			"include": "#vue-comments"
+		},
+		{
+			"include": "#self-closing-tag"
+		},
+		{
+			"begin": "(<)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.html.vue"
+				}
+			},
+			"end": "(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.end.html.vue"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)md\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "text.html.markdown",
+							"patterns": [
+								{
+									"include": "text.html.markdown"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?!template(?![A-Za-z0-9:-]))([A-Za-z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)html\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"contentName": "text.html.derivative",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"include": "#html-stuff"
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)pug\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "text.pug",
+							"patterns": [
+								{
+									"include": "text.pug"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)stylus\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.stylus",
+							"patterns": [
+								{
+									"include": "source.stylus"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)postcss\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.postcss",
+							"patterns": [
+								{
+									"include": "source.postcss"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)sass\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.sass",
+							"patterns": [
+								{
+									"include": "source.sass"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)css\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.css",
+							"patterns": [
+								{
+									"include": "source.css"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)scss\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.css.scss",
+							"patterns": [
+								{
+									"include": "source.css.scss"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)less\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.css.less",
+							"patterns": [
+								{
+									"include": "source.css.less"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)js\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.js",
+							"patterns": [
+								{
+									"include": "source.js"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)ts\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.ts",
+							"patterns": [
+								{
+									"include": "source.ts"
+								}
+							]
+						},
+						{
+							"begin": "(?<=>)",
+							"while": "^(?!\\s*<\\/script[\\s>])",
+							"name": "source.ts",
+							"patterns": [
+								{
+									"include": "source.ts"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)jsx\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.js.jsx",
+							"patterns": [
+								{
+									"include": "source.js.jsx"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)tsx\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.tsx",
+							"patterns": [
+								{
+									"include": "source.tsx"
+								}
+							]
+						},
+						{
+							"begin": "(?<=>)",
+							"while": "^(?!\\s*<\\/script[\\s>])",
+							"name": "source.tsx",
+							"patterns": [
+								{
+									"include": "source.tsx"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)coffee\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.coffee",
+							"patterns": [
+								{
+									"include": "source.coffee"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)json\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.json",
+							"patterns": [
+								{
+									"include": "source.json"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)jsonc\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.json.comments",
+							"patterns": [
+								{
+									"include": "source.json.comments"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)json5\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.json5",
+							"patterns": [
+								{
+									"include": "source.json5"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)yaml\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.yaml",
+							"patterns": [
+								{
+									"include": "source.yaml"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)toml\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.toml",
+							"patterns": [
+								{
+									"include": "source.toml"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)(gql|graphql)\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "source.graphql",
+							"patterns": [
+								{
+									"include": "source.graphql"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)vue\\b\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "text.html.vue",
+							"patterns": [
+								{
+									"include": "text.html.vue"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(template)(?=\\s|\\/?>)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/template[\\s>])",
+							"name": "text.html.derivative",
+							"patterns": [
+								{
+									"include": "#html-stuff"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(script)(?=\\s|\\/?>)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#multi-line-script-tag-stuff"
+						}
+					]
+				},
+				{
+					"begin": "(style)(?=\\s|\\/?>)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#multi-line-style-tag-stuff"
+						}
+					]
+				},
+				{
+					"begin": "([a-zA-Z0-9:-]+)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag.$1.html.vue"
+						}
+					},
+					"end": "(</)(\\1)\\s*(?=>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"2": {
+							"name": "entity.name.tag.$2.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/)",
+							"name": "text"
+						}
+					]
+				}
+			]
+		}
+	],
+	"repository": {
+		"multi-line-script-tag-stuff": {
+			"begin": "\\G",
+			"end": "(?=<\\/script[\\s>])",
+			"patterns": [
+				{
+					"begin": "\\G(?!\\blang\\s*=\\s*(?:['\"]?)(?:ts|tsx|jsx|coffee)\\b)",
+					"end": "(?=\\blang\\s*=\\s*(?:['\"]?)(?:ts|tsx|jsx|coffee)\\b)|(>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.end.html.vue"
+						}
+					},
+					"name": "meta.tag-stuff",
+					"patterns": [
+						{
+							"include": "#vue-directives"
+						},
+						{
+							"include": "text.html.basic#attribute"
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)ts\\b)",
+					"end": "(?=<\\/script[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.ts",
+							"patterns": [
+								{
+									"include": "source.ts"
+								}
+							]
+						},
+						{
+							"begin": "(?<=>)",
+							"while": "^(?!\\s*<\\/script[\\s>])",
+							"name": "source.ts",
+							"patterns": [
+								{
+									"include": "source.ts"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)tsx\\b)",
+					"end": "(?=<\\/script[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.tsx",
+							"patterns": [
+								{
+									"include": "source.tsx"
+								}
+							]
+						},
+						{
+							"begin": "(?<=>)",
+							"while": "^(?!\\s*<\\/script[\\s>])",
+							"name": "source.tsx",
+							"patterns": [
+								{
+									"include": "source.tsx"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)jsx\\b)",
+					"end": "(?=<\\/script[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.js.jsx",
+							"patterns": [
+								{
+									"include": "source.js.jsx"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)coffee\\b)",
+					"end": "(?=<\\/script[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.coffee",
+							"patterns": [
+								{
+									"include": "source.coffee"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=>)",
+					"end": "(?=<\\/script[\\s>])",
+					"name": "source.js",
+					"patterns": [
+						{
+							"include": "source.js"
+						}
+					]
+				}
+			]
+		},
+		"multi-line-style-tag-stuff": {
+			"begin": "\\G",
+			"end": "(?=<\\/style[\\s>])",
+			"patterns": [
+				{
+					"begin": "\\G(?!\\blang\\s*=\\s*(?:['\"]?)(?:scss|stylus|less|postcss)\\b)",
+					"end": "(?=\\blang\\s*=\\s*(?:['\"]?)(?:scss|stylus|less|postcss)\\b)|(>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.end.html.vue"
+						}
+					},
+					"name": "meta.tag-stuff",
+					"patterns": [
+						{
+							"include": "#vue-directives"
+						},
+						{
+							"include": "text.html.basic#attribute"
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)scss\\b)",
+					"end": "(?=<\\/style[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/style[\\s>])",
+							"name": "source.css.scss",
+							"patterns": [
+								{
+									"include": "source.css.scss"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)stylus\\b)",
+					"end": "(?=<\\/style[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/style[\\s>])",
+							"name": "source.stylus",
+							"patterns": [
+								{
+									"include": "source.stylus"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)less\\b)",
+					"end": "(?=<\\/style[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/style[\\s>])",
+							"name": "source.css.less",
+							"patterns": [
+								{
+									"include": "source.css.less"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?=\\blang\\s*=\\s*(?:['\"]?)postcss\\b)",
+					"end": "(?=<\\/style[\\s>])",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)",
+							"end": "(?=<\\/style[\\s>])",
+							"name": "source.postcss",
+							"patterns": [
+								{
+									"include": "source.postcss"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=>)",
+					"end": "(?=<\\/style[\\s>])",
+					"name": "source.css",
+					"patterns": [
+						{
+							"include": "source.css"
+						}
+					]
+				}
+			]
+		},
+		"self-closing-tag": {
+			"begin": "(<)([a-zA-Z0-9:-]+)(?=([^>]+/>))",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.html.vue"
+				},
+				"2": {
+					"name": "entity.name.tag.$2.html.vue"
+				}
+			},
+			"end": "(/>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.end.html.vue"
+				}
+			},
+			"name": "self-closing-tag",
+			"patterns": [
+				{
+					"include": "#tag-stuff"
+				}
+			]
+		},
+		"capitalized-tag": {
+			"begin": "(<)([A-Z][a-zA-Z0-9:-]*)(?=\\s|/?>)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.html.vue"
+				},
+				"2": {
+					"name": "entity.name.tag.html.vue"
+				}
+			},
+			"end": "/?>",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.tag.end.html.vue"
+				}
+			},
+			"name": "meta.tag.structure.$2.start.html.vue",
+			"patterns": [
+				{
+					"begin": "\\G",
+					"end": "(?=/?>)",
+					"patterns": [
+						{
+							"include": "#vue-directives"
+						},
+						{
+							"include": "text.html.basic#attribute"
+						}
+					]
+				}
+			]
+		},
+		"template-tag": {
+			"patterns": [
+				{
+					"include": "#template-tag-1"
+				},
+				{
+					"include": "#template-tag-2"
+				}
+			]
+		},
+		"template-tag-1": {
+			"begin": "(<)(template)\\b(>)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.html.vue"
+				},
+				"2": {
+					"name": "entity.name.tag.$2.html.vue"
+				},
+				"3": {
+					"name": "punctuation.definition.tag.end.html.vue"
+				}
+			},
+			"end": "(/?>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.end.html.vue"
+				}
+			},
+			"name": "meta.template-tag.start",
+			"patterns": [
+				{
+					"begin": "\\G",
+					"end": "(?=/>)|((</)(template)(?=[\\s>]))",
+					"endCaptures": {
+						"2": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"3": {
+							"name": "entity.name.tag.$3.html.vue"
+						}
+					},
+					"name": "meta.template-tag.end",
+					"patterns": [
+						{
+							"include": "#html-stuff"
+						}
+					]
+				}
+			]
+		},
+		"template-tag-2": {
+			"begin": "(<)(template)(?=\\s|\\/?>)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.html.vue"
+				},
+				"2": {
+					"name": "entity.name.tag.$2.html.vue"
+				}
+			},
+			"end": "(/?>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.end.html.vue"
+				}
+			},
+			"name": "meta.template-tag.start",
+			"patterns": [
+				{
+					"begin": "\\G",
+					"end": "(?=/>)|((</)(template)(?=[\\s>]))",
+					"endCaptures": {
+						"2": {
+							"name": "punctuation.definition.tag.begin.html.vue"
+						},
+						"3": {
+							"name": "entity.name.tag.$3.html.vue"
+						}
+					},
+					"name": "meta.template-tag.end",
+					"patterns": [
+						{
+							"include": "#tag-stuff"
+						},
+						{
+							"include": "#html-stuff"
+						}
+					]
+				}
+			]
+		},
+		"html-stuff": {
+			"patterns": [
+				{
+					"include": "#template-tag"
+				},
+				{
+					"include": "#capitalized-tag"
+				},
+				{
+					"include": "text.html.derivative"
+				},
+				{
+					"include": "text.html.basic"
+				}
+			]
+		},
+		"tag-stuff": {
+			"begin": "\\G",
+			"end": "(?=/>)|(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.end.html.vue"
+				}
+			},
+			"name": "meta.tag-stuff",
+			"patterns": [
+				{
+					"include": "#vue-directives"
+				},
+				{
+					"include": "text.html.basic#attribute"
+				}
+			]
+		},
+		"vue-directives": {
+			"patterns": [
+				{
+					"include": "#vue-directives-control"
+				},
+				{
+					"include": "#vue-directives-generic-attr"
+				},
+				{
+					"include": "#vue-directives-style-attr"
+				},
+				{
+					"include": "#vue-directives-original"
+				}
+			]
+		},
+		"vue-directives-original": {
+			"begin": "(?:(?:(v-[\\w-]+)(:)?)|([:\\.])|(@)|(#))(?:(?:(\\[)([^\\]]*)(\\]))|([\\w-]+))?",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.other.attribute-name.html.vue"
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html.vue"
+				},
+				"3": {
+					"name": "punctuation.attribute-shorthand.bind.html.vue"
+				},
+				"4": {
+					"name": "punctuation.attribute-shorthand.event.html.vue"
+				},
+				"5": {
+					"name": "punctuation.attribute-shorthand.slot.html.vue"
+				},
+				"6": {
+					"name": "punctuation.separator.key-value.html.vue"
+				},
+				"7": {
+					"name": "source.ts.embedded.html.vue",
+					"patterns": [
+						{
+							"include": "source.ts#expression"
+						}
+					]
+				},
+				"8": {
+					"name": "punctuation.separator.key-value.html.vue"
+				},
+				"9": {
+					"name": "entity.other.attribute-name.html.vue"
+				}
+			},
+			"end": "(?=\\s*[^=\\s])",
+			"name": "meta.attribute.directive.vue",
+			"patterns": [
+				{
+					"match": "(\\.)([\\w-]*)",
+					"1": {
+						"name": "punctuation.separator.key-value.html.vue"
+					},
+					"2": {
+						"name": "entity.other.attribute-name.html.vue"
+					}
+				},
+				{
+					"include": "#vue-directives-expression"
+				}
+			]
+		},
+		"vue-directives-control": {
+			"begin": "(?:(v-for)|(v-if|v-else-if|v-else))(?=[=/>)\\s])",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.loop.vue"
+				},
+				"2": {
+					"name": "keyword.control.conditional.vue"
+				}
+			},
+			"end": "(?=\\s*[^=\\s])",
+			"name": "meta.attribute.directive.control.vue",
+			"patterns": [
+				{
+					"include": "#vue-directives-expression"
+				}
+			]
+		},
+		"vue-directives-expression": {
+			"patterns": [
+				{
+					"begin": "(=)\\s*('|\"|`)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.separator.key-value.html.vue"
+						},
+						"2": {
+							"name": "punctuation.definition.string.begin.html.vue"
+						}
+					},
+					"end": "(\\2)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.html.vue"
+						}
+					},
+					"patterns": [
+						{
+							"begin": "(?<=('|\"|`))",
+							"end": "(?=\\1)",
+							"name": "source.ts.embedded.html.vue",
+							"patterns": [
+								{
+									"include": "source.ts#expression"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(=)\\s*(?=[^'\"`])",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.separator.key-value.html.vue"
+						}
+					},
+					"end": "(?=(\\s|>|\\/>))",
+					"patterns": [
+						{
+							"begin": "(?=[^'\"`])",
+							"end": "(?=(\\s|>|\\/>))",
+							"name": "source.ts.embedded.html.vue",
+							"patterns": [
+								{
+									"include": "source.ts#expression"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"vue-directives-style-attr": {
+			"begin": "\\b(style)\\s*(=)",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.other.attribute-name.html.vue"
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html.vue"
+				}
+			},
+			"end": "(?<='|\")",
+			"name": "meta.attribute.style.vue",
+			"patterns": [
+				{
+					"comment": "Copy from source.css#rule-list-innards",
+					"begin": "('|\")",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.html.vue"
+						}
+					},
+					"end": "(\\1)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.html.vue"
+						}
+					},
+					"name": "source.css.embedded.html.vue",
+					"patterns": [
+						{
+							"include": "source.css#comment-block"
+						},
+						{
+							"include": "source.css#escapes"
+						},
+						{
+							"include": "source.css#font-features"
+						},
+						{
+							"match": "(?x) (?<![\\w-])\n--\n(?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter\n(?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier\n  |\\\\(?:[0-9a-fA-F]{1,6}|.)\n)*",
+							"name": "variable.css"
+						},
+						{
+							"begin": "(?<![-a-zA-Z])(?=[-a-zA-Z])",
+							"end": "$|(?![-a-zA-Z])",
+							"name": "meta.property-name.css",
+							"patterns": [
+								{
+									"include": "source.css#property-names"
+								}
+							]
+						},
+						{
+							"comment": "Modify end to fix #199. TODO: handle ' character.",
+							"begin": "(:)\\s*",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.separator.key-value.css"
+								}
+							},
+							"end": "\\s*(;)|\\s*(?='|\")",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.terminator.rule.css"
+								}
+							},
+							"contentName": "meta.property-value.css",
+							"patterns": [
+								{
+									"include": "source.css#comment-block"
+								},
+								{
+									"include": "source.css#property-values"
+								}
+							]
+						},
+						{
+							"match": ";",
+							"name": "punctuation.terminator.rule.css"
+						}
+					]
+				}
+			]
+		},
+		"vue-directives-generic-attr": {
+			"begin": "\\b(generic)\\s*(=)",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.other.attribute-name.html.vue"
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html.vue"
+				}
+			},
+			"end": "(?<='|\")",
+			"name": "meta.attribute.generic.vue",
+			"patterns": [
+				{
+					"begin": "('|\")",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.html.vue"
+						}
+					},
+					"end": "(\\1)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.html.vue"
+						}
+					},
+					"name": "meta.type.parameters.vue",
+					"comment": "https://github.com/microsoft/vscode/blob/fd4346210f59135fad81a8b8c4cea7bf5a9ca6b4/extensions/typescript-basics/syntaxes/TypeScript.tmLanguage.json#L4002-L4020",
+					"patterns": [
+						{
+							"include": "source.ts#comment"
+						},
+						{
+							"name": "storage.modifier.ts",
+							"match": "(?<![_$[:alnum:]])(?:(?<=\\.\\.\\.)|(?<!\\.))(extends|in|out)(?![_$[:alnum:]])(?:(?=\\.\\.\\.)|(?!\\.))"
+						},
+						{
+							"include": "source.ts#type"
+						},
+						{
+							"include": "source.ts#punctuation-comma"
+						},
+						{
+							"name": "keyword.operator.assignment.ts",
+							"match": "(=)(?!>)"
+						}
+					]
+				}
+			]
+		},
+		"vue-interpolations": {
+			"patterns": [
+				{
+					"begin": "(\\{\\{)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.interpolation.begin.html.vue"
+						}
+					},
+					"end": "(\\}\\})",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.interpolation.end.html.vue"
+						}
+					},
+					"name": "expression.embedded.vue",
+					"patterns": [
+						{
+							"begin": "\\G",
+							"end": "(?=\\}\\})",
+							"name": "source.ts.embedded.html.vue",
+							"patterns": [
+								{
+									"include": "source.ts#expression"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"vue-comments": {
+			"patterns": [
+				{
+					"include": "#vue-comments-key-value"
+				},
+				{
+					"begin": "<!--",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.vue"
+						}
+					},
+					"end": "-->",
+					"name": "comment.block.vue"
+				}
+			]
+		},
+		"vue-comments-key-value": {
+			"begin": "(<!--)\\s*(@)([\\w$]+)(?=\\s)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.vue"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.comment.vue"
+				},
+				"3": {
+					"name": "storage.type.class.comment.vue"
+				}
+			},
+			"end": "(-->)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.vue"
+				}
+			},
+			"name": "comment.block.vue",
+			"patterns": [
+				{
+					"include": "source.json#value"
+				}
+			]
+		}
+	}
+}

--- a/editor/src/test/java/org/nmox/studio/editor/grammars/GrammarBundleTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/grammars/GrammarBundleTest.java
@@ -18,7 +18,10 @@ class GrammarBundleTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"java", "c", "cpp", "python", "ruby", "rust", "php", "shell", "json",
-        "html", "css", "scss", "less"})
+        "html", "css", "scss", "less",
+        // the config layer: what a web repo is actually full of
+        "ini", "ignore", "graphql", "vue", "svelte", "astro", "pug",
+        "handlebars", "liquid", "nginx", "makefile", "proto", "prisma"})
     @DisplayName("Grammar resource exists and parses with a scopeName")
     void grammarShipsAndParses(String language) throws IOException {
         String resource = language + ".tmLanguage.json";
@@ -32,9 +35,33 @@ class GrammarBundleTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"text/x-java", "text/x-c", "text/x-cpp", "text/x-rust",
-        "text/x-php5", "text/x-go", "text/x-python", "text/x-ruby", "text/sh"})
+        "text/x-php5", "text/x-go", "text/x-python", "text/x-ruby", "text/sh",
+        "text/x-ini", "text/x-ignore", "text/x-graphql", "text/x-pug",
+        "text/x-nginx-conf", "text/x-makefile", "text/x-protobuf", "text/x-prisma",
+        "text/x-yaml", "text/x-toml", "text/x-dockerfile", "text/x-sql"})
     @DisplayName("Every code language has comment-toggle syntax")
     void commentSyntaxCovered(String mime) {
         assertThat(LanguageComments.lineCommentFor(mime)).as(mime).isNotNull();
+    }
+
+    /**
+     * Every grammar registration class must point at a real bundled
+     * resource - a typo in the annotation would silently kill that
+     * language's highlighting at runtime.
+     */
+    @org.junit.jupiter.api.Test
+    @DisplayName("Every @GrammarRegistration references a bundled grammar file")
+    void registrationsReferenceRealFiles() throws Exception {
+        java.io.File dir = new java.io.File("src/main/java/org/nmox/studio/editor/grammars");
+        org.junit.jupiter.api.Assumptions.assumeTrue(dir.isDirectory());
+        java.util.regex.Pattern p = java.util.regex.Pattern.compile("grammar = \"([^\"]+)\"");
+        for (java.io.File src : dir.listFiles((d, n) -> n.endsWith("Grammar.java"))) {
+            String code = java.nio.file.Files.readString(src.toPath());
+            java.util.regex.Matcher m = p.matcher(code);
+            while (m.find()) {
+                assertThat(GrammarBundleTest.class.getResource(m.group(1)))
+                        .as(src.getName() + " -> " + m.group(1)).isNotNull();
+            }
+        }
     }
 }

--- a/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerContractTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerContractTest.java
@@ -35,7 +35,10 @@ class LanguageServerContractTest {
         "text/x-haskell", "text/x-zig", "text/x-erlang", "text/x-elixir",
         "text/x-clojure", "text/x-lisp", "text/x-lua", "text/x-ocaml",
         "text/x-crystal", "text/x-julia", "text/x-r", "text/x-perl",
-        "text/x-groovy", "text/sh", "text/x-json"
+        "text/x-groovy", "text/sh", "text/x-json",
+        // the config layer
+        "text/x-yaml", "text/x-toml", "text/x-dockerfile", "text/x-graphql",
+        "text/x-vue", "text/x-svelte", "text/x-astro", "text/x-prisma"
     })
     @DisplayName("Grammar language has a registered LanguageServerProvider")
     void languageServerRegistered(String mime) throws Exception {

--- a/editor/src/test/java/org/nmox/studio/editor/spell/CodeSpellTokenListProviderTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/spell/CodeSpellTokenListProviderTest.java
@@ -1,0 +1,49 @@
+package org.nmox.studio.editor.spell;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The whole point of the code spellchecker is that it checks words in
+ * comments and nowhere else. That hinges on recognising a comment token
+ * across both lexers we ship: the custom JS/TS lexer names the id
+ * category "comment", while TextMate gives every token the single id
+ * TEXTMATE and exposes the real scope stack as a "categories" property.
+ *
+ * Reading the wrong property key (the bug this guards) silently turned
+ * every config file - .editorconfig, .env, nginx.conf - back into prose,
+ * so keys and values like "charset" and "indent_style" were flagged as
+ * misspellings.
+ */
+class CodeSpellTokenListProviderTest {
+
+    @Test
+    @DisplayName("Custom-lexer comment category is recognised")
+    void customLexerComment() {
+        assertThat(CodeSpellTokenListProvider.isCommentScope("comment", null)).isTrue();
+        assertThat(CodeSpellTokenListProvider.isCommentScope("line-comment", null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("TextMate comment scope in the categories property is recognised")
+    void textmateComment() {
+        // what the TextMate lexer attaches for a '#' line in an .editorconfig
+        Object categories = List.of("source.ini", "comment.line.number-sign.ini");
+        assertThat(CodeSpellTokenListProvider.isCommentScope("textmate", categories)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Config keys and values are NOT comments - no prose check leaks in")
+    void configValuesAreNotComments() {
+        // 'charset = utf-8' tokenises with keyword/value scopes, never comment
+        assertThat(CodeSpellTokenListProvider.isCommentScope("textmate",
+                List.of("source.ini", "keyword.other.definition.ini"))).isFalse();
+        assertThat(CodeSpellTokenListProvider.isCommentScope("textmate",
+                List.of("source.ini", "string.unquoted.ini"))).isFalse();
+        assertThat(CodeSpellTokenListProvider.isCommentScope("identifier", null)).isFalse();
+        assertThat(CodeSpellTokenListProvider.isCommentScope(null, null)).isFalse();
+    }
+}


### PR DESCRIPTION
## What

A web repo is full of files NMOX opened as **plain text** — no highlighting, and worse, prose spellcheck flagging keys and values like `charset` and `indent_style` as misspellings (reported on `.editorconfig`). This brings the config layer in as a first-class citizen.

- **13 new TextMate grammars** (pinned + attributed in `NOTICE-grammars.md`): INI/`.editorconfig`, ignore files, GraphQL, Vue, Svelte, Astro, Pug, Handlebars, Liquid, nginx, Makefile, Protocol Buffers, Prisma. YAML/TOML/Dockerfile/SQL ride the platform's native support (no duplicate editors).
- **`ConfigFileResolver`** — a real `MIMEResolver` subclass (the pattern the platform's own `DockerfileResolver` uses) that matches dotfiles and bare names by filename: `.editorconfig`, `.env`/`.env.*`, `.gitignore`, `Makefile`, `nginx.conf`. A leading-dot "extension" rule can never catch these.
- Comment-toggling and comment-only spellcheck extended to every new mime; **LSP** for yaml/taplo/dockerfile/graphql/vue/svelte/astro/prisma.

## Two real bugs fixed in the process

1. **Comment-only spellcheck read the wrong token property** (`scopes` instead of the TextMate lexer's `categories`), so comment detection silently failed for *every* TextMate language and the checker fell back to prose. Now correct — verified live on Python (comment typo `coment` flagged, identifier `myvariabel` not) and on `.editorconfig` (keys/values clean).
2. **A CSL language binding crashed these files on open** (`ClassNotFoundException` on the lexer class at document-load); removed — the TextMate grammar alone carries highlighting.

## Verified

- Live: `.editorconfig`, `.gitignore`, `Makefile`, `nginx.conf` open as their types; `.editorconfig` keys/values no longer underlined; Python still gets comment-only spellcheck; Makefile comment typo flagged.
- Tests: grammar-bundle + LSP-contract extended to the new mimes (87 checks), plus a focused `CodeSpellTokenListProviderTest` proving comment scopes detected and key/value scopes rejected. **146 editor tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)