### PR TITLE
Workspace Trust: persist the grant, themed dialog, path-boundary match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.4.7] — 2026-06-17
+
+### Fixed
+- **Workspace Trust stops asking once you've answered.** The grant was
+  written with `Preferences.put` but never flushed, so a less-than-clean
+  quit dropped it and the next launch asked you to trust the same folder
+  all over again — it now persists immediately. The prompt is also a
+  proper platform dialog now instead of a bare Swing window, and trusting
+  `/a/foo` no longer accidentally trusts the unrelated sibling `/a/foobar`
+  (the check now respects path boundaries).
+
 ## [1.4.6] — 2026-06-17
 
 ### Added

--- a/rack/src/main/java/org/nmox/studio/rack/service/WorkspaceTrust.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/WorkspaceTrust.java
@@ -1,11 +1,13 @@
 package org.nmox.studio.rack.service;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-import javax.swing.JOptionPane;
-import javax.swing.SwingUtilities;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 
 /**
  * Manages trusted workspace directories. Running terminal/process tools (like npm,
@@ -38,6 +40,14 @@ public final class WorkspaceTrust {
     private static synchronized void save() {
         String joined = String.join(File.pathSeparator, trustedPaths);
         prefs.put(PREF_TRUSTED_KEYS, joined);
+        try {
+            // Persist now. java.util.prefs flushes lazily / on clean exit, so
+            // without this an abrupt quit loses the grant and the user is asked
+            // to trust the same folder again on the next launch.
+            prefs.flush();
+        } catch (BackingStoreException ignore) {
+            // best effort; the in-memory set still holds for this session
+        }
     }
 
     /** True if the directory (or a parent) has been trusted by the user. */
@@ -47,7 +57,9 @@ public final class WorkspaceTrust {
         }
         String absolute = dir.getAbsolutePath();
         for (String path : trustedPaths) {
-            if (absolute.startsWith(path)) {
+            // match on a path boundary, so trusting /a/foo doesn't also
+            // trust the unrelated sibling /a/foobar
+            if (absolute.equals(path) || absolute.startsWith(path + File.separator)) {
                 return true;
             }
         }
@@ -79,41 +91,25 @@ public final class WorkspaceTrust {
             return true;
         }
 
-        final boolean[] result = new boolean[1];
-        try {
-            Runnable r = () -> {
-                String message = "<html><b>Do you trust the files in this folder?</b><br><br>"
-                        + "Opening untrusted folders can expose your machine to security risks if automated<br>"
-                        + "tasks (like npm installations, watchers, database scripts, or compilers) run automatically.<br><br>"
-                        + "Project: <code>" + dir.getAbsolutePath() + "</code></html>";
-                
-                int choice = JOptionPane.showOptionDialog(
-                        null,
-                        message,
-                        "Workspace Trust Confirmation",
-                        JOptionPane.YES_NO_OPTION,
-                        JOptionPane.WARNING_MESSAGE,
-                        null,
-                        new Object[]{"Yes, Trust Workspace", "No, Keep Safe"},
-                        "No, Keep Safe"
-                );
-                
-                if (choice == JOptionPane.YES_OPTION) {
-                    trust(dir);
-                    result[0] = true;
-                } else {
-                    result[0] = false;
-                }
-            };
-
-            if (SwingUtilities.isEventDispatchThread()) {
-                r.run();
-            } else {
-                SwingUtilities.invokeAndWait(r);
-            }
-        } catch (Exception ex) {
-            return false;
+        // Platform dialog (themed with the rest of the IDE), not a bare
+        // Swing window; DialogDisplayer is safe to call from any thread and
+        // blocks until the user answers.
+        String message = "<html><b>Do you trust the files in this folder?</b><br><br>"
+                + "Running this project's tasks — npm installs, watchers, database<br>"
+                + "scripts, compilers — executes its code on your machine.<br><br>"
+                + "Project: <code>" + dir.getAbsolutePath() + "</code></html>";
+        Object trustOption = "Trust Workspace";
+        NotifyDescriptor nd = new NotifyDescriptor(
+                message,
+                "Workspace Trust",
+                NotifyDescriptor.DEFAULT_OPTION,
+                NotifyDescriptor.WARNING_MESSAGE,
+                new Object[]{trustOption, "Keep Safe"},
+                "Keep Safe");
+        if (DialogDisplayer.getDefault().notify(nd) == trustOption) {
+            trust(dir);
+            return true;
         }
-        return result[0];
+        return false;
     }
 }

--- a/rack/src/test/java/org/nmox/studio/rack/service/WorkspaceTrustTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/service/WorkspaceTrustTest.java
@@ -33,6 +33,19 @@ class WorkspaceTrustTest {
     }
 
     @Test
+    @DisplayName("Trust honours path boundaries — a sibling with a shared prefix is not trusted")
+    void trustHonoursPathBoundary() {
+        File foo = tempDir.resolve("foo").toFile();
+        File foobar = tempDir.resolve("foobar").toFile();
+        WorkspaceTrust.trust(foo);
+
+        assertThat(WorkspaceTrust.isTrusted(foo)).isTrue();
+        assertThat(WorkspaceTrust.isTrusted(new File(foo, "sub"))).isTrue();
+        // /…/foobar must NOT inherit trust from /…/foo
+        assertThat(WorkspaceTrust.isTrusted(foobar)).isFalse();
+    }
+
+    @Test
     @DisplayName("Headless runs cannot prompt, so trust is granted rather than silently refused")
     void headlessGrantsTrust() {
         // The regression this guards: a modal trust prompt with no user to


### PR DESCRIPTION
Surfaced from real use — the trust prompt kept re-asking for the same temp folder, in a bare Swing window.

- **Persist immediately.** `save()` did `Preferences.put` but never `flush()`, so a non-clean quit lost the grant and the next launch re-prompted an already-trusted folder. Now flushes.
- **Themed dialog.** Replaced the raw `JOptionPane` with a platform `NotifyDescriptor`/`DialogDisplayer` so it matches the rest of the IDE instead of looking like a stray Java window.
- **Path-boundary match.** `isTrusted` used `startsWith(path)`, so trusting `/a/foo` also trusted the unrelated sibling `/a/foobar`. Now matches on a path boundary.

New regression test `trustHonoursPathBoundary`; `WorkspaceTrustTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)