### PR TITLE
Workspace Trust dialog: render HTML, run tests headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.4.9] — 2026-06-17
+
+### Fixed
+- **The Workspace Trust dialog renders its text instead of showing raw
+  HTML.** The 1.4.7 move to the platform dialog passed an HTML string,
+  which NetBeans shows verbatim (`<html><b>…`) rather than formatted; the
+  message is now a `JLabel`, which renders it.
+- **The test suite runs headless, so it never pops a real dialog onto
+  your screen mid-build.** On macOS local test runs weren't headless, so a
+  command-launching test could surface the trust prompt (for a `junit…`
+  temp folder, no less). Surefire now sets `java.awt.headless=true`,
+  matching CI — and the previously-skipped headless trust test now
+  actually runs.
+
 ## [1.4.8] — 2026-06-17
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
                 <version>3.1.2</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <!-- Run the unit suite headless so it matches CI and never
+                         pops a real Swing dialog (e.g. a workspace-trust prompt)
+                         onto the developer's screen mid-build. -->
+                    <systemPropertyVariables>
+                        <java.awt.headless>true</java.awt.headless>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             </plugins>

--- a/rack/src/main/java/org/nmox/studio/rack/service/WorkspaceTrust.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/WorkspaceTrust.java
@@ -100,7 +100,8 @@ public final class WorkspaceTrust {
                 + "Project: <code>" + dir.getAbsolutePath() + "</code></html>";
         Object trustOption = "Trust Workspace";
         NotifyDescriptor nd = new NotifyDescriptor(
-                message,
+                // a JLabel renders the HTML; a bare String is shown as raw text
+                new javax.swing.JLabel(message),
                 "Workspace Trust",
                 NotifyDescriptor.DEFAULT_OPTION,
                 NotifyDescriptor.WARNING_MESSAGE,


### PR DESCRIPTION
Two bugs from one screenshot of the trust prompt:

1. **Raw HTML in the dialog.** The 1.4.7 move to `DialogDisplayer` passed an HTML *String*, which NetBeans shows verbatim (`<html><b>…`). Wrapped the message in a `JLabel` so it renders.
2. **Tests popped a real dialog.** macOS local `mvn test` isn't headless, so a command-launching test surfaced the trust prompt on screen (for a `junit…` temp dir). Surefire now sets `java.awt.headless=true`, matching CI — and `WorkspaceTrustTest.headlessGrantsTrust` (previously skipped locally) now runs (3/3, 0 skipped).

Full suite green, headless, no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)