### PR TITLE
Language-server health UX + first dialog slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.5.0] — 2026-06-17
+
+### Added
+- **Language-server health — "why is there no hover here?" finally has an
+  answer.** The platform delivers go-to-definition, hover, rename and
+  live errors for free once a language's server launches, but every
+  server is an external binary the developer installs. Now, when a
+  file's server isn't found, you get one notification — once per language
+  per session — naming the binary and the exact command to install it,
+  click-to-copy. No nagging, no modal. And **Tools ▸ Language Servers…**
+  shows the whole polyglot picture at a glance: every language NMOX can
+  light up, which servers are installed, and the install command for the
+  ones that aren't.
+
+### Changed
+- **The New Web Project dialogs are now platform dialogs** (the first
+  slice of moving off raw `JOptionPane` to `DialogDisplayer`/
+  `NotifyDescriptor`): the name prompt and the success/error messages are
+  themed with the rest of the IDE and behave under the test harness.
+
 ## [1.4.9] — 2026-06-17
 
 ### Fixed

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -137,6 +137,11 @@
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-dialogs</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-projectapi</artifactId>
             <version>${netbeans.version}</version>
         </dependency>

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerCatalog.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerCatalog.java
@@ -1,0 +1,78 @@
+package org.nmox.studio.editor.lsp;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.nmox.studio.rack.engine.ToolLocator;
+
+/**
+ * What each language's intelligence needs and how to get it. The
+ * platform's LSP client delivers hover, go-to-definition, rename and
+ * live errors for free once a server launches — but every server is an
+ * external binary the developer installs. This catalog turns a missing
+ * binary into an answer ("install gopls: go install …") instead of
+ * silence, which is the difference between "45 languages" as a
+ * highlighting claim and as a working-intelligence one.
+ */
+public final class LanguageServerCatalog {
+
+    /** A language's server: the binary that must be on PATH, and how to install it. */
+    public record Server(String language, String binary, String install) {
+    }
+
+    // keyed by the binary name the providers actually launch
+    private static final Map<String, Server> BY_BINARY = new LinkedHashMap<>();
+
+    private static void add(String language, String binary, String install) {
+        BY_BINARY.put(binary, new Server(language, binary, install));
+    }
+
+    static {
+        add("TypeScript / JavaScript", "typescript-language-server",
+                "npm install -g typescript-language-server typescript");
+        add("Python", "pyright-langserver", "npm install -g pyright");
+        add("Go", "gopls", "go install golang.org/x/tools/gopls@latest");
+        add("Rust", "rust-analyzer", "rustup component add rust-analyzer");
+        add("PHP", "intelephense", "npm install -g intelephense");
+        add("Ruby", "ruby-lsp", "gem install ruby-lsp");
+        add("C / C++", "clangd", "install LLVM (brew install llvm) or Xcode Command Line Tools");
+        add("Java", "jdtls", "brew install jdtls");
+        add("C#", "csharp-ls", "dotnet tool install -g csharp-ls");
+        add("F#", "fsautocomplete", "dotnet tool install -g fsautocomplete");
+        add("Elixir", "elixir-ls", "brew install elixir-ls");
+        add("Scala", "metals", "coursier install metals");
+        add("Kotlin", "kotlin-language-server", "brew install kotlin-language-server");
+        add("Swift", "sourcekit-lsp", "ships with the Swift toolchain / Xcode");
+        add("Haskell", "haskell-language-server-wrapper", "ghcup install hls");
+        add("Zig", "zls", "install zls from github.com/zigtools/zls");
+        add("Erlang", "erlang_ls", "install erlang_ls from github.com/erlang-ls/erlang_ls");
+        add("Clojure", "clojure-lsp", "brew install clojure-lsp/brew/clojure-lsp-native");
+        add("Dart", "dart", "install the Dart SDK");
+        add("Lua", "lua-language-server", "brew install lua-language-server");
+        add("OCaml", "ocamllsp", "opam install ocaml-lsp-server");
+        add("Julia", "julia", "install Julia, then the LanguageServer.jl package");
+    }
+
+    private LanguageServerCatalog() {
+    }
+
+    /** The catalog entry for a launch binary, or null when uncatalogued. */
+    public static Server forBinary(String binary) {
+        return BY_BINARY.get(binary);
+    }
+
+    /** Every known server, in declaration order (web stack first). */
+    public static java.util.Collection<Server> all() {
+        return BY_BINARY.values();
+    }
+
+    /** True if the binary resolves on the IDE's augmented PATH. */
+    public static boolean isInstalled(String binary) {
+        for (String dir : ToolLocator.augmentedPath().split(File.pathSeparator)) {
+            if (new File(dir, binary).canExecute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerHealth.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerHealth.java
@@ -1,0 +1,86 @@
+package org.nmox.studio.editor.lsp;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.awt.image.BufferedImage;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import org.nmox.studio.editor.lsp.LanguageServerCatalog.Server;
+import org.openide.awt.NotificationDisplayer;
+import org.openide.awt.StatusDisplayer;
+
+/**
+ * Turns a missing language server from silence into a one-line answer.
+ * When a file's server can't launch, the developer gets a single
+ * notification — once per language per session — naming the binary and
+ * the command to install it, click-to-copy. No nagging, no modal: just
+ * the answer to "why is there no hover here?".
+ */
+public final class LanguageServerHealth {
+
+    private static final Set<String> REPORTED = ConcurrentHashMap.newKeySet();
+    private static final Icon ICON = dot();
+
+    private LanguageServerHealth() {
+    }
+
+    /** Called when a server binary failed to launch; notifies at most once per binary. */
+    public static void reportMissing(String binary) {
+        if (binary == null || !REPORTED.add(binary)) {
+            return; // already told them this session
+        }
+        Server s = LanguageServerCatalog.forBinary(binary);
+        String language = s != null ? s.language() : binary;
+        String install = s != null ? s.install()
+                : "install " + binary + " and put it on your PATH";
+        String title = language + " intelligence unavailable";
+        String detail = "Install " + binary
+                + " for go-to-definition, hover, rename and live errors  —  click to copy: "
+                + install;
+        NotificationDisplayer.getDefault().notify(title, ICON, detail, e -> {
+            Toolkit.getDefaultToolkit().getSystemClipboard()
+                    .setContents(new StringSelection(install), null);
+            StatusDisplayer.getDefault().setStatusText("Copied: " + install);
+        });
+    }
+
+    /** Forget the session's reports — so a freshly-installed server can re-notify if still missing. */
+    static void resetForTest() {
+        REPORTED.clear();
+    }
+
+    /** An at-a-glance HTML report of which servers are installed vs missing. */
+    public static String statusReportHtml() {
+        StringBuilder sb = new StringBuilder("<html><body style='width:460px'>"
+                + "<b>Language servers</b> — the intelligence backends behind hover, "
+                + "go-to-definition, rename and live errors.<br><br>"
+                + "<table cellspacing='3'>");
+        for (Server s : LanguageServerCatalog.all()) {
+            boolean ok = LanguageServerCatalog.isInstalled(s.binary());
+            sb.append("<tr><td>").append(ok ? "&#10003;" : "&#10007;").append("</td>")
+                    .append("<td><b>").append(s.language()).append("</b></td>")
+                    .append("<td><code>").append(s.binary()).append("</code></td>")
+                    .append("<td>").append(ok ? "installed"
+                            : "<i>" + s.install() + "</i>").append("</td></tr>");
+        }
+        return sb.append("</table></body></html>").toString();
+    }
+
+    /** A small amber attention dot, so the notification needs no icon resource. */
+    private static Icon dot() {
+        BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g.setColor(new Color(240, 196, 25));
+        g.fillOval(3, 3, 10, 10);
+        g.setColor(new Color(150, 120, 10));
+        g.drawOval(3, 3, 10, 10);
+        g.dispose();
+        return new ImageIcon(img);
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerStatusAction.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerStatusAction.java
@@ -1,0 +1,33 @@
+package org.nmox.studio.editor.lsp;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JLabel;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+
+/**
+ * "Which language servers do I have?" — a one-look answer for a polyglot
+ * workspace, listing every language NMOX can light up and whether its
+ * server is installed, with the install command for the ones that aren't.
+ */
+@ActionID(category = "Tools", id = "org.nmox.studio.editor.lsp.LanguageServerStatusAction")
+@ActionRegistration(displayName = "#CTL_LanguageServers")
+@ActionReference(path = "Menu/Tools", position = 1450)
+@Messages("CTL_LanguageServers=Language Servers…")
+public final class LanguageServerStatusAction implements ActionListener {
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // a JLabel renders the HTML report; a bare String would show raw markup
+        NotifyDescriptor d = new NotifyDescriptor.Message(
+                new JLabel(LanguageServerHealth.statusReportHtml()),
+                NotifyDescriptor.PLAIN_MESSAGE);
+        d.setTitle("Language Servers");
+        DialogDisplayer.getDefault().notify(d);
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServers.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServers.java
@@ -58,6 +58,20 @@ public final class LanguageServers {
         }
     }
 
+    /** A single-server provider call: launch, and on failure tell the user how to install it. */
+    static LanguageServerProvider.LanguageServerDescription provide(Lookup lookup, List<String> command) {
+        return reported(launch(lookup, command), command.get(0));
+    }
+
+    /** Notifies (once per session) how to install {@code primaryBinary} when the server didn't start. */
+    static LanguageServerProvider.LanguageServerDescription reported(
+            LanguageServerProvider.LanguageServerDescription result, String primaryBinary) {
+        if (result == null) {
+            LanguageServerHealth.reportMissing(primaryBinary);
+        }
+        return result;
+    }
+
     /** The first candidate that launches wins; null when none can. */
     @SafeVarargs
     static LanguageServerProvider.LanguageServerDescription launchFirst(
@@ -79,19 +93,12 @@ public final class LanguageServers {
     static LanguageServerProvider.LanguageServerDescription launchNpm(
             Lookup lookup, String bin, String... args) {
         File dir = projectDir(lookup);
-        if (dir != null) {
-            File local = new File(dir, "node_modules/.bin/" + bin);
-            if (local.canExecute()) {
-                List<String> cmd = new ArrayList<>();
-                cmd.add(local.getAbsolutePath());
-                cmd.addAll(List.of(args));
-                return launch(lookup, cmd);
-            }
-        }
+        File local = dir == null ? null : new File(dir, "node_modules/.bin/" + bin);
         List<String> cmd = new ArrayList<>();
-        cmd.add(bin);
+        cmd.add(local != null && local.canExecute() ? local.getAbsolutePath() : bin);
         cmd.addAll(List.of(args));
-        return launch(lookup, cmd);
+        // report the package name, not the resolved node_modules path
+        return reported(launch(lookup, cmd), bin);
     }
 
     private static boolean onPath(String name) {
@@ -125,7 +132,7 @@ public final class LanguageServers {
     public static final class PythonServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("pyright-langserver", "--stdio"));
+            return provide(lookup, List.of("pyright-langserver", "--stdio"));
         }
     }
 
@@ -134,7 +141,7 @@ public final class LanguageServers {
     public static final class GoServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("gopls"));
+            return provide(lookup, List.of("gopls"));
         }
     }
 
@@ -143,7 +150,7 @@ public final class LanguageServers {
     public static final class RustServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("rust-analyzer"));
+            return provide(lookup, List.of("rust-analyzer"));
         }
     }
 
@@ -152,9 +159,9 @@ public final class LanguageServers {
     public static final class ElixirServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launchFirst(lookup,
+            return reported(launchFirst(lookup,
                     List.of("elixir-ls"),
-                    List.of("language_server.sh"));
+                    List.of("language_server.sh")), "elixir-ls");
         }
     }
 
@@ -166,7 +173,7 @@ public final class LanguageServers {
     public static final class ClangdServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("clangd", "--background-index"));
+            return provide(lookup, List.of("clangd", "--background-index"));
         }
     }
 
@@ -175,7 +182,7 @@ public final class LanguageServers {
     public static final class JavaServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("jdtls"));
+            return provide(lookup, List.of("jdtls"));
         }
     }
 
@@ -184,9 +191,9 @@ public final class LanguageServers {
     public static final class CSharpServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launchFirst(lookup,
+            return reported(launchFirst(lookup,
                     List.of("csharp-ls"),
-                    List.of("OmniSharp", "-lsp"));
+                    List.of("OmniSharp", "-lsp")), "csharp-ls");
         }
     }
 
@@ -195,7 +202,7 @@ public final class LanguageServers {
     public static final class FSharpServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("fsautocomplete"));
+            return provide(lookup, List.of("fsautocomplete"));
         }
     }
 
@@ -215,9 +222,9 @@ public final class LanguageServers {
     public static final class RubyServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launchFirst(lookup,
+            return reported(launchFirst(lookup,
                     List.of("ruby-lsp"),
-                    List.of("solargraph", "stdio"));
+                    List.of("solargraph", "stdio")), "ruby-lsp");
         }
     }
 
@@ -226,7 +233,7 @@ public final class LanguageServers {
     public static final class DartServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("dart", "language-server", "--protocol=lsp"));
+            return provide(lookup, List.of("dart", "language-server", "--protocol=lsp"));
         }
     }
 
@@ -235,7 +242,7 @@ public final class LanguageServers {
     public static final class ScalaServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("metals"));
+            return provide(lookup, List.of("metals"));
         }
     }
 
@@ -244,7 +251,7 @@ public final class LanguageServers {
     public static final class KotlinServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("kotlin-language-server"));
+            return provide(lookup, List.of("kotlin-language-server"));
         }
     }
 
@@ -253,7 +260,7 @@ public final class LanguageServers {
     public static final class SwiftServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("sourcekit-lsp"));
+            return provide(lookup, List.of("sourcekit-lsp"));
         }
     }
 
@@ -262,7 +269,7 @@ public final class LanguageServers {
     public static final class HaskellServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("haskell-language-server-wrapper", "--lsp"));
+            return provide(lookup, List.of("haskell-language-server-wrapper", "--lsp"));
         }
     }
 
@@ -271,7 +278,7 @@ public final class LanguageServers {
     public static final class ZigServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("zls"));
+            return provide(lookup, List.of("zls"));
         }
     }
 
@@ -280,7 +287,7 @@ public final class LanguageServers {
     public static final class ErlangServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("erlang_ls", "--transport", "stdio"));
+            return provide(lookup, List.of("erlang_ls", "--transport", "stdio"));
         }
     }
 
@@ -289,7 +296,7 @@ public final class LanguageServers {
     public static final class ClojureServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("clojure-lsp"));
+            return provide(lookup, List.of("clojure-lsp"));
         }
     }
 
@@ -298,7 +305,7 @@ public final class LanguageServers {
     public static final class LispServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("cl-lsp"));
+            return provide(lookup, List.of("cl-lsp"));
         }
     }
 
@@ -307,7 +314,7 @@ public final class LanguageServers {
     public static final class LuaServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("lua-language-server"));
+            return provide(lookup, List.of("lua-language-server"));
         }
     }
 
@@ -316,7 +323,7 @@ public final class LanguageServers {
     public static final class OCamlServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("ocamllsp"));
+            return provide(lookup, List.of("ocamllsp"));
         }
     }
 
@@ -325,7 +332,7 @@ public final class LanguageServers {
     public static final class CrystalServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("crystalline"));
+            return provide(lookup, List.of("crystalline"));
         }
     }
 
@@ -334,7 +341,7 @@ public final class LanguageServers {
     public static final class JuliaServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("julia", "--startup-file=no", "--history-file=no",
+            return provide(lookup, List.of("julia", "--startup-file=no", "--history-file=no",
                     "-e", "using LanguageServer; runserver()"));
         }
     }
@@ -344,7 +351,7 @@ public final class LanguageServers {
     public static final class RServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("R", "--no-echo", "-e", "languageserver::run()"));
+            return provide(lookup, List.of("R", "--no-echo", "-e", "languageserver::run()"));
         }
     }
 
@@ -353,9 +360,9 @@ public final class LanguageServers {
     public static final class PerlServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launchFirst(lookup,
+            return reported(launchFirst(lookup,
                     List.of("pls"),
-                    List.of("perl", "-MPerl::LanguageServer", "-e", "Perl::LanguageServer::run"));
+                    List.of("perl", "-MPerl::LanguageServer", "-e", "Perl::LanguageServer::run")), "pls");
         }
     }
 
@@ -364,7 +371,7 @@ public final class LanguageServers {
     public static final class GroovyServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("groovy-language-server"));
+            return provide(lookup, List.of("groovy-language-server"));
         }
     }
 
@@ -424,7 +431,7 @@ public final class LanguageServers {
     public static final class TomlServer implements LanguageServerProvider {
         @Override
         public LanguageServerDescription startServer(Lookup lookup) {
-            return launch(lookup, List.of("taplo", "lsp", "stdio"));
+            return provide(lookup, List.of("taplo", "lsp", "stdio"));
         }
     }
 

--- a/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerCatalogTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerCatalogTest.java
@@ -1,0 +1,50 @@
+package org.nmox.studio.editor.lsp;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.editor.lsp.LanguageServerCatalog.Server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The catalog is what turns a missing language server into an answer
+ * instead of silence, so the install hints have to be there and right.
+ */
+class LanguageServerCatalogTest {
+
+    @Test
+    @DisplayName("The headline web-stack languages map to the right binary and a real install hint")
+    void headlineLanguages() {
+        assertThat(LanguageServerCatalog.forBinary("gopls").language()).isEqualTo("Go");
+        assertThat(LanguageServerCatalog.forBinary("gopls").install()).contains("gopls");
+        assertThat(LanguageServerCatalog.forBinary("rust-analyzer").install()).contains("rustup");
+        assertThat(LanguageServerCatalog.forBinary("typescript-language-server").install())
+                .contains("npm install");
+        assertThat(LanguageServerCatalog.forBinary("pyright-langserver")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("An uncatalogued binary returns null (caller falls back to a generic message)")
+    void unknownBinaryIsNull() {
+        assertThat(LanguageServerCatalog.forBinary("totally-not-a-server")).isNull();
+    }
+
+    @Test
+    @DisplayName("Every entry is fully populated — language, binary, and a non-empty install hint")
+    void everyEntryComplete() {
+        for (Server s : LanguageServerCatalog.all()) {
+            assertThat(s.language()).isNotBlank();
+            assertThat(s.binary()).isNotBlank();
+            assertThat(s.install()).isNotBlank();
+        }
+        assertThat(LanguageServerCatalog.all()).hasSizeGreaterThanOrEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("Install detection: a ubiquitous tool reads as present, a nonsense one as absent")
+    void detection() {
+        // 'sh' is on every unix PATH the IDE augments; the nonsense name is on none
+        assertThat(LanguageServerCatalog.isInstalled("sh")).isTrue();
+        assertThat(LanguageServerCatalog.isInstalled("nmox-no-such-binary-zzz")).isFalse();
+    }
+}

--- a/ui/src/main/java/org/nmox/studio/ui/actions/NewWebProjectAction.java
+++ b/ui/src/main/java/org/nmox/studio/ui/actions/NewWebProjectAction.java
@@ -5,7 +5,8 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import javax.swing.JFileChooser;
-import javax.swing.JOptionPane;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionRegistration;
@@ -31,13 +32,13 @@ public final class NewWebProjectAction implements ActionListener {
         
         if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
             File selectedDir = chooser.getSelectedFile();
-            String projectName = JOptionPane.showInputDialog(null, 
-                    "Enter project name:", 
-                    "New Web Project", 
-                    JOptionPane.QUESTION_MESSAGE);
-            
-            if (projectName != null && !projectName.trim().isEmpty()) {
-                createWebProject(new File(selectedDir, projectName));
+            NotifyDescriptor.InputLine input =
+                    new NotifyDescriptor.InputLine("Enter project name:", "New Web Project");
+            if (DialogDisplayer.getDefault().notify(input) == NotifyDescriptor.OK_OPTION) {
+                String projectName = input.getInputText();
+                if (projectName != null && !projectName.trim().isEmpty()) {
+                    createWebProject(new File(selectedDir, projectName));
+                }
             }
         }
     }
@@ -107,17 +108,15 @@ public final class NewWebProjectAction implements ActionListener {
                     "  \"created\": \"" + System.currentTimeMillis() + "\"\n" +
                     "}");
 
-            JOptionPane.showMessageDialog(null, 
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
                     "Web project created successfully at:\n" + projectDir.getAbsolutePath(),
-                    "Project Created", 
-                    JOptionPane.INFORMATION_MESSAGE);
+                    NotifyDescriptor.INFORMATION_MESSAGE));
 
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
-            JOptionPane.showMessageDialog(null, 
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
                     "Failed to create project: " + ex.getMessage(),
-                    "Error", 
-                    JOptionPane.ERROR_MESSAGE);
+                    NotifyDescriptor.ERROR_MESSAGE));
         }
     }
 


### PR DESCRIPTION
Acts on the top "ready for polyglot use" recommendation. The platform's LSP client already delivers hover/go-to-definition/rename/diagnostics once a server launches — but every server is an external binary, and a missing one was silent. This makes "45 languages" a working-intelligence claim, not just a highlighting one.

- **`LanguageServerCatalog`** (pure, tested): language → server binary + install command + PATH detection.
- **Missing-server notification**: when a server won't launch, one `NotificationDisplayer` per language per session names the binary and the install command, click-to-copy. Routed through `provide()`/`reported()` so fallback providers (ruby-lsp→solargraph, php intelephense→phpactor) only notify when *all* candidates miss.
- **Tools ▸ Language Servers…**: an at-a-glance installed/missing report (`DialogDisplayer` + `JLabel`).
- **First `JOptionPane`→`DialogDisplayer` slice**: New Web Project's name prompt + success/error messages.

**Verified live** (screenshot in the session): the status dialog correctly shows ✓ Go/Rust/C/Swift/Dart and ✗ the rest with exact install commands; HTML renders cleanly. `LanguageServerCatalogTest` (4) + full suite green across all 11 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)