### PR TITLE
Language Servers: a one-click install interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.6.0] — 2026-06-17
+
+### Added
+- **One-click language-server install.** Tools ▸ Language Servers… is now
+  an install interface, not just a status list: every language NMOX can
+  light up, with an **Install** button that runs the ecosystem's own
+  command — npm, brew, `go install`, `cargo`/`rustup`, `gem`, `dotnet
+  tool`, `coursier`, `opam` — each in its idiomatic way, with the bar
+  running across while it downloads and the output streaming to the
+  Output window. **Install all missing** walks the batch with a Cancel
+  that kills the run; servers that ship with their toolchain (Swift,
+  Dart) or need a manual setup are marked, never given a fake button; and
+  a server whose package manager isn't present says "install `go` first"
+  rather than failing cryptically. Commands run as argv through the
+  rack's executor — nothing is shell-interpolated and sudo is never
+  added.
+
 ## [1.5.0] — 2026-06-17
 
 ### Added

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -142,6 +142,11 @@
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util-ui</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-projectapi</artifactId>
             <version>${netbeans.version}</version>
         </dependency>

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerCatalog.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerCatalog.java
@@ -2,6 +2,7 @@ package org.nmox.studio.editor.lsp;
 
 import java.io.File;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.nmox.studio.rack.engine.ToolLocator;
 
@@ -9,48 +10,78 @@ import org.nmox.studio.rack.engine.ToolLocator;
  * What each language's intelligence needs and how to get it. The
  * platform's LSP client delivers hover, go-to-definition, rename and
  * live errors for free once a server launches — but every server is an
- * external binary the developer installs. This catalog turns a missing
- * binary into an answer ("install gopls: go install …") instead of
- * silence, which is the difference between "45 languages" as a
- * highlighting claim and as a working-intelligence one.
+ * external binary the developer installs, each in its ecosystem's own
+ * idiom (npm, brew, go install, cargo, gem, dotnet tool, coursier,
+ * opam). This catalog names the binary, the human install hint, and —
+ * where there's a single clean command — the exact argv to run it.
  */
 public final class LanguageServerCatalog {
 
-    /** A language's server: the binary that must be on PATH, and how to install it. */
-    public record Server(String language, String binary, String install) {
+    /**
+     * A language's server: the binary that must be on PATH, the human
+     * install hint, and the runnable install command ({@code command} is
+     * empty when there's no single command — those stay manual).
+     */
+    public record Server(String language, String binary, String install, List<String> command) {
+
+        /** True when this server can be installed by running one command. */
+        public boolean autoInstallable() {
+            return command != null && !command.isEmpty();
+        }
+
+        /** The package manager / toolchain the install command drives (npm, brew, go, …). */
+        public String installer() {
+            return autoInstallable() ? command.get(0) : "";
+        }
     }
 
-    // keyed by the binary name the providers actually launch
     private static final Map<String, Server> BY_BINARY = new LinkedHashMap<>();
 
-    private static void add(String language, String binary, String install) {
-        BY_BINARY.put(binary, new Server(language, binary, install));
+    private static void add(String language, String binary, String hint, List<String> command) {
+        BY_BINARY.put(binary, new Server(language, binary, hint, command));
     }
 
     static {
         add("TypeScript / JavaScript", "typescript-language-server",
-                "npm install -g typescript-language-server typescript");
-        add("Python", "pyright-langserver", "npm install -g pyright");
-        add("Go", "gopls", "go install golang.org/x/tools/gopls@latest");
-        add("Rust", "rust-analyzer", "rustup component add rust-analyzer");
-        add("PHP", "intelephense", "npm install -g intelephense");
-        add("Ruby", "ruby-lsp", "gem install ruby-lsp");
-        add("C / C++", "clangd", "install LLVM (brew install llvm) or Xcode Command Line Tools");
-        add("Java", "jdtls", "brew install jdtls");
-        add("C#", "csharp-ls", "dotnet tool install -g csharp-ls");
-        add("F#", "fsautocomplete", "dotnet tool install -g fsautocomplete");
-        add("Elixir", "elixir-ls", "brew install elixir-ls");
-        add("Scala", "metals", "coursier install metals");
-        add("Kotlin", "kotlin-language-server", "brew install kotlin-language-server");
-        add("Swift", "sourcekit-lsp", "ships with the Swift toolchain / Xcode");
-        add("Haskell", "haskell-language-server-wrapper", "ghcup install hls");
-        add("Zig", "zls", "install zls from github.com/zigtools/zls");
-        add("Erlang", "erlang_ls", "install erlang_ls from github.com/erlang-ls/erlang_ls");
-        add("Clojure", "clojure-lsp", "brew install clojure-lsp/brew/clojure-lsp-native");
-        add("Dart", "dart", "install the Dart SDK");
-        add("Lua", "lua-language-server", "brew install lua-language-server");
-        add("OCaml", "ocamllsp", "opam install ocaml-lsp-server");
-        add("Julia", "julia", "install Julia, then the LanguageServer.jl package");
+                "npm install -g typescript-language-server typescript",
+                List.of("npm", "install", "-g", "typescript-language-server", "typescript"));
+        add("Python", "pyright-langserver", "npm install -g pyright",
+                List.of("npm", "install", "-g", "pyright"));
+        add("Go", "gopls", "go install golang.org/x/tools/gopls@latest",
+                List.of("go", "install", "golang.org/x/tools/gopls@latest"));
+        add("Rust", "rust-analyzer", "rustup component add rust-analyzer",
+                List.of("rustup", "component", "add", "rust-analyzer"));
+        add("PHP", "intelephense", "npm install -g intelephense",
+                List.of("npm", "install", "-g", "intelephense"));
+        add("Ruby", "ruby-lsp", "gem install ruby-lsp",
+                List.of("gem", "install", "ruby-lsp"));
+        add("C / C++", "clangd", "brew install llvm (or Xcode Command Line Tools)",
+                List.of("brew", "install", "llvm"));
+        add("Java", "jdtls", "brew install jdtls",
+                List.of("brew", "install", "jdtls"));
+        add("C#", "csharp-ls", "dotnet tool install -g csharp-ls",
+                List.of("dotnet", "tool", "install", "-g", "csharp-ls"));
+        add("F#", "fsautocomplete", "dotnet tool install -g fsautocomplete",
+                List.of("dotnet", "tool", "install", "-g", "fsautocomplete"));
+        add("Elixir", "elixir-ls", "brew install elixir-ls",
+                List.of("brew", "install", "elixir-ls"));
+        add("Scala", "metals", "coursier install metals",
+                List.of("coursier", "install", "metals"));
+        add("Kotlin", "kotlin-language-server", "brew install kotlin-language-server",
+                List.of("brew", "install", "kotlin-language-server"));
+        add("Swift", "sourcekit-lsp", "ships with the Swift toolchain / Xcode", List.of());
+        add("Haskell", "haskell-language-server-wrapper", "ghcup install hls",
+                List.of("ghcup", "install", "hls"));
+        add("Zig", "zls", "install zls from github.com/zigtools/zls", List.of());
+        add("Erlang", "erlang_ls", "install erlang_ls from github.com/erlang-ls/erlang_ls", List.of());
+        add("Clojure", "clojure-lsp", "brew install clojure-lsp/brew/clojure-lsp-native",
+                List.of("brew", "install", "clojure-lsp/brew/clojure-lsp-native"));
+        add("Dart", "dart", "install the Dart SDK", List.of());
+        add("Lua", "lua-language-server", "brew install lua-language-server",
+                List.of("brew", "install", "lua-language-server"));
+        add("OCaml", "ocamllsp", "opam install ocaml-lsp-server",
+                List.of("opam", "install", "ocaml-lsp-server"));
+        add("Julia", "julia", "install Julia, then the LanguageServer.jl package", List.of());
     }
 
     private LanguageServerCatalog() {

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerInstaller.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerInstaller.java
@@ -1,0 +1,67 @@
+package org.nmox.studio.editor.lsp;
+
+import java.io.File;
+import java.util.Map;
+import org.nmox.studio.editor.lsp.LanguageServerCatalog.Server;
+import org.nmox.studio.rack.engine.CommandExecutor;
+
+/**
+ * Installs a language server by running its ecosystem's own command
+ * (npm / brew / go / cargo / gem / dotnet / coursier / opam) through the
+ * rack's CommandExecutor — argv, never a shell string, so nothing is
+ * interpolated; the live output streams to the Output window; and a
+ * missing package manager is reported up front instead of as a cryptic
+ * failure. No sudo is ever added.
+ */
+public final class LanguageServerInstaller {
+
+    /** Outcome of an install attempt. */
+    public enum Result {
+        INSTALLED,
+        FAILED,
+        NEEDS_TOOLCHAIN,
+        NOT_AUTO
+    }
+
+    /** UI hooks; all fire on the process worker thread, so marshal to the EDT. */
+    public interface Listener {
+        void onStarted(Server server);
+
+        void onFinished(Server server, Result result, int exitCode);
+    }
+
+    private LanguageServerInstaller() {
+    }
+
+    /**
+     * Starts the install; returns a handle to cancel it, or null when the
+     * server isn't auto-installable or its package manager is absent (the
+     * listener is told which).
+     */
+    public static CommandExecutor.Handle install(Server server, Listener listener) {
+        if (!server.autoInstallable()) {
+            listener.onFinished(server, Result.NOT_AUTO, -1);
+            return null;
+        }
+        String installer = server.installer();
+        if (!LanguageServerCatalog.isInstalled(installer)) {
+            // e.g. "go install …" but go isn't here: don't run a doomed command
+            listener.onFinished(server, Result.NEEDS_TOOLCHAIN, -1);
+            return null;
+        }
+
+        listener.onStarted(server);
+        String tab = "Install " + server.binary();
+        File home = new File(System.getProperty("user.home", "."));
+        CommandExecutor.Handle handle = CommandExecutor.run(
+                tab, home, Map.of(), server.command(), line -> {
+                }, exit -> {
+                    // success = the command succeeded; a freshly-installed binary may
+                    // not be on the resolved PATH until restart, so trust the exit code
+                    Result r = exit == 0 ? Result.INSTALLED : Result.FAILED;
+                    listener.onFinished(server, r, exit);
+                });
+        CommandExecutor.showOutput(tab);
+        return handle;
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerStatusAction.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerStatusAction.java
@@ -1,19 +1,20 @@
 package org.nmox.studio.editor.lsp;
 
+import java.awt.Dialog;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import javax.swing.JLabel;
+import javax.swing.JButton;
+import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
-import org.openide.NotifyDescriptor;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionRegistration;
 import org.openide.util.NbBundle.Messages;
 
 /**
- * "Which language servers do I have?" — a one-look answer for a polyglot
- * workspace, listing every language NMOX can light up and whether its
- * server is installed, with the install command for the ones that aren't.
+ * Opens the language-server install interface: which languages NMOX can
+ * light up, which servers are present, and one-click installs for the
+ * ones that aren't. Non-modal, so installs run while you keep working.
  */
 @ActionID(category = "Tools", id = "org.nmox.studio.editor.lsp.LanguageServerStatusAction")
 @ActionRegistration(displayName = "#CTL_LanguageServers")
@@ -23,11 +24,12 @@ public final class LanguageServerStatusAction implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        // a JLabel renders the HTML report; a bare String would show raw markup
-        NotifyDescriptor d = new NotifyDescriptor.Message(
-                new JLabel(LanguageServerHealth.statusReportHtml()),
-                NotifyDescriptor.PLAIN_MESSAGE);
-        d.setTitle("Language Servers");
-        DialogDisplayer.getDefault().notify(d);
+        LanguageServersPanel panel = new LanguageServersPanel();
+        JButton close = new JButton("Close");
+        DialogDescriptor d = new DialogDescriptor(panel, "Language Servers", false,
+                new Object[]{close}, close, DialogDescriptor.DEFAULT_ALIGN, null, null);
+        Dialog dialog = DialogDisplayer.getDefault().createDialog(d);
+        close.addActionListener(ev -> dialog.dispose());
+        dialog.setVisible(true);
     }
 }

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServersPanel.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServersPanel.java
@@ -1,0 +1,247 @@
+package org.nmox.studio.editor.lsp;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import org.nmox.studio.editor.lsp.LanguageServerCatalog.Server;
+import org.nmox.studio.editor.lsp.LanguageServerInstaller.Result;
+import org.nmox.studio.rack.engine.CommandExecutor;
+
+/**
+ * The install interface behind Tools ▸ Language Servers…: every language
+ * NMOX can light up, whether its server is present, and a one-click
+ * Install that runs the ecosystem's own command with the bar running
+ * across while it downloads. Installs run one at a time (the bar tracks
+ * the batch); output streams to the Output window; Cancel kills the run.
+ */
+public final class LanguageServersPanel extends JPanel {
+
+    private static final Color OK = new Color(120, 200, 130);
+    private static final Color MISSING = new Color(220, 140, 90);
+
+    private final JProgressBar bar = new JProgressBar();
+    private final JLabel status = new JLabel(" ");
+    private final JButton cancelBtn = new JButton("Cancel");
+    private final List<Row> rows = new ArrayList<>();
+    private final Deque<Row> queue = new ArrayDeque<>();
+    private CommandExecutor.Handle current;
+    private int batchTotal;
+    private int batchDone;
+
+    public LanguageServersPanel() {
+        super(new BorderLayout(0, 8));
+        setBorder(BorderFactory.createEmptyBorder(12, 12, 12, 12));
+        setPreferredSize(new Dimension(560, 520));
+
+        JLabel header = new JLabel("<html><b>Language servers</b> — the intelligence backends behind "
+                + "hover, go-to-definition, rename and live errors. Install one and it lights up "
+                + "the next time you open that language.</html>");
+        add(header, BorderLayout.NORTH);
+
+        JPanel list = new JPanel();
+        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
+        for (Server s : LanguageServerCatalog.all()) {
+            Row r = new Row(s);
+            rows.add(r);
+            list.add(r);
+        }
+        list.add(Box.createVerticalGlue());
+        JScrollPane scroll = new JScrollPane(list);
+        scroll.getVerticalScrollBar().setUnitIncrement(16);
+        add(scroll, BorderLayout.CENTER);
+
+        JButton all = new JButton("Install all missing");
+        all.addActionListener(e -> installAllMissing());
+        cancelBtn.setEnabled(false);
+        cancelBtn.addActionListener(e -> cancel());
+        bar.setVisible(false);
+
+        JPanel footer = new JPanel(new BorderLayout(8, 4));
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
+        buttons.add(all);
+        buttons.add(cancelBtn);
+        footer.add(buttons, BorderLayout.WEST);
+        JPanel progress = new JPanel(new BorderLayout(6, 0));
+        progress.add(bar, BorderLayout.CENTER);
+        progress.add(status, BorderLayout.SOUTH);
+        footer.add(progress, BorderLayout.CENTER);
+        add(footer, BorderLayout.SOUTH);
+    }
+
+    private void installAllMissing() {
+        if (current != null) {
+            return;
+        }
+        queue.clear();
+        for (Row r : rows) {
+            if (!LanguageServerCatalog.isInstalled(r.server.binary()) && r.server.autoInstallable()) {
+                queue.add(r);
+            }
+        }
+        if (queue.isEmpty()) {
+            status.setText("Everything installable is already installed.");
+            return;
+        }
+        batchTotal = queue.size();
+        batchDone = 0;
+        startNext();
+    }
+
+    private void startNext() {
+        Row row = queue.poll();
+        if (row == null) {
+            bar.setVisible(false);
+            cancelBtn.setEnabled(false);
+            status.setText("Done.");
+            return;
+        }
+        install(row, true);
+    }
+
+    private void install(Row row, boolean batch) {
+        if (current != null) {
+            return; // one at a time
+        }
+        row.button.setEnabled(false);
+        row.statusLabel.setText("…");
+        bar.setVisible(true);
+        cancelBtn.setEnabled(true);
+        if (batch && batchTotal > 0) {
+            bar.setIndeterminate(false);
+            bar.setMinimum(0);
+            bar.setMaximum(batchTotal);
+            bar.setValue(batchDone);
+            bar.setStringPainted(true);
+            bar.setString(row.server.language() + "  (" + (batchDone + 1) + "/" + batchTotal + ")");
+        } else {
+            bar.setIndeterminate(true);
+            bar.setStringPainted(true);
+            bar.setString("Installing " + row.server.language() + "…");
+        }
+        status.setText("Running: " + String.join(" ", row.server.command()));
+
+        current = LanguageServerInstaller.install(row.server, new LanguageServerInstaller.Listener() {
+            @Override
+            public void onStarted(Server server) {
+            }
+
+            @Override
+            public void onFinished(Server server, Result result, int exitCode) {
+                SwingUtilities.invokeLater(() -> finished(row, result, batch));
+            }
+        });
+        // synchronous-failure cases (not auto / missing toolchain) already
+        // delivered onFinished and returned null; nothing is running
+    }
+
+    private void finished(Row row, Result result, boolean batch) {
+        current = null;
+        switch (result) {
+            case INSTALLED -> {
+                row.refresh();
+                status.setText("Installed " + row.server.language() + ".");
+            }
+            case FAILED -> {
+                row.statusLabel.setText("✗");
+                row.statusLabel.setForeground(MISSING);
+                row.button.setEnabled(true);
+                status.setText(row.server.language() + " install failed — see the Output window.");
+            }
+            case NEEDS_TOOLCHAIN -> {
+                row.button.setEnabled(false);
+                row.button.setText(row.server.installer() + " not found");
+                status.setText("Install " + row.server.installer()
+                        + " first, then retry " + row.server.language() + ".");
+            }
+            default -> row.button.setEnabled(true);
+        }
+        if (batch) {
+            batchDone++;
+            startNext();
+        } else {
+            bar.setVisible(false);
+            cancelBtn.setEnabled(false);
+        }
+    }
+
+    private void cancel() {
+        queue.clear();
+        if (current != null) {
+            current.kill();
+            current = null;
+        }
+        bar.setVisible(false);
+        cancelBtn.setEnabled(false);
+        status.setText("Cancelled.");
+        for (Row r : rows) {
+            r.refresh();
+        }
+    }
+
+    /** One language's row: status, name, and its Install action. */
+    private final class Row extends JPanel {
+
+        private final Server server;
+        private final JLabel statusLabel = new JLabel();
+        private final JButton button = new JButton();
+
+        Row(Server server) {
+            super(new BorderLayout(8, 0));
+            this.server = server;
+            setBorder(BorderFactory.createEmptyBorder(4, 2, 4, 2));
+            setMaximumSize(new Dimension(Integer.MAX_VALUE, 38));
+            setAlignmentX(Component.LEFT_ALIGNMENT);
+
+            statusLabel.setPreferredSize(new Dimension(18, 18));
+            add(statusLabel, BorderLayout.WEST);
+
+            JLabel name = new JLabel("<html><b>" + server.language() + "</b>&nbsp;&nbsp;"
+                    + "<span style='color:#888'><code>" + server.binary() + "</code></span></html>");
+            add(name, BorderLayout.CENTER);
+
+            button.addActionListener(e -> install(this, false));
+            JPanel east = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
+            east.add(button);
+            add(east, BorderLayout.EAST);
+
+            refresh();
+        }
+
+        void refresh() {
+            boolean ok = LanguageServerCatalog.isInstalled(server.binary());
+            if (ok) {
+                statusLabel.setText("✓");
+                statusLabel.setForeground(OK);
+                button.setText("Installed");
+                button.setEnabled(false);
+            } else {
+                statusLabel.setText("✗");
+                statusLabel.setForeground(MISSING);
+                if (server.autoInstallable()) {
+                    button.setText("Install");
+                    button.setToolTipText(String.join(" ", server.command()));
+                    button.setEnabled(true);
+                } else {
+                    button.setText("Manual");
+                    button.setToolTipText(server.install());
+                    button.setEnabled(false);
+                }
+            }
+        }
+    }
+}

--- a/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerCatalogTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/lsp/LanguageServerCatalogTest.java
@@ -47,4 +47,19 @@ class LanguageServerCatalogTest {
         assertThat(LanguageServerCatalog.isInstalled("sh")).isTrue();
         assertThat(LanguageServerCatalog.isInstalled("nmox-no-such-binary-zzz")).isFalse();
     }
+
+    @Test
+    @DisplayName("Auto-installable servers carry a runnable argv; manual ones are flagged, never faked")
+    void installCommands() {
+        Server go = LanguageServerCatalog.forBinary("gopls");
+        assertThat(go.autoInstallable()).isTrue();
+        assertThat(go.command()).containsExactly("go", "install", "golang.org/x/tools/gopls@latest");
+        assertThat(go.installer()).isEqualTo("go");
+
+        // Swift ships with the toolchain — there is no one-command install, so no fake button
+        Server swift = LanguageServerCatalog.forBinary("sourcekit-lsp");
+        assertThat(swift.autoInstallable()).isFalse();
+        assertThat(swift.command()).isEmpty();
+        assertThat(swift.installer()).isEmpty();
+    }
 }


### PR DESCRIPTION
Turns Tools ▸ Language Servers… from a status list into an installer, as requested.

- **`LanguageServerCatalog.Server`** gains a runnable `command` (empty ⇒ manual); `autoInstallable()`/`installer()` expose it.
- **`LanguageServerInstaller`** runs the command as **argv** through the rack's `CommandExecutor` (no shell interpolation, no sudo), checks the package manager is present first (`NEEDS_TOOLCHAIN` if not), and reports `INSTALLED`/`FAILED`.
- **`LanguageServersPanel`**: per-language rows with **Install** buttons, the progress bar running across during a run, live output to the Output window, **Install all missing** (determinate bar) with a **Cancel** that kills the process, and re-detection flipping rows to ✓ Installed. Servers that ship with a toolchain (Swift/Dart) or need manual setup (Zig/Julia/Erlang) are shown but never given a fake button.
- The Tools action now opens this panel **non-modally**, so installs run while you keep working.

**Verified live** (screenshots in session): the panel shows correct ✓/✗ detection; clicking Install on TypeScript ran `npm install -g typescript-language-server typescript`, streamed to Output, and flipped the row to ✓ Installed. `LanguageServerCatalogTest` extended (5); full suite green across all 11 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)