### PR TITLE
DRY: shared ProcessSupport factory for tool launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to NMOX Studio are documented here. The format follows
 ## [Unreleased]
 
 ### Changed
+- **One place to launch a tool, done right.** The process-launch
+  preamble — PATH augmentation, empty stdin, the no-color/non-interactive
+  environment — was copy-pasted at three sites (`CommandExecutor`,
+  `DockerClient`, `PortScanner`), and one copy hardcoded `/dev/null`,
+  which breaks on Windows. It now lives once in `ProcessSupport`; the
+  Windows null-device bug is fixed and a wedged `lsof` is reaped on
+  timeout instead of leaking.
 - **The build now policies itself.** SpotBugs runs on every `mvn verify`
   (so on every CI push and PR) with a correctness-focused filter, and
   JaCoCo reports coverage per module (≈40% instruction today, carried by

--- a/rack/src/main/java/org/nmox/studio/rack/docker/DockerClient.java
+++ b/rack/src/main/java/org/nmox/studio/rack/docker/DockerClient.java
@@ -1,7 +1,6 @@
 package org.nmox.studio.rack.docker;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -61,11 +60,7 @@ public final class DockerClient {
         cmd.add("docker");
         Collections.addAll(cmd, args);
         try {
-            ProcessBuilder pb = new ProcessBuilder(ToolLocator.resolveCommand(cmd))
-                    .redirectInput(new File(System.getProperty("os.name", "")
-                            .toLowerCase().contains("win") ? "NUL" : "/dev/null"));
-            pb.environment().put("PATH", ToolLocator.augmentedPath());
-            pb.environment().put("NO_COLOR", "1");
+            ProcessBuilder pb = org.nmox.studio.rack.engine.ProcessSupport.builder(cmd);
             Process p = pb.start();
             // Drain stderr on its own thread so a large stderr burst can't fill
             // its pipe and deadlock the stdout read (and vice versa). On a

--- a/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/CommandExecutor.java
@@ -64,18 +64,9 @@ public final class CommandExecutor {
 
         Process process;
         try {
-            // resolve the tool against the augmented path: a Finder-launched
-            // IDE has a bare PATH with no node/npm/git on it
-            ProcessBuilder pb = new ProcessBuilder(ToolLocator.resolveCommand(command))
-                    .directory(dir)
-                    // no terminal is attached: an interactive prompt would
-                    // hang forever, so give prompts an empty stdin instead
-                    .redirectInput(devNull());
-            pb.environment().put("PATH", ToolLocator.augmentedPath());
-            // belt and braces against prompts and ANSI art:
-            pb.environment().put("npm_config_yes", "true");   // npx auto-confirms downloads
-            pb.environment().put("GIT_TERMINAL_PROMPT", "0"); // git fails fast, never prompts
-            pb.environment().put("NO_COLOR", "1");            // tools that honor it skip ANSI
+            // shared hardening (PATH augment, empty stdin, no-color/non-interactive
+            // env); see ProcessSupport. Per-launch env overrides go on top.
+            ProcessBuilder pb = ProcessSupport.builder(command).directory(dir);
             pb.environment().putAll(env);
             process = pb.start();
         } catch (IOException ex) {
@@ -235,12 +226,6 @@ public final class CommandExecutor {
     /** Removes ANSI escapes so LCDs and the output window show clean text. */
     static String stripAnsi(String line) {
         return line.indexOf('\u001B') < 0 ? line : ANSI.matcher(line).replaceAll("");
-    }
-
-    /** The platform's empty input stream (no terminal is attached). */
-    private static File devNull() {
-        return new File(System.getProperty("os.name", "").toLowerCase().contains("win")
-                ? "NUL" : "/dev/null");
     }
 
     private static void safeAccept(Consumer<String> onLine, String line) {

--- a/rack/src/main/java/org/nmox/studio/rack/engine/PortScanner.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/PortScanner.java
@@ -1,6 +1,5 @@
 package org.nmox.studio.rack.engine;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,13 +27,13 @@ public final class PortScanner {
     public static CompletableFuture<List<PortInfo>> scan() {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                ProcessBuilder pb = new ProcessBuilder(
-                        "lsof", "-nP", "-iTCP", "-sTCP:LISTEN", "-F", "pcn")
-                        .redirectInput(new File("/dev/null"));
-                pb.environment().put("PATH", ToolLocator.augmentedPath());
+                ProcessBuilder pb = ProcessSupport.builder(
+                        List.of("lsof", "-nP", "-iTCP", "-sTCP:LISTEN", "-F", "pcn"));
                 Process p = pb.start();
                 String out = new String(p.getInputStream().readAllBytes());
-                p.waitFor(10, TimeUnit.SECONDS);
+                if (!p.waitFor(10, TimeUnit.SECONDS)) {
+                    p.destroyForcibly(); // a wedged lsof must not leak as a child
+                }
                 return parse(out);
             } catch (Exception ex) {
                 return List.of();

--- a/rack/src/main/java/org/nmox/studio/rack/engine/ProcessSupport.java
+++ b/rack/src/main/java/org/nmox/studio/rack/engine/ProcessSupport.java
@@ -1,0 +1,44 @@
+package org.nmox.studio.rack.engine;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One place to launch a developer tool correctly. Every process the IDE
+ * spawns — build commands, lsof, docker — needs the same hardening, and
+ * it used to be copy-pasted at each launch site (one copy even hardcoded
+ * {@code /dev/null}, breaking on Windows). This is that preamble, once:
+ *
+ * <ul>
+ *   <li>the command resolved against the augmented PATH — a Finder-launched
+ *       IDE has a bare PATH with no node/npm/git on it;</li>
+ *   <li>that same PATH in the child's environment;</li>
+ *   <li>empty stdin from the OS null device, so an interactive prompt can't
+ *       hang a process that has no terminal attached;</li>
+ *   <li>the no-color / non-interactive environment that keeps output clean.</li>
+ * </ul>
+ */
+public final class ProcessSupport {
+
+    private ProcessSupport() {
+    }
+
+    /** The OS null device: {@code /dev/null}, or {@code NUL} on Windows. */
+    public static File nullDevice() {
+        boolean windows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        return new File(windows ? "NUL" : "/dev/null");
+    }
+
+    /** A hardened ProcessBuilder for a dev-tool command line. */
+    public static ProcessBuilder builder(List<String> command) {
+        ProcessBuilder pb = new ProcessBuilder(ToolLocator.resolveCommand(command))
+                .redirectInput(nullDevice());
+        Map<String, String> env = pb.environment();
+        env.put("PATH", ToolLocator.augmentedPath());
+        env.put("npm_config_yes", "true");   // npx auto-confirms downloads
+        env.put("GIT_TERMINAL_PROMPT", "0");  // git fails fast, never prompts
+        env.put("NO_COLOR", "1");             // tools that honor it skip ANSI
+        return pb;
+    }
+}


### PR DESCRIPTION
Extracts the thrice-copied process-launch hardening into one `ProcessSupport` factory.

- **Fixes a latent Windows bug**: `PortScanner` hardcoded `/dev/null`; the shared `nullDevice()` is OS-aware (`NUL` on Windows).
- **Reaps a wedged `lsof`** on timeout (was leaked).
- Removes the duplicated `devNull()` and now-unused imports.

Behaviour-preserving for the existing macOS/Linux paths; SpotBugs gate + full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)