### PR TITLE
Solid-debt: outline false-positives, infra leak, npm wait bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ All notable changes to NMOX Studio are documented here. The format follows
   swallowing them), two dead copy-paste ternaries in the infra deploy
   planner (both branches were identical), a no-op port lookup, and
   missing `switch` defaults.
+- **The structure outline no longer invents symbols.** A `function` or
+  `class` that only *looks* like a declaration because it sits inside a
+  block comment or a multi-line `` `template literal` `` (an embedded SQL
+  or HTML heredoc) is no longer listed in the Navigator.
+- The Infrastructure Designer detaches its graph and rack listeners and
+  stops its autosave timer when closed, so opening and closing it no
+  longer leaks a listener each time.
+- `NpmService` bounds the wait for a finished command: once its output
+  has drained, a process that never exits is reaped after a grace period
+  instead of hanging the action thread (a slow build is unaffected — its
+  output has to finish first).
 
 ## [1.6.0] — 2026-06-17
 

--- a/editor/src/main/java/org/nmox/studio/editor/outline/OutlineModel.java
+++ b/editor/src/main/java/org/nmox/studio/editor/outline/OutlineModel.java
@@ -116,34 +116,84 @@ public final class OutlineModel {
     private static List<Item> js(String[] lines) {
         List<Item> out = new ArrayList<>();
         int brace = 0;
+        // carries across lines: are we inside a /* */ block comment or a
+        // `backtick` template literal? Without this, a declaration that only
+        // looks like one inside a comment or a multi-line template string
+        // (e.g. an embedded SQL/HTML heredoc) is mis-reported as a symbol.
+        boolean[] state = {false, false};
         for (int i = 0; i < lines.length && i < MAX_LINES; i++) {
-            String line = lines[i];
+            String code = stripNonCode(lines[i], state);
             int depthHere = brace;
             Matcher m;
-            if ((m = JS_TEST.matcher(line)).find()) {
+            if ((m = JS_TEST.matcher(code)).find()) {
                 out.add(new Item(OutlineKind.TEST, m.group(1), null, i, depthHere));
-            } else if ((m = JS_CLASS.matcher(line)).find()) {
+            } else if ((m = JS_CLASS.matcher(code)).find()) {
                 out.add(new Item(OutlineKind.CLASS, m.group(1), null, i, depthHere));
-            } else if ((m = JS_IFACE.matcher(line)).find()) {
+            } else if ((m = JS_IFACE.matcher(code)).find()) {
                 out.add(new Item(OutlineKind.INTERFACE, m.group(1), null, i, depthHere));
-            } else if ((m = JS_ENUM.matcher(line)).find()) {
+            } else if ((m = JS_ENUM.matcher(code)).find()) {
                 out.add(new Item(OutlineKind.ENUM, m.group(1), null, i, depthHere));
-            } else if ((m = JS_TYPE.matcher(line)).find()) {
+            } else if ((m = JS_TYPE.matcher(code)).find()) {
                 out.add(new Item(OutlineKind.TYPE, m.group(1), null, i, depthHere));
-            } else if ((m = JS_FUNC.matcher(line)).find()) {
+            } else if ((m = JS_FUNC.matcher(code)).find()) {
                 out.add(new Item(OutlineKind.FUNCTION, m.group(1), null, i, depthHere));
-            } else if ((m = JS_ARROW.matcher(line)).find()) {
+            } else if ((m = JS_ARROW.matcher(code)).find()) {
                 out.add(new Item(OutlineKind.FUNCTION, m.group(1), null, i, depthHere));
-            } else if (depthHere > 0 && (m = JS_METHOD.matcher(line)).find()
+            } else if (depthHere > 0 && (m = JS_METHOD.matcher(code)).find()
                     && !JS_KEYWORDS.contains(m.group(1))) {
                 out.add(new Item(OutlineKind.METHOD, m.group(1), null, i, depthHere));
             }
-            brace += netBraces(line);
+            brace += netBraces(code);
             if (brace < 0) {
                 brace = 0;
             }
         }
         return out;
+    }
+
+    /**
+     * Returns the line with block comments, line comments and backtick
+     * template literals blanked out, carrying block-comment / template state
+     * across lines via {@code state} ([0]=inBlockComment, [1]=inTemplate).
+     * Regular "…"/'…' strings are left alone — a declaration keyword inside a
+     * single-line string is rare and self-correcting on the next line.
+     */
+    static String stripNonCode(String line, boolean[] state) {
+        StringBuilder code = new StringBuilder(line.length());
+        int j = 0;
+        while (j < line.length()) {
+            if (state[0]) { // inside /* */
+                int end = line.indexOf("*/", j);
+                if (end < 0) {
+                    return code.toString();
+                }
+                state[0] = false;
+                j = end + 2;
+            } else if (state[1]) { // inside `template`
+                int end = line.indexOf('`', j);
+                if (end < 0) {
+                    return code.toString();
+                }
+                state[1] = false;
+                j = end + 1;
+            } else {
+                char c = line.charAt(j);
+                char next = j + 1 < line.length() ? line.charAt(j + 1) : '\0';
+                if (c == '/' && next == '/') {
+                    break; // rest of the line is a comment
+                } else if (c == '/' && next == '*') {
+                    state[0] = true;
+                    j += 2;
+                } else if (c == '`') {
+                    state[1] = true;
+                    j++;
+                } else {
+                    code.append(c);
+                    j++;
+                }
+            }
+        }
+        return code.toString();
     }
 
     // ---- CSS / SCSS / LESS ----------------------------------------------

--- a/editor/src/test/java/org/nmox/studio/editor/outline/OutlineModelTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/outline/OutlineModelTest.java
@@ -47,6 +47,21 @@ class OutlineModelTest {
     }
 
     @Test
+    @DisplayName("JS outline ignores declarations inside comments and template literals")
+    void jsSkipsCommentsAndTemplates() {
+        String src = String.join("\n",
+                "function real() {}",
+                "/* function commented() {} */",
+                "const sql = `",
+                "  export function inTemplate() {",
+                "`;",
+                "function alsoReal() {}");
+        List<Item> items = outline("text/javascript", src);
+        assertThat(items).extracting(Item::name).contains("real", "alsoReal");
+        assertThat(items).extracting(Item::name).doesNotContain("commented", "inTemplate");
+    }
+
+    @Test
     @DisplayName("JS test files: describe/it blocks become navigable")
     void jsTests() {
         String src = """

--- a/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
+++ b/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
@@ -63,6 +63,8 @@ public final class InfraDesignerTopComponent extends TopComponent {
     private final JLabel tokenLabel = new JLabel();
     private final JLabel costLabel = new JLabel();
     private final Timer saveDebounce;
+    private final InfraGraph.Listener graphListener;
+    private final org.nmox.studio.rack.model.Rack.Listener rackListener;
     private boolean loading;
 
     public InfraDesignerTopComponent() {
@@ -95,7 +97,7 @@ public final class InfraDesignerTopComponent extends TopComponent {
 
         saveDebounce = new Timer(1000, e -> save());
         saveDebounce.setRepeats(false);
-        graph.addListener(new InfraGraph.Listener() {
+        graphListener = new InfraGraph.Listener() {
             @Override
             public void graphChanged() {
                 SwingUtilities.invokeLater(() -> {
@@ -105,14 +107,16 @@ public final class InfraDesignerTopComponent extends TopComponent {
                     }
                 });
             }
-        });
+        };
+        graph.addListener(graphListener);
 
-        RackService.getDefault().getRack().addListener(new org.nmox.studio.rack.model.Rack.Listener() {
+        rackListener = new org.nmox.studio.rack.model.Rack.Listener() {
             @Override
             public void projectChanged() {
                 SwingUtilities.invokeLater(InfraDesignerTopComponent.this::load);
             }
-        });
+        };
+        RackService.getDefault().getRack().addListener(rackListener);
         load();
         refreshToken();
         refreshCost();
@@ -367,5 +371,18 @@ public final class InfraDesignerTopComponent extends TopComponent {
     }
 
     void readProperties(java.util.Properties p) {
+    }
+
+    @Override
+    protected void componentClosed() {
+        // stop the debounce timer and drop our listeners, so a close/reopen
+        // cycle doesn't accumulate zombie listeners on the graph and the rack
+        saveDebounce.stop();
+        graph.removeListener(graphListener);
+        try {
+            RackService.getDefault().getRack().removeListener(rackListener);
+        } catch (RuntimeException | LinkageError ignore) {
+            // rack already gone; nothing left to detach
+        }
     }
 }

--- a/tools/src/main/java/org/nmox/studio/tools/npm/NpmService.java
+++ b/tools/src/main/java/org/nmox/studio/tools/npm/NpmService.java
@@ -150,7 +150,16 @@ public class NpmService {
                     }
                 }
                 
-                int exitCode = process.waitFor();
+                // the read loop above already drained all output (it blocks
+                // until stdout closes), so the process should exit promptly;
+                // a generous grace then reap guards against a child that
+                // closes its pipe but never exits, without ever truncating a
+                // legitimately slow build (whose output had to finish first)
+                if (!process.waitFor(60, java.util.concurrent.TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    throw new RuntimeException("Command did not exit after its output ended");
+                }
+                int exitCode = process.exitValue();
                 if (exitCode != 0) {
                     err.println("Command failed with exit code: " + exitCode);
                     throw new RuntimeException("Command failed with exit code: " + exitCode + "\nOutput: " + output);


### PR DESCRIPTION
Three audit fixes:
- **OutlineModel** strips comments + backtick template literals before matching declarations — no more phantom symbols from `/* function x */` or a multi-line SQL/HTML heredoc. Regression test added.
- **InfraDesignerTopComponent** now detaches its graph + rack listeners and stops the autosave timer on `componentClosed()` (was leaking a listener per open/close).
- **NpmService** bounds the post-output `waitFor` (grace-then-reap), so a wedged child can't hang the action thread; slow builds are unaffected since their output drains first.

SpotBugs gate + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)