### PR TITLE
Modernize to Java 21 LTS + cross-platform CI matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,14 +8,20 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Prove the cross-platform claim: the full verify (tests + SpotBugs gate)
+    # runs on Linux and macOS, on the Java 21 LTS the app now targets.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: maven
       - name: Build with Maven
         run: mvn -B verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
       - name: Stamp version into branding
         run: |
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
       - name: Stamp version into branding
         run: |
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
       - name: Stamp version into branding
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- **NMOX Studio is now a Java 21 LTS application.** The source target
+  moved 17 → 21 and the installers bundle a Temurin 21 runtime, so the
+  app ships on a current, supported JVM (newer GC, security fixes, the
+  language features 21 brings). CI proves the cross-platform claim it
+  always made: the full `verify` — tests plus the SpotBugs gate — now
+  runs on a **Linux + macOS matrix** on JDK 21, not just one Linux/JDK 17
+  box. (The NetBeans Platform itself stays on RELEASE270; a platform bump
+  is its own careful step.)
+
 ## [1.7.0] — 2026-06-18
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ NMOX Studio is a NetBeans Platform-based IDE for modern web development, with fi
 ## Build and Run Commands
 
 ### Prerequisites
-- **Java 17+** (required; project uses Java 17, tested with Java 23)
+- **Java 21+** (required; project targets Java 21 LTS, tested with Java 23)
 - **Maven 3.6+**
 
 **IMPORTANT**: Ensure JAVA_HOME points to JDK 17+ or use `--jdkhome` when running:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NMOX Studio is an IDE for web development with a twist: your tooling lives in a 
 
 ## Download
 
-Grab **[the latest release](https://github.com/NMOX/NMOX-Studio/releases/latest)** — DMG (macOS), installer (Windows), tar.gz/deb (Linux), or portable zip. The DMG, installer, tar.gz and deb ship with their own Java runtime — nothing to install. (The portable zip alone expects a Java 17+ on the machine.)
+Grab **[the latest release](https://github.com/NMOX/NMOX-Studio/releases/latest)** — DMG (macOS), installer (Windows), tar.gz/deb (Linux), or portable zip. The DMG, installer, tar.gz and deb ship with their own Java runtime — nothing to install. (The portable zip alone expects a Java 21+ on the machine.)
 
 > **macOS note:** the app is not yet notarized. If Gatekeeper objects, right-click the app and choose *Open*, or run `xattr -d com.apple.quarantine "/Applications/NMOX Studio.app"`.
 
@@ -82,7 +82,7 @@ See the [CHANGELOG](CHANGELOG.md) for the full release history.
 ## Quick Start
 
 ### Prerequisites
-- **Java 17+** (JDK required for development)
+- **Java 21+** (JDK required for development)
 - **Maven 3.6+**
 - **Git** (for source code management)
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
         <netbeans.version>RELEASE270</netbeans.version>
         <brandingToken>nmoxstudio</brandingToken>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <junit.version>5.10.2</junit.version>
         <mockito.version>5.12.0</mockito.version>
         <assertj.version>3.26.0</assertj.version>


### PR DESCRIPTION
Moves the whole stack to the current LTS.

- **Source target 17 → 21**; full `verify` (tests + SpotBugs gate) green on JDK 21 locally.
- **Installers bundle Temurin 21** (release jobs were pinned to 17).
- **CI matrix**: the full verify now runs on **ubuntu + macOS**, JDK 21 — the cross-platform/polyglot claim, actually exercised, instead of one Linux/JDK-17 box.
- Docs updated to Java 21+.

NetBeans Platform stays on RELEASE270 — a platform bump deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)