### PR TITLE
Supply chain: Dependabot config + release SBOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Keeps NMOX Studio's dependencies, CI actions, and the project-scaffold
+# templates current and patched. Security updates land regardless; this
+# adds scheduled version updates, grouped to keep the PR volume sane.
+version: 2
+updates:
+  # The Maven reactor (NetBeans Platform, JUnit/AssertJ/Mockito, plugins).
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      maven:
+        patterns: ["*"]
+
+  # The GitHub Actions used by the build/release workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # The npm dependencies inside the project templates NMOX scaffolds, so a
+  # freshly generated project never starts out vulnerable (the Vite advisory
+  # that prompted this was exactly such a case).
+  - package-ecosystem: npm
+    directories:
+      - "/tools/src/main/resources/org/nmox/studio/tools/npm/templates/vue"
+      - "/tools/src/main/resources/org/nmox/studio/tools/npm/templates/react"
+      - "/tools/src/main/resources/org/nmox/studio/tools/npm/templates/vanilla"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
             branding/src/main/nbm-branding/core/core.jar/org/netbeans/core/startup/Bundle.properties
       - name: Build application
         run: mvn -B clean package -DskipTests
+      - name: Software Bill of Materials (CycloneDX)
+        run: |
+          mvn -B org.cyclonedx:cyclonedx-maven-plugin:2.9.1:makeAggregateBom \
+            -DoutputFormat=json -DoutputName=bom
+          cp target/bom.json "NMOX-Studio-${{ needs.version.outputs.version }}-sbom.json"
       - name: Portable zip
         run: |
           cp application/target/NMOX-Studio-app-*.zip \
@@ -43,6 +48,7 @@ jobs:
           name: linux-artifacts
           path: |
             NMOX-Studio-*-portable.zip
+            NMOX-Studio-*-sbom.json
             application/target/dist/NMOX-Studio-*-linux.tar.gz
             application/target/dist/nmox-studio_*.deb
 
@@ -123,6 +129,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/**/NMOX-Studio-*-portable.zip
+            artifacts/**/NMOX-Studio-*-sbom.json
             artifacts/**/NMOX-Studio-*-linux.tar.gz
             artifacts/**/nmox-studio_*.deb
             artifacts/**/NMOX-Studio-*-macos.dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to NMOX Studio are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **Supply-chain hygiene.** Dependabot now watches three ecosystems —
+  the Maven reactor, the GitHub Actions in the workflows, and the npm
+  dependencies inside the project-scaffold templates — so a generated
+  project never starts out vulnerable (the Vite advisory that bit us was
+  exactly that case) and the build's own dependencies stay patched. Every
+  release now also ships a **CycloneDX SBOM** (`*-sbom.json`) listing every
+  component that goes into the app.
+
 ### Changed
 - **NMOX Studio is now a Java 21 LTS application.** The source target
   moved 17 → 21 and the installers bundle a Temurin 21 runtime, so the


### PR DESCRIPTION
Closes out the excellence-polish pass.

- **Dependabot** now explicitly covers three ecosystems: the Maven reactor, the GitHub Actions in the workflows, and the npm deps inside the **project-scaffold templates** (the Vite advisory that bit us came from exactly there). Grouped + weekly to keep PR volume sane.
- Every release attaches a **CycloneDX SBOM** (`*-sbom.json`, ~566 components) — generated and verified locally.

Code signing (macOS notarization / Windows Authenticode) is the one remaining polish item and needs certificates — flagged for David.

🤖 Generated with [Claude Code](https://claude.com/claude-code)