### PR TITLE
Rock-solid: security gate (find-sec-bugs) + ReDoS fixes + process-handle race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Security
+- **A security static-analysis gate, and a clean review behind it.**
+  find-sec-bugs now runs alongside SpotBugs on every build. It caught two
+  genuine **ReDoS** (catastrophic-backtracking) regexes — in the eslint
+  and `docker ps` output parsers, which chew on external tool output —
+  now rewritten to linear time; the source-outline regexes also got a
+  line-length bound. Everything else it flags is by-design for a local
+  IDE (process launches via argv not a shell, file ops on the user's own
+  paths, a localhost debug socket, UI-jitter randomness) and is excluded
+  with a written rationale, so the dangerous classes — XXE, SSRF, weak
+  crypto, hardcoded secrets, unsafe deserialization — stay watched.
+
+### Fixed
+- **A running tool process can't be orphaned by a stale exit.** A
+  device's `exec` swapped its process handle without an identity check,
+  so a previous run's exit callback arriving late could null out the
+  handle of the run that replaced it — leaving a live process that
+  `isLive()`/panic could no longer see or kill. The swap is now
+  identity-guarded.
+- Removed a dead, unescaped HTML-building method left over from the
+  language-server panel rework.
+
 ## [1.8.0] — 2026-06-18
 
 ### Added

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -60,6 +60,52 @@
          vector this warns about does not apply to our non-final UI classes. -->
     <Match><Bug pattern="CT_CONSTRUCTOR_THROW"/></Match>
 
+    <!-- ===== find-sec-bugs: reviewed, by-design for a local desktop IDE ===== -->
+    <!-- Command injection: every tool launch is ProcessBuilder(List<String>) —
+         literal argv entries, never a shell string, so there is no shell to
+         inject into. WorkspaceTrust additionally gates running a project's
+         tools at all. (The other find-sec-bugs detectors — XXE, SSRF, weak
+         crypto/random, hardcoded secrets, unsafe deserialization — stay on.) -->
+    <Match><Bug pattern="COMMAND_INJECTION"/></Match>
+    <!-- Path traversal is a server-sandbox-escape concern. NMOX is a local IDE
+         operating on the user's own filesystem with the user's own privileges;
+         the paths are the user's own choice, there is no sandbox to escape and
+         no remote attacker supplying them. -->
+    <Match><Bug pattern="PATH_TRAVERSAL_IN"/></Match>
+
+    <!-- The source-parser grammar regexes (OutlineModel, CodeIndexService)
+         are flagged ReDoS-prone, but they only ever run on the user's own
+         source, off the EDT; OutlineModel additionally caps each line's length
+         before matching. Rewriting these many language-grammar regexes would
+         risk the parsers' correctness for no real gain. REDOS stays active
+         everywhere else — it already caught two genuine ones in the eslint and
+         docker output parsers (external tool output), which we fixed. -->
+    <Match>
+        <Class name="org.nmox.studio.editor.outline.OutlineModel"/>
+        <Bug pattern="REDOS"/>
+    </Match>
+    <Match>
+        <Class name="org.nmox.studio.editor.index.CodeIndexService"/>
+        <Bug pattern="REDOS"/>
+    </Match>
+
+    <!-- The debug adapter (DAP) connects to a debug server on 127.0.0.1 — local
+         IPC, like LSP over stdio; an unencrypted localhost socket is expected.
+         The server-socket flag is also a false positive: `new ServerSocket(0)`
+         there is opened and immediately closed only to grab a free port. -->
+    <Match>
+        <Class name="org.nmox.studio.editor.debug.DapDebugAction"/>
+        <Bug pattern="UNENCRYPTED_SOCKET,UNENCRYPTED_SERVER_SOCKET"/>
+    </Match>
+
+    <!-- Math.random() here only jitters a newly-dropped node's canvas position;
+         it is not used for anything security-sensitive. Scoped to this class so
+         a genuine crypto-context Math.random() elsewhere would still be caught. -->
+    <Match>
+        <Class name="~org\.nmox\.studio\.infra\.ui\.InfraPalette.*"/>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+    </Match>
+
     <!-- Tests may trip benign patterns; analyse main code only for the gate. -->
     <Match><Class name="~.*Test"/></Match>
 </FindBugsFilter>

--- a/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerHealth.java
+++ b/editor/src/main/java/org/nmox/studio/editor/lsp/LanguageServerHealth.java
@@ -54,23 +54,6 @@ public final class LanguageServerHealth {
         REPORTED.clear();
     }
 
-    /** An at-a-glance HTML report of which servers are installed vs missing. */
-    public static String statusReportHtml() {
-        StringBuilder sb = new StringBuilder("<html><body style='width:460px'>"
-                + "<b>Language servers</b> — the intelligence backends behind hover, "
-                + "go-to-definition, rename and live errors.<br><br>"
-                + "<table cellspacing='3'>");
-        for (Server s : LanguageServerCatalog.all()) {
-            boolean ok = LanguageServerCatalog.isInstalled(s.binary());
-            sb.append("<tr><td>").append(ok ? "&#10003;" : "&#10007;").append("</td>")
-                    .append("<td><b>").append(s.language()).append("</b></td>")
-                    .append("<td><code>").append(s.binary()).append("</code></td>")
-                    .append("<td>").append(ok ? "installed"
-                            : "<i>" + s.install() + "</i>").append("</td></tr>");
-        }
-        return sb.append("</table></body></html>").toString();
-    }
-
     /** A small amber attention dot, so the notification needs no icon resource. */
     private static Icon dot() {
         BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);

--- a/editor/src/main/java/org/nmox/studio/editor/outline/OutlineModel.java
+++ b/editor/src/main/java/org/nmox/studio/editor/outline/OutlineModel.java
@@ -85,10 +85,23 @@ public final class OutlineModel {
         };
     }
 
+    /** No real declaration's name lives past this column. */
+    private static final int MAX_LINE_LEN = 2_000;
+
     static String[] splitLines(CharSequence text) {
         String s = text.toString();
         // keep it bounded; split is fine for normal source sizes
-        return s.split("\n", -1);
+        String[] lines = s.split("\n", -1);
+        // Bound each line's length before the symbol regexes see it: a
+        // pathologically long line could make a grammar regex backtrack
+        // badly (ReDoS), and truncating well past any real declaration is
+        // behaviour-preserving, so matching stays linear-time in practice.
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].length() > MAX_LINE_LEN) {
+                lines[i] = lines[i].substring(0, MAX_LINE_LEN);
+            }
+        }
+        return lines;
     }
 
     // ---- JS / TS family --------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,17 @@
                     <threshold>Medium</threshold>
                     <failOnError>true</failOnError>
                     <excludeFilterFile>${maven.multiModuleProjectDirectory}/config/spotbugs-exclude.xml</excludeFilterFile>
+                    <!-- security detectors: command injection, path traversal,
+                         SSRF, weak crypto/random, XXE — the threat surface of an
+                         IDE that spawns processes, calls cloud APIs and parses
+                         untrusted files -->
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>1.13.0</version>
+                        </plugin>
+                    </plugins>
                 </configuration>
                 <executions>
                     <execution>

--- a/rack/src/main/java/org/nmox/studio/rack/devices/LintDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/LintDevice.java
@@ -61,8 +61,12 @@ public class LintDevice extends CommandDevice {
     private final java.util.List<org.nmox.studio.rack.engine.DiagnosticsBus.Problem> collected =
             java.util.Collections.synchronizedList(new java.util.ArrayList<>());
     private volatile java.io.File currentFile;
+    // Greedy capture of the rest of the line (linear-time): the old lazy
+    // ".*?" with an optional trailing rule-name group could backtrack
+    // catastrophically (ReDoS) on a long message. The message is trimmed at
+    // the call site and may carry the rule name, which is fine to show.
     private static final java.util.regex.Pattern ESLINT_LOC =
-            java.util.regex.Pattern.compile("^\\s+(\\d+):(\\d+)\\s+(error|warning)\\s+(.*?)(?:\\s\\s+[\\w@/-]+)?$");
+            java.util.regex.Pattern.compile("^\\s+(\\d+):(\\d+)\\s+(error|warning)\\s+(.*)$");
 
     @Override
     protected void onLine(String line) {

--- a/rack/src/main/java/org/nmox/studio/rack/docker/DockerClient.java
+++ b/rack/src/main/java/org/nmox/studio/rack/docker/DockerClient.java
@@ -261,8 +261,12 @@ public final class DockerClient {
         return rows;
     }
 
-    /** "0.0.0.0:8080->80/tcp, :::8080->80/tcp" -> [8080]. */
-    private static final Pattern HOST_PORT = Pattern.compile("(?:^|[\\s,])(?:[\\d.]+|\\[?::]?\\]?):(\\d+)->");
+    /**
+     * "0.0.0.0:8080->80/tcp, :::8080->80/tcp" -> [8080]. The published host
+     * port is the run of digits immediately before "->"; matching just that
+     * is linear-time (the old host-matching alternation could backtrack — ReDoS).
+     */
+    private static final Pattern HOST_PORT = Pattern.compile(":(\\d+)->");
 
     static List<Integer> hostPorts(String ports) {
         List<Integer> result = new ArrayList<>();

--- a/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/model/RackDevice.java
@@ -252,11 +252,19 @@ public abstract class RackDevice extends JPanel {
         Map<String, String> env = new LinkedHashMap<>(
                 rack != null ? rack.getEnvOverrides() : Map.of());
         env.putAll(extraEnv);
-        running = CommandExecutor.run(title, workingDir, env,
+        // identity-guarded swap: a previous run's onExit, arriving late on a
+        // worker thread, must not null out the handle of the run that replaced
+        // it — that would orphan a live process (isLive()/panic() would see
+        // nothing to kill).
+        CommandExecutor.Handle[] self = new CommandExecutor.Handle[1];
+        self[0] = CommandExecutor.run(title, workingDir, env,
                 command, onLine, code -> {
-                    running = null;
+                    if (running == self[0]) {
+                        running = null;
+                    }
                     onExit.accept(code);
                 });
+        running = self[0];
     }
 
     protected boolean isProcessRunning() {


### PR DESCRIPTION
Hardening pass.

- **find-sec-bugs** joins the SpotBugs gate. Documented security review: **2 genuine ReDoS** fixed (the eslint and `docker ps` output parsers — external input — rewritten linear-time), OutlineModel line-length bounded. Everything else it flags is by-design for a local IDE (argv launches, the user's own file paths, a localhost DAP socket, UI-jitter `Math.random`) and excluded with written rationale; the dangerous classes (XXE/SSRF/weak-crypto/secrets/deserialization) stay live.
- **Process-handle race fixed**: `RackDevice.exec` now identity-guards the handle swap, so a stale `onExit` can't null out a newer run's handle and orphan a live process.
- Deleted a dead unescaped HTML method.

SpotBugs + find-sec-bugs + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)