### PR TITLE
Coverage gate: fail-closed JaCoCo floors on the logic modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- **Coverage can't silently regress now.** JaCoCo gained a fail-closed
+  floor on the three substantial-logic modules — rack (≥40% line),
+  infra (≥30%), editor (≥28%) — verified to actually fail the build when
+  coverage drops below the line. The UI/glue/packaging modules stay
+  measured but ungated, since forcing coverage there would only breed
+  hollow tests. That completes the self-policing build: a correctness
+  gate (SpotBugs), a security gate (find-sec-bugs), and now a coverage
+  gate, all on every push.
+
 ## [1.8.1] — 2026-06-18
 
 ### Security

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -225,6 +225,33 @@
                     </archive>
                 </configuration>
             </plugin>
+                    <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>coverage-floor</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.28</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/infra/pom.xml
+++ b/infra/pom.xml
@@ -108,6 +108,33 @@
                     </archive>
                 </configuration>
             </plugin>
+                    <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>coverage-floor</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.30</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/rack/pom.xml
+++ b/rack/pom.xml
@@ -156,6 +156,33 @@
                     </archive>
                 </configuration>
             </plugin>
+                    <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>coverage-floor</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.40</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Completes the self-policing build — it already had a **correctness** gate (SpotBugs) and a **security** gate (find-sec-bugs); this adds a **coverage** gate.

- Fail-closed JaCoCo line-coverage floors on the three substantial-logic modules: **rack ≥ 40%, infra ≥ 30%, editor ≥ 28%** (each ~5pts below current, a ratchet not a brittle freeze).
- **Validated it actually enforces**: temporarily raising rack's floor to 0.99 fails the build (`lines covered ratio is 0.45, but expected minimum is 0.99`).
- UI/glue/packaging modules stay measured-but-ungated on purpose — forcing coverage onto Swing/actions/packaging would only breed hollow tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)