### PR TITLE
fix(rack): make device controls carry real signals and results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.8.6] — 2026-06-22
+
+A control-surface audit swept all 33 rack devices for knobs, toggles, buttons,
+and patch jacks that looked wired but weren't — and made them carry real
+signals and real results. Most of the fleet was already honest; the cases below
+were not.
+
+### Fixed
+- **VERITAS COVER actually collects coverage now.** The toggle keyed on the raw
+  RUNNER knob, so in the default AUTO position (and anywhere AUTO resolved a
+  framework) it added nothing — the switch was visibly on and did nothing. It
+  now resolves AUTO first, so a jest/vitest project gets `--coverage` and a
+  Python project gets `pytest --cov`.
+- **BLACKBOX's OUT jack was inert.** The flight recorder declared an output port
+  but never emitted on it — a cable you could draw that could never carry a
+  signal. It now broadcasts the newest tape entry (launch, exit, or error) as it
+  happens, so you can wire BLACKBOX → MONITOR for a live event log or into a
+  notifier.
+- **SONAR's OUT jack spoke prose, not data.** It emitted the sentence
+  `"sonar: N ports listening"`, which nothing downstream could act on. It now
+  emits the listening port numbers as a sorted, de-duplicated, comma-separated
+  list a wired device can parse.
+- **FORGE's WATCH toggle was a no-op in the esbuild position.** esbuild now gets
+  `--watch` when WATCH is on, like the other bundlers.
+
+### Added
+- **PING can send a request body.** POST and PUT previously sent an empty body,
+  so you couldn't smoke-test an API that expects a payload. A new body field is
+  sent on POST/PUT (with a JSON `Content-Type` when the body looks like JSON);
+  reads and blank bodies stay body-less.
+- **`DeviceWiringTest`** locks these behaviors in: COVER resolves AUTO before
+  adding a coverage flag, PING's request builder carries the body only on
+  write methods, SONAR's payload is machine-usable, and BLACKBOX's OUT jack
+  delivers a recorder event down a real cable.
+
+### Changed
+- **NPM-9000** dropped two dead button fields (inlined as locals), and
+  **MAESTRO's** STOP ALL now describes honestly what it does — halt every
+  command-backed device — rather than implying it can stop timer- or
+  listener-driven ones.
+
 ## [1.8.5] — 2026-06-21
 
 ### Fixed

--- a/rack/src/main/java/org/nmox/studio/rack/devices/BlackboxDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BlackboxDevice.java
@@ -80,6 +80,17 @@ public class BlackboxDevice extends RackDevice {
     }
 
     private void onRecorderChange() {
+        // broadcast the newest tape entry of any kind (launch, exit, error)
+        // so the OUT jack is a live event source: wire it into MONITOR for a
+        // running log, or into a notifier. last() only sees completed runs.
+        List<Event> tape = FlightRecorder.getDefault().timeline();
+        if (!tape.isEmpty()) {
+            Event newest = tape.get(tape.size() - 1);
+            String dur = newest.durationMs() >= 0
+                    ? " " + (newest.durationMs() / 1000.0) + "s" : "";
+            emit("out", org.nmox.studio.rack.model.Signal.data(
+                    newest.device() + " " + newest.kind().name() + dur));
+        }
         onEdt(() -> {
             recLed.setOn(true);
             recFade.restart();

--- a/rack/src/main/java/org/nmox/studio/rack/devices/BuildDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BuildDevice.java
@@ -180,7 +180,12 @@ public class BuildDevice extends CommandDevice {
                     cmd.add("--watch");
                 }
             }
-            case "esbuild" -> cmd.addAll(List.of("npx", "esbuild", "--bundle", "src/index.js", "--outdir=dist"));
+            case "esbuild" -> {
+                cmd.addAll(List.of("npx", "esbuild", "--bundle", "src/index.js", "--outdir=dist"));
+                if (watch) {
+                    cmd.add("--watch");
+                }
+            }
             case "parcel" -> cmd.addAll(List.of("npx", "parcel", watch ? "watch" : "build"));
             default -> cmd.addAll(List.of("npm", "run", "build"));
         }

--- a/rack/src/main/java/org/nmox/studio/rack/devices/HttpDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/HttpDevice.java
@@ -27,6 +27,7 @@ public class HttpDevice extends RackDevice {
 
     private final Knob methodKnob;
     private final LcdDisplay urlLcd;
+    private final LcdDisplay bodyLcd;
     private final LcdDisplay statusLcd;
     private final VuMeter latencyMeter;
     private final Led okLed;
@@ -42,6 +43,9 @@ public class HttpDevice extends RackDevice {
         urlLcd = place(new LcdDisplay(260, 1), 184, 46);
         urlLcd.setText("http://localhost:3000");
         urlLcd.setEditable("Request URL");
+        bodyLcd = place(new LcdDisplay(260, 1), 184, 78);
+        bodyLcd.setText("");
+        bodyLcd.setEditable("Request body (sent on POST/PUT)");
         RackButton send = place(new RackButton("SEND", RackStyle.GO), RackStyle.TRANSPORT_X, 46);
         statusLcd = place(new LcdDisplay(120, 1), 460, 46);
         statusLcd.setText("—");
@@ -59,6 +63,7 @@ public class HttpDevice extends RackDevice {
 
         param("method", methodKnob);
         param("url", urlLcd);
+        param("body", bodyLcd);
     }
 
     private void fire() {
@@ -75,10 +80,7 @@ public class HttpDevice extends RackDevice {
         long start = System.nanoTime();
         HttpRequest request;
         try {
-            request = HttpRequest.newBuilder(URI.create(url))
-                    .method(METHODS[methodKnob.getSelectedIndex()], HttpRequest.BodyPublishers.noBody())
-                    .timeout(Duration.ofSeconds(15))
-                    .build();
+            request = buildRequest(METHODS[methodKnob.getSelectedIndex()], url, bodyLcd.getText());
         } catch (RuntimeException ex) {
             onEdt(() -> {
                 failLed.setOn(true);
@@ -113,6 +115,32 @@ public class HttpDevice extends RackDevice {
                         emit("body", Signal.data(body.length() > 400 ? body.substring(0, 400) + "…" : body));
                     }
                 });
+    }
+
+    /**
+     * Builds the request: POST/PUT carry the body field (JSON gets a
+     * Content-Type so APIs accept it); everything else is body-less.
+     * Static and side-effect-free so the wiring is unit-testable.
+     */
+    static HttpRequest buildRequest(String method, String url, String body) {
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofSeconds(15));
+        boolean sendsBody = ("POST".equals(method) || "PUT".equals(method))
+                && body != null && !body.isBlank();
+        if (sendsBody) {
+            b.method(method, HttpRequest.BodyPublishers.ofString(body));
+            if (looksJson(body)) {
+                b.header("Content-Type", "application/json");
+            }
+        } else {
+            b.method(method, HttpRequest.BodyPublishers.noBody());
+        }
+        return b.build();
+    }
+
+    static boolean looksJson(String body) {
+        String t = body.strip();
+        return t.startsWith("{") || t.startsWith("[");
     }
 
     @Override

--- a/rack/src/main/java/org/nmox/studio/rack/devices/MasterControlDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/MasterControlDevice.java
@@ -12,8 +12,9 @@ import org.nmox.studio.rack.ui.controls.RackStyle;
 /**
  * MAESTRO Master Control: the transport section. One big RUN button
  * fans a trigger out of four jacks at once - patch them into any
- * combination of devices to fire a whole pipeline; STOP ALL kills
- * every running process in the rack.
+ * combination of devices to fire a whole pipeline; STOP ALL halts
+ * every command-backed device in the rack - the ones that launched a
+ * process (servers, builds, tunnels) - by killing it.
  */
 public class MasterControlDevice extends RackDevice {
 

--- a/rack/src/main/java/org/nmox/studio/rack/devices/NpmScriptDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/NpmScriptDevice.java
@@ -20,15 +20,13 @@ public class NpmScriptDevice extends CommandDevice {
 
     private final Knob scriptKnob;
     private final Knob managerKnob;
-    private final RackButton runButton;
-    private final RackButton stopButton;
 
     public NpmScriptDevice() {
         super("npm-script", "NPM-9000", "SCRIPT SEQUENCER", new Color(203, 56, 55), 2);
 
-        runButton = place(new RackButton("RUN", RackStyle.GO), RackStyle.TRANSPORT_X, 52);
+        RackButton runButton = place(new RackButton("RUN", RackStyle.GO), RackStyle.TRANSPORT_X, 52);
         runButton.setCommandPreview(this::commandPreview);
-        stopButton = place(new RackButton("STOP", RackStyle.STOP), RackStyle.TRANSPORT_STOP_X, 52);
+        RackButton stopButton = place(new RackButton("STOP", RackStyle.STOP), RackStyle.TRANSPORT_STOP_X, 52);
         scriptKnob = place(new Knob("SCRIPT", new String[]{"—"}, 0), 180, 40);
         managerKnob = place(new Knob("ENGINE", MANAGERS, 0), 254, 40);
 

--- a/rack/src/main/java/org/nmox/studio/rack/devices/SonarDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/SonarDevice.java
@@ -100,8 +100,7 @@ public class SonarDevice extends RackDevice {
                 }
                 fieldLcd.setText(low.length() == 0 ? "DEV BAND QUIET" : "DEV: " + low);
             });
-            emit("out", org.nmox.studio.rack.model.Signal.data(
-                    "sonar: " + ports.size() + " ports listening"));
+            emit("out", org.nmox.studio.rack.model.Signal.data(listeningPorts(ports)));
         });
         // docker's published ports belong to containers, not the daemon pid
         DockerClient.getDefault().containers().thenAccept(cs -> {
@@ -113,6 +112,20 @@ public class SonarDevice extends RackDevice {
             }
             dockerOwners = owners;
         });
+    }
+
+    /**
+     * The sweep result as a machine-usable payload: the listening port
+     * numbers, ascending and de-duplicated, comma-separated - so a wired
+     * downstream device can act on the field instead of parsing prose.
+     */
+    static String listeningPorts(List<PortInfo> ports) {
+        return ports.stream()
+                .map(PortInfo::port)
+                .distinct()
+                .sorted()
+                .map(String::valueOf)
+                .collect(java.util.stream.Collectors.joining(","));
     }
 
     private void restartPoller() {

--- a/rack/src/main/java/org/nmox/studio/rack/devices/TestDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/TestDevice.java
@@ -156,10 +156,15 @@ public class TestDevice extends CommandDevice {
             default -> cmd.addAll(List.of("npm", "test"));
         }
         if (coverageSwitch.isOn()) {
-            switch (frameworkKnob.getSelectedOption()) {
+            // resolve AUTO first: keyed on the raw "auto" knob the flag never
+            // fired, so COVER did nothing in the default case even for jest/vitest
+            switch (effectiveFramework()) {
                 case "jest", "vitest" -> cmd.add("--coverage");
+                case "pytest" -> cmd.add("--cov");
                 default -> {
-                    // tool decides; coverage flag not portable
+                    // no portable coverage flag for this runner (mocha needs
+                    // nyc, cargo needs llvm-cov, go needs -coverprofile);
+                    // leave the command for the tool to decide
                 }
             }
         }

--- a/rack/src/test/java/org/nmox/studio/rack/devices/DeviceWiringTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/DeviceWiringTest.java
@@ -1,0 +1,161 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nmox.studio.rack.engine.FlightRecorder;
+import org.nmox.studio.rack.engine.PortScanner.PortInfo;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.Rack;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards that the device controls cleaned up in the wiring audit do
+ * what their faceplates claim: a knob/toggle that is read where it
+ * changes the command, and an OUT jack that actually carries a usable
+ * signal. These are the cases that looked wired but weren't.
+ */
+class DeviceWiringTest {
+
+    // ---- VERITAS: COVER must apply when AUTO resolves to a coverage-capable runner ----
+
+    @Test
+    @DisplayName("COVER adds --coverage when AUTO resolves to jest (the bug: it keyed on the raw knob)")
+    void coverageFiresOnAutoResolvedJest(@TempDir Path dir) throws IOException {
+        // a Node project whose only test framework is a jest dependency,
+        // no "test" script - so AUTO resolves to jest, not npm-script
+        Files.writeString(dir.resolve("package.json"),
+                "{\"devDependencies\":{\"jest\":\"^29\"}}");
+        Rack rack = new Rack();
+        rack.setProjectDir(dir.toFile());
+        TestDevice tests = new TestDevice();
+        tests.applyState(Map.of("coverage", "true")); // framework left on AUTO
+        rack.addDevice(tests);
+
+        assertThat(tests.buildCommand()).containsSubsequence("npx", "jest", "--coverage");
+        rack.shutdown();
+    }
+
+    @Test
+    @DisplayName("COVER adds --cov when AUTO resolves to pytest")
+    void coverageFiresOnAutoResolvedPytest(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("pyproject.toml"), "[project]\nname = \"demo\"\n");
+        Rack rack = new Rack();
+        rack.setProjectDir(dir.toFile());
+        TestDevice tests = new TestDevice();
+        tests.applyState(Map.of("coverage", "true"));
+        rack.addDevice(tests);
+
+        assertThat(tests.buildCommand()).contains("--cov");
+        rack.shutdown();
+    }
+
+    @Test
+    @DisplayName("COVER off leaves the command bare")
+    void coverageOffAddsNothing(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("package.json"),
+                "{\"devDependencies\":{\"jest\":\"^29\"}}");
+        Rack rack = new Rack();
+        rack.setProjectDir(dir.toFile());
+        TestDevice tests = new TestDevice();
+        rack.addDevice(tests);
+
+        assertThat(tests.buildCommand()).doesNotContain("--coverage");
+        rack.shutdown();
+    }
+
+    // ---- PING: POST/PUT must carry the body field; everything else stays body-less ----
+
+    @Test
+    @DisplayName("POST with a JSON body sends it with a JSON Content-Type")
+    void postCarriesJsonBody() {
+        HttpRequest r = HttpDevice.buildRequest("POST", "http://localhost:3000/api", "{\"a\":1}");
+        assertThat(r.method()).isEqualTo("POST");
+        assertThat(r.bodyPublisher()).isPresent();
+        assertThat(r.bodyPublisher().get().contentLength()).isGreaterThan(0);
+        assertThat(r.headers().firstValue("Content-Type")).hasValue("application/json");
+    }
+
+    @Test
+    @DisplayName("POST with a non-JSON body sends it without forcing a JSON Content-Type")
+    void postPlainBodyHasNoJsonHeader() {
+        HttpRequest r = HttpDevice.buildRequest("PUT", "http://localhost:3000/api", "hello=world");
+        assertThat(r.bodyPublisher().get().contentLength()).isGreaterThan(0);
+        assertThat(r.headers().firstValue("Content-Type")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("GET ignores any body; POST with a blank body sends none")
+    void readMethodsAndBlankBodiesAreBodyLess() {
+        HttpRequest get = HttpDevice.buildRequest("GET", "http://localhost:3000", "{\"a\":1}");
+        assertThat(get.bodyPublisher().get().contentLength()).isZero();
+
+        HttpRequest blank = HttpDevice.buildRequest("POST", "http://localhost:3000", "   ");
+        assertThat(blank.bodyPublisher().get().contentLength()).isZero();
+    }
+
+    // ---- SONAR: OUT must carry a machine-usable port list, not prose ----
+
+    @Test
+    @DisplayName("SONAR emits ports as a sorted, de-duplicated, comma-separated list")
+    void sonarEmitsMachineUsablePorts() {
+        List<PortInfo> ports = List.of(
+                new PortInfo(8080, 1, "node"),
+                new PortInfo(3000, 2, "node"),
+                new PortInfo(3000, 3, "other"), // duplicate port
+                new PortInfo(5173, 4, "vite"));
+        assertThat(SonarDevice.listeningPorts(ports)).isEqualTo("3000,5173,8080");
+    }
+
+    // ---- BLACKBOX: the OUT jack was declared but never emitted; now it taps the recorder ----
+
+    @Test
+    @DisplayName("BLACKBOX OUT broadcasts the newest flight-recorder event down the cable")
+    void blackboxEmitsRecorderEvents(@TempDir Path dir) throws InterruptedException {
+        Rack rack = new Rack();
+        rack.setProjectDir(dir.toFile());
+        BlackboxDevice blackbox = new BlackboxDevice();
+        Probe probe = new Probe();
+        rack.addDevice(blackbox);
+        rack.addDevice(probe);
+        rack.connect(blackbox.getPort("out"), probe.getPort("data"));
+
+        // a real recorder event (a launch line) notifies listeners
+        FlightRecorder.getDefault().line("FORGE", "$ npm run build", false);
+
+        assertThat(probe.hit.await(3, TimeUnit.SECONDS)).as("blackbox delivered an event").isTrue();
+        assertThat(probe.received).anyMatch(s -> s.contains("FORGE") && s.contains("LAUNCH"));
+        rack.shutdown();
+    }
+
+    /** Captures whatever is patched into it; the cable is delivered async. */
+    private static final class Probe extends RackDevice {
+        final ConcurrentLinkedQueue<String> received = new ConcurrentLinkedQueue<>();
+        final CountDownLatch hit = new CountDownLatch(1);
+
+        Probe() {
+            super("probe", "PROBE", "TEST PROBE", new Color(0, 0, 0), 1);
+            addInPort("data", "DATA", SignalType.DATA);
+        }
+
+        @Override
+        public void receive(Port in, Signal signal) {
+            received.add(in.getId() + ":" + signal.type() + ":" + signal.payload());
+            hit.countDown();
+        }
+    }
+}


### PR DESCRIPTION
A control-surface audit across all 33 rack devices — tracing every knob, toggle, button, IN port, and OUT port to its effect — found that **most of the fleet is genuinely wired**, but a handful of controls looked wired and weren't. This fixes those so they carry real signals and produce real results for web developers.

## Real bugs / dead wiring
- **VERITAS `COVER`** keyed coverage on the *raw* RUNNER knob, so in the default **AUTO** position (and anywhere AUTO resolved a framework) `--coverage` was never added — the switch was visibly on and did nothing. Now resolves AUTO first; jest/vitest get `--coverage`, pytest gets `--cov`.
- **BLACKBOX `OUT`** declared a DATA jack but had **zero `emit()` calls** — a cable you could draw that could never fire. Now broadcasts the newest flight-recorder entry (launch/exit/error) as it happens → wire it into MONITOR for a live log or into a notifier.
- **SONAR `OUT`** emitted the sentence `"sonar: N ports listening"`; nothing downstream could parse it. Now emits a sorted, de-duplicated, comma-separated port list.
- **FORGE `WATCH`** was a no-op in the esbuild position; esbuild now gets `--watch`.

## Real-results improvement
- **PING** POST/PUT sent `noBody()`, so you couldn't smoke-test an API with a payload. A new request-body field is sent on POST/PUT (JSON bodies get a `Content-Type: application/json`); reads and blank bodies stay body-less.

## Cleanup / honesty
- **NPM-9000** dropped two dead button fields (inlined as locals).
- **MAESTRO** STOP ALL docstring now matches what `panic()` actually does (halts command-backed devices), instead of implying it stops timer/listener-driven ones.

## Tests
- New `DeviceWiringTest` (8 cases) locks in the four behavioral fixes: COVER resolves AUTO before flagging coverage, PING's request builder carries a body only on write methods, SONAR's payload is machine-usable, and BLACKBOX's OUT jack delivers a recorder event down a real cable.
- Full `mvn verify` green across all 11 modules — SpotBugs, find-sec-bugs, and JaCoCo coverage floors all pass.

Devices audited and found already-correct (no changes): RUN, DEVSERVER, BENCH, PACKAGEMANAGER, ENV, ANGULAR, NEXT, PHOENIX, REFLEX, ROSETTA, DEPLOY, TUNNEL, DOCKER, DATABASE, DEBUG, TEMPO, GIT, BROWSER, CONSOLE, TERMINAL, PREFLIGHT, LINT, FORMAT, TYPECHECK, AUDIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)