### PR TITLE
feat(editor): format on save with Prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Format on save with Prettier.** Saving a JS/TS, CSS/SCSS/Less, HTML,
+  JSON, YAML, Markdown, Vue, GraphQL, Svelte, or Astro file now runs the
+  project's own Prettier over the buffer first — strictly opt-in twice
+  over: the IDE-wide toggle (Options → Editor → Format on Save, default
+  on) and the project's own Prettier config (any `.prettierrc*` /
+  `prettier.config.*` up the tree, or a package.json that mentions
+  prettier — monorepo roots count). The project-pinned
+  `node_modules/.bin/prettier` is preferred over a global install so
+  output matches CI. Failures never interrupt the save: a syntax error
+  mid-edit, a missing binary, or a hung process (5 s kill) all save the
+  buffer unchanged with a log line. The applied edit is the minimal
+  changed span, so the caret and scroll position survive the save.
+
+### Tests
+- `PrettierFormatterTest`: the opt-in walk (config names, package.json
+  mention, monorepo walk-past), local-binary preference, every failure
+  mode collapsing to "no change", and a real-process round trip through
+  the stdin/stdout runner. `FormatOnSaveTest`: minimal-edit correctness
+  on every shape of change (Positions survive a middle-of-file edit),
+  and mime coverage read from the generated layer — the artifact that
+  actually registers the hook.
+
 ## [1.9.0] — 2026-06-22
 
 Polyglot pipelines already compose as parallel *lanes* — one device chain per

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ files, GraphQL, Vue, Svelte, Astro, Pug, Handlebars, Liquid, nginx,
 Makefile, Protocol Buffers, Prisma, YAML, TOML, Dockerfile. First-class
 HTML, CSS, SCSS and Less with tag, attribute, value and property
 completion; LSP with ordered server fallbacks; a regex-aware JavaScript
-lexer; typing intelligence; comment-only spellcheck (your keys and values
+lexer; typing intelligence; **format on save with Prettier** (opt-in via
+the project's own Prettier config, project-pinned binary preferred, caret
+survives the save); comment-only spellcheck (your keys and values
 are never flagged as typos); a **Structure navigator** (⌘7) that outlines
 any file — classes, functions, tests, selectors, headings, config keys —
 and jumps to a symbol on click; and the NMOX Phosphor dark theme.

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-options-api</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-editor-mimelookup</artifactId>
             <version>${netbeans.version}</version>
         </dependency>

--- a/editor/src/main/java/org/nmox/studio/editor/format/FormatOnSave.java
+++ b/editor/src/main/java/org/nmox/studio/editor/format/FormatOnSave.java
@@ -1,0 +1,141 @@
+package org.nmox.studio.editor.format;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.editor.mimelookup.MimeRegistrations;
+import org.netbeans.modules.editor.NbEditorUtilities;
+import org.netbeans.spi.editor.document.OnSaveTask;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.NbPreferences;
+
+/**
+ * Format on save, the way every modern web editor does it: Ctrl+S runs
+ * the project's own Prettier over the buffer before the bytes hit disk.
+ * Strictly opt-in twice over — the IDE-wide toggle (Options → Editor →
+ * Format on Save, default on) and the project's own Prettier config;
+ * a project that never chose Prettier never gets rewritten.
+ *
+ * The replacement is the minimal edit between old and new text (common
+ * prefix and suffix stripped), so the caret and the scroll position
+ * survive the save instead of jumping to the top of the file.
+ */
+public final class FormatOnSave implements OnSaveTask {
+
+    private static final Logger LOG = Logger.getLogger(FormatOnSave.class.getName());
+
+    /** Preference key for the IDE-wide toggle; default is on. */
+    static final String PREF_ENABLED = "formatOnSave";
+
+    private final Document doc;
+    private volatile boolean cancelled;
+
+    FormatOnSave(Document doc) {
+        this.doc = doc;
+    }
+
+    @Override
+    public void performTask() {
+        if (cancelled || !isEnabled()) {
+            return;
+        }
+        FileObject fo = NbEditorUtilities.getFileObject(doc);
+        File file = fo == null ? null : FileUtil.toFile(fo);
+        if (file == null) {
+            return; // in-memory or virtual documents save as-is
+        }
+        String text;
+        try {
+            text = doc.getText(0, doc.getLength());
+        } catch (BadLocationException ex) {
+            return;
+        }
+        String formatted = new PrettierFormatter().format(text, file);
+        if (formatted == null || cancelled) {
+            return;
+        }
+        try {
+            applyMinimalEdit(doc, text, formatted);
+        } catch (BadLocationException ex) {
+            LOG.log(Level.WARNING, "format-on-save could not apply edit", ex);
+        }
+    }
+
+    @Override
+    public void runLocked(Runnable run) {
+        run.run();
+    }
+
+    @Override
+    public boolean cancel() {
+        cancelled = true;
+        return true;
+    }
+
+    static boolean isEnabled() {
+        return NbPreferences.forModule(FormatOnSave.class).getBoolean(PREF_ENABLED, true);
+    }
+
+    static void setEnabled(boolean enabled) {
+        NbPreferences.forModule(FormatOnSave.class).putBoolean(PREF_ENABLED, enabled);
+    }
+
+    /**
+     * Replaces only the span that actually changed: the longest common
+     * prefix and suffix stay untouched, so document Positions outside
+     * the span (carets, folds, annotations) keep their places.
+     */
+    static void applyMinimalEdit(Document doc, String before, String after)
+            throws BadLocationException {
+        if (before.equals(after)) {
+            return;
+        }
+        int minLength = Math.min(before.length(), after.length());
+        int prefix = 0;
+        while (prefix < minLength && before.charAt(prefix) == after.charAt(prefix)) {
+            prefix++;
+        }
+        int suffix = 0;
+        while (suffix < minLength - prefix
+                && before.charAt(before.length() - 1 - suffix)
+                == after.charAt(after.length() - 1 - suffix)) {
+            suffix++;
+        }
+        doc.remove(prefix, before.length() - suffix - prefix);
+        doc.insertString(prefix, after.substring(prefix, after.length() - suffix), null);
+    }
+
+    /**
+     * One factory per Prettier-formattable mime. Svelte and Astro ride
+     * along because their Prettier plugins are declared in the very
+     * config that opts the project in; without the plugin Prettier
+     * errors and the save proceeds untouched.
+     */
+    @MimeRegistrations({
+        @MimeRegistration(mimeType = "text/javascript", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/typescript", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/css", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-scss", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-less", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/html", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-json", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-yaml", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-markdown", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/markdown", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-vue", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-graphql", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-svelte", service = OnSaveTask.Factory.class, position = 400),
+        @MimeRegistration(mimeType = "text/x-astro", service = OnSaveTask.Factory.class, position = 400)
+    })
+    public static final class FactoryImpl implements OnSaveTask.Factory {
+
+        @Override
+        public OnSaveTask createTask(Context context) {
+            return new FormatOnSave(context.getDocument());
+        }
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/format/FormatOnSaveOptionsController.java
+++ b/editor/src/main/java/org/nmox/studio/editor/format/FormatOnSaveOptionsController.java
@@ -1,0 +1,106 @@
+package org.nmox.studio.editor.format;
+
+import java.awt.BorderLayout;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import org.netbeans.spi.options.OptionsPanelController;
+import org.openide.util.HelpCtx;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+
+/**
+ * Options → Editor → Format on Save: the one switch for the Prettier
+ * save hook. The heavy lifting (project opt-in, binary resolution)
+ * happens per save in {@link FormatOnSave}; this only flips the
+ * IDE-wide preference.
+ */
+@NbBundle.Messages({
+    "FormatOnSave_DisplayName=Format on Save",
+    "FormatOnSave_Keywords=format save prettier formatter"
+})
+@OptionsPanelController.SubRegistration(
+        location = "Editor",
+        displayName = "#FormatOnSave_DisplayName",
+        keywords = "#FormatOnSave_Keywords",
+        keywordsCategory = "Editor/FormatOnSave"
+)
+public class FormatOnSaveOptionsController extends OptionsPanelController {
+
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    private JPanel panel;
+    private JCheckBox enabled;
+
+    @Override
+    public void update() {
+        getPanel();
+        enabled.setSelected(FormatOnSave.isEnabled());
+    }
+
+    @Override
+    public void applyChanges() {
+        FormatOnSave.setEnabled(enabled.isSelected());
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public boolean isChanged() {
+        return enabled != null && enabled.isSelected() != FormatOnSave.isEnabled();
+    }
+
+    @Override
+    public JComponent getComponent(Lookup masterLookup) {
+        return getPanel();
+    }
+
+    private JPanel getPanel() {
+        if (panel != null) {
+            return panel;
+        }
+        enabled = new JCheckBox("Format files with Prettier on save");
+        JLabel detail = new JLabel("<html><i>Runs only in projects that opted into Prettier"
+                + " — a .prettierrc / prettier.config file or a package.json that mentions"
+                + " prettier. The project's own node_modules/.bin/prettier is preferred"
+                + " over a global install. Files that fail to format save unchanged.</i></html>");
+        JPanel column = new JPanel();
+        column.setLayout(new BoxLayout(column, BoxLayout.Y_AXIS));
+        enabled.setAlignmentX(JComponent.LEFT_ALIGNMENT);
+        detail.setAlignmentX(JComponent.LEFT_ALIGNMENT);
+        column.add(enabled);
+        column.add(Box.createVerticalStrut(8));
+        column.add(detail);
+        panel = new JPanel(new BorderLayout());
+        panel.setBorder(BorderFactory.createEmptyBorder(12, 12, 12, 12));
+        panel.add(column, BorderLayout.NORTH);
+        return panel;
+    }
+
+    @Override
+    public HelpCtx getHelpCtx() {
+        return HelpCtx.DEFAULT_HELP;
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener l) {
+        pcs.addPropertyChangeListener(l);
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener l) {
+        pcs.removePropertyChangeListener(l);
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/format/PrettierFormatter.java
+++ b/editor/src/main/java/org/nmox/studio/editor/format/PrettierFormatter.java
@@ -1,0 +1,193 @@
+package org.nmox.studio.editor.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.nmox.studio.rack.engine.ToolLocator;
+
+/**
+ * Pipes a document through Prettier the way the project itself would run
+ * it: only when the project has opted in (a Prettier config file anywhere
+ * up the directory tree, or a package.json that mentions prettier), and
+ * preferring the project's own node_modules/.bin/prettier over a global
+ * install so the output matches what the project pinned.
+ *
+ * Everything that can go wrong — no opt-in, no binary, a syntax error
+ * mid-edit, a hung process — degrades to "no change" and a log line,
+ * never a dialog. A formatter that interrupts typing is worse than none.
+ */
+public final class PrettierFormatter {
+
+    private static final Logger LOG = Logger.getLogger(PrettierFormatter.class.getName());
+
+    /** Documents beyond this size save unformatted rather than stall the save. */
+    static final int MAX_CHARS = 512_000;
+    /** A hung prettier is killed after this many milliseconds. */
+    static final long TIMEOUT_MS = 5_000;
+
+    /** Every filename Prettier recognizes as its own configuration. */
+    static final List<String> CONFIG_FILES = List.of(
+            ".prettierrc", ".prettierrc.json", ".prettierrc.yml", ".prettierrc.yaml",
+            ".prettierrc.json5", ".prettierrc.js", ".prettierrc.cjs", ".prettierrc.mjs",
+            ".prettierrc.toml", "prettier.config.js", "prettier.config.cjs",
+            "prettier.config.mjs");
+
+    /** Runs the external process; a seam so tests never need a real prettier. */
+    interface Runner {
+        Result run(List<String> command, File workDir, String stdin)
+                throws IOException, InterruptedException;
+    }
+
+    record Result(int exitCode, String stdout) {
+    }
+
+    private final Runner runner;
+
+    public PrettierFormatter() {
+        this(PrettierFormatter::exec);
+    }
+
+    PrettierFormatter(Runner runner) {
+        this.runner = runner;
+    }
+
+    /**
+     * The formatted text, or null whenever the save should proceed
+     * untouched: project not opted in, prettier absent, text already
+     * formatted, or any failure.
+     */
+    public String format(String text, File file) {
+        if (text.length() > MAX_CHARS) {
+            LOG.log(Level.FINE, "Skipping format-on-save, file too large: {0}", file);
+            return null;
+        }
+        File dir = file.getParentFile();
+        if (dir == null || !projectOptedIn(dir)) {
+            return null;
+        }
+        String binary = resolveBinary(dir);
+        if (binary == null) {
+            return null;
+        }
+        try {
+            Result result = runner.run(
+                    List.of(binary, "--stdin-filepath", file.getAbsolutePath()), dir, text);
+            if (result.exitCode() != 0) {
+                // usually a syntax error mid-edit: a normal condition, save as-is
+                LOG.log(Level.FINE, "prettier exited {0} for {1}",
+                        new Object[]{result.exitCode(), file});
+                return null;
+            }
+            String formatted = result.stdout();
+            return formatted.isEmpty() || formatted.equals(text) ? null : formatted;
+        } catch (IOException ex) {
+            LOG.log(Level.INFO, "prettier failed to run: {0}", ex.getMessage());
+            return null;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+    }
+
+    /**
+     * True when some directory from {@code startDir} upward carries a
+     * Prettier config file or a package.json that mentions prettier (a
+     * "prettier" options key or dependency). Walks past non-mentioning
+     * package.json files so a monorepo's root config still counts.
+     */
+    static boolean projectOptedIn(File startDir) {
+        for (File dir = startDir; dir != null; dir = dir.getParentFile()) {
+            for (String name : CONFIG_FILES) {
+                if (new File(dir, name).isFile()) {
+                    return true;
+                }
+            }
+            File packageJson = new File(dir, "package.json");
+            if (packageJson.isFile() && mentionsPrettier(packageJson)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A cheap textual test — a {@code "prettier"} key anywhere in
+     * package.json covers both the embedded-options form and a
+     * (dev)dependency, without parsing JSON on every save.
+     */
+    private static boolean mentionsPrettier(File packageJson) {
+        try {
+            return Files.readString(packageJson.toPath(), StandardCharsets.UTF_8)
+                    .contains("\"prettier\"");
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * The nearest node_modules/.bin/prettier walking up from
+     * {@code startDir}, falling back to a global install on the
+     * augmented PATH; null when neither exists.
+     */
+    static String resolveBinary(File startDir) {
+        String local = findLocalBinary(startDir);
+        if (local != null) {
+            return local;
+        }
+        String global = ToolLocator.resolve("prettier");
+        // ToolLocator returns the bare name unchanged when nothing was found
+        return global.contains(File.separator) ? global : null;
+    }
+
+    /** The project-pinned prettier, or null when no ancestor has one. */
+    static String findLocalBinary(File startDir) {
+        for (File dir = startDir; dir != null; dir = dir.getParentFile()) {
+            File bin = new File(dir, "node_modules/.bin/prettier");
+            if (bin.canExecute()) {
+                return bin.getAbsolutePath();
+            }
+            File cmd = new File(dir, "node_modules/.bin/prettier.cmd");
+            if (cmd.isFile()) {
+                return cmd.getAbsolutePath();
+            }
+        }
+        return null;
+    }
+
+    /** The real runner: stdout drained on its own thread, stdin fed, hard timeout. */
+    private static Result exec(List<String> command, File workDir, String stdin)
+            throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(workDir);
+        pb.environment().put("PATH", ToolLocator.augmentedPath());
+        pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+        Process process = pb.start();
+        AtomicReference<byte[]> output = new AtomicReference<>(new byte[0]);
+        Thread drain = new Thread(() -> {
+            try (InputStream in = process.getInputStream()) {
+                output.set(in.readAllBytes());
+            } catch (IOException ex) {
+                // process died; the exit code tells the story
+            }
+        }, "prettier-stdout");
+        drain.start();
+        try (OutputStream out = process.getOutputStream()) {
+            out.write(stdin.getBytes(StandardCharsets.UTF_8));
+        }
+        if (!process.waitFor(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly();
+            LOG.log(Level.INFO, "prettier timed out after {0} ms, killed", TIMEOUT_MS);
+            return new Result(-1, "");
+        }
+        drain.join(1_000);
+        return new Result(process.exitValue(), new String(output.get(), StandardCharsets.UTF_8));
+    }
+}

--- a/editor/src/main/java/org/nmox/studio/editor/format/PrettierFormatter.java
+++ b/editor/src/main/java/org/nmox/studio/editor/format/PrettierFormatter.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.nmox.studio.rack.engine.ProcessSupport;
 import org.nmox.studio.rack.engine.ToolLocator;
 
 /**
@@ -165,9 +166,11 @@ public final class PrettierFormatter {
     /** The real runner: stdout drained on its own thread, stdin fed, hard timeout. */
     private static Result exec(List<String> command, File workDir, String stdin)
             throws IOException, InterruptedException {
-        ProcessBuilder pb = new ProcessBuilder(command);
+        ProcessBuilder pb = ProcessSupport.builder(command);
         pb.directory(workDir);
-        pb.environment().put("PATH", ToolLocator.augmentedPath());
+        // the one departure from the hardened default: the document text
+        // goes down stdin instead of the null device
+        pb.redirectInput(ProcessBuilder.Redirect.PIPE);
         pb.redirectError(ProcessBuilder.Redirect.DISCARD);
         Process process = pb.start();
         AtomicReference<byte[]> output = new AtomicReference<>(new byte[0]);

--- a/editor/src/test/java/org/nmox/studio/editor/format/FormatOnSaveTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/format/FormatOnSaveTest.java
@@ -140,7 +140,8 @@ class FormatOnSaveTest {
                 "text/javascript", "text/typescript",
                 "text/css", "text/x-scss", "text/x-less",
                 "text/html", "text/x-json", "text/x-yaml",
-                "text/x-markdown", "text/x-vue", "text/x-graphql");
+                "text/x-markdown", "text/markdown", "text/x-vue", "text/x-graphql",
+                "text/x-svelte", "text/x-astro");
     }
 
     /** Collects Editors/&lt;mime&gt;/OnSave paths that register our factory. */

--- a/editor/src/test/java/org/nmox/studio/editor/format/FormatOnSaveTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/format/FormatOnSaveTest.java
@@ -1,0 +1,164 @@
+package org.nmox.studio.editor.format;
+
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.PlainDocument;
+import javax.swing.text.Position;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The minimal-edit apply is what keeps the caret in place across a
+ * save; these tests pin its correctness on every shape of change and
+ * the mime coverage of the on-save registration.
+ */
+class FormatOnSaveTest {
+
+    private static PlainDocument doc(String text) throws BadLocationException {
+        PlainDocument doc = new PlainDocument();
+        doc.insertString(0, text, null);
+        return doc;
+    }
+
+    private static String text(PlainDocument doc) throws BadLocationException {
+        return doc.getText(0, doc.getLength());
+    }
+
+    @Test
+    @DisplayName("A middle-of-file change leaves surrounding Positions untouched")
+    void middleChangeKeepsPositions() throws BadLocationException {
+        PlainDocument doc = doc("aaa MIDDLE zzz");
+        Position beforeChange = doc.createPosition(2);   // inside 'aaa'
+        Position afterChange = doc.createPosition(12);   // inside 'zzz'
+
+        FormatOnSave.applyMinimalEdit(doc, "aaa MIDDLE zzz", "aaa CENTER zzz");
+
+        assertThat(text(doc)).isEqualTo("aaa CENTER zzz");
+        assertThat(beforeChange.getOffset()).isEqualTo(2);
+        assertThat(afterChange.getOffset()).isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("Pure insertion and pure deletion both apply cleanly")
+    void insertionAndDeletion() throws BadLocationException {
+        PlainDocument doc = doc("const x=1\n");
+        FormatOnSave.applyMinimalEdit(doc, "const x=1\n", "const x = 1;\n");
+        assertThat(text(doc)).isEqualTo("const x = 1;\n");
+
+        PlainDocument shrink = doc("a  =  1");
+        FormatOnSave.applyMinimalEdit(shrink, "a  =  1", "a = 1");
+        assertThat(text(shrink)).isEqualTo("a = 1");
+    }
+
+    @Test
+    @DisplayName("Identical text is a strict no-op — no remove, no insert, no undo entry")
+    void identicalTextIsNoOp() throws BadLocationException {
+        PlainDocument doc = doc("same");
+        boolean[] mutated = {false};
+        doc.addDocumentListener(new javax.swing.event.DocumentListener() {
+            @Override
+            public void insertUpdate(javax.swing.event.DocumentEvent e) {
+                mutated[0] = true;
+            }
+
+            @Override
+            public void removeUpdate(javax.swing.event.DocumentEvent e) {
+                mutated[0] = true;
+            }
+
+            @Override
+            public void changedUpdate(javax.swing.event.DocumentEvent e) {
+            }
+        });
+
+        FormatOnSave.applyMinimalEdit(doc, "same", "same");
+
+        assertThat(mutated[0]).isFalse();
+    }
+
+    @Test
+    @DisplayName("Overlapping prefix and suffix (aaa → aa) does not double-count shared chars")
+    void overlappingPrefixSuffix() throws BadLocationException {
+        PlainDocument doc = doc("aaa");
+        FormatOnSave.applyMinimalEdit(doc, "aaa", "aa");
+        assertThat(text(doc)).isEqualTo("aa");
+
+        PlainDocument grow = doc("aa");
+        FormatOnSave.applyMinimalEdit(grow, "aa", "aaa");
+        assertThat(text(grow)).isEqualTo("aaa");
+    }
+
+    @Test
+    @DisplayName("A complete rewrite still lands exactly")
+    void completeRewrite() throws BadLocationException {
+        PlainDocument doc = doc("entirely old content");
+        FormatOnSave.applyMinimalEdit(doc, "entirely old content", "brand new");
+        assertThat(text(doc)).isEqualTo("brand new");
+    }
+
+    @Test
+    @DisplayName("Empty-to-text and text-to-empty are handled")
+    void emptyEdges() throws BadLocationException {
+        PlainDocument doc = doc("");
+        FormatOnSave.applyMinimalEdit(doc, "", "content\n");
+        assertThat(text(doc)).isEqualTo("content\n");
+
+        PlainDocument drain = doc("gone");
+        FormatOnSave.applyMinimalEdit(drain, "gone", "");
+        assertThat(text(drain)).isEmpty();
+    }
+
+    /**
+     * Reads the annotation-processor-generated layer rather than the
+     * (source-retention) annotations: this is the artifact the platform
+     * actually loads, and the one that silently vanishes when annotation
+     * processing is misconfigured.
+     */
+    @Test
+    @DisplayName("The save hook is registered for every Prettier-formattable mime the IDE edits")
+    void mimeCoverage() throws Exception {
+        Set<String> mimes = new HashSet<>();
+        try (InputStream layer = FormatOnSave.class
+                .getResourceAsStream("/META-INF/generated-layer.xml")) {
+            assertThat(layer).as("generated-layer.xml must exist (annotation processing ran)")
+                    .isNotNull();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            collectOnSaveMimes(dbf.newDocumentBuilder().parse(layer).getDocumentElement(),
+                    "", mimes);
+        }
+
+        assertThat(mimes).contains(
+                "text/javascript", "text/typescript",
+                "text/css", "text/x-scss", "text/x-less",
+                "text/html", "text/x-json", "text/x-yaml",
+                "text/x-markdown", "text/x-vue", "text/x-graphql");
+    }
+
+    /** Collects Editors/&lt;mime&gt;/OnSave paths that register our factory. */
+    private static void collectOnSaveMimes(Element element, String path, Set<String> mimes) {
+        NodeList children = element.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (!(child instanceof Element el)) {
+                continue;
+            }
+            if ("folder".equals(el.getTagName())) {
+                collectOnSaveMimes(el, path + "/" + el.getAttribute("name"), mimes);
+            } else if ("file".equals(el.getTagName())
+                    && el.getAttribute("name").contains("FormatOnSave")
+                    && path.startsWith("/Editors/") && path.endsWith("/OnSave")) {
+                mimes.add(path.substring("/Editors/".length(),
+                        path.length() - "/OnSave".length()));
+            }
+        }
+    }
+}

--- a/editor/src/test/java/org/nmox/studio/editor/format/PrettierFormatterTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/format/PrettierFormatterTest.java
@@ -1,0 +1,205 @@
+package org.nmox.studio.editor.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The formatter's promise is "the project's prettier, or nothing":
+ * these tests pin the opt-in walk, the local-binary preference, and
+ * every failure mode collapsing to null (save proceeds untouched).
+ */
+class PrettierFormatterTest {
+
+    @TempDir
+    Path root;
+
+    // ---- opt-in detection --------------------------------------------------
+
+    @Test
+    @DisplayName("A .prettierrc anywhere up the tree opts the project in")
+    void configFileOptsIn() throws IOException {
+        Files.createFile(root.resolve(".prettierrc"));
+        Path nested = Files.createDirectories(root.resolve("src/components"));
+
+        assertThat(PrettierFormatter.projectOptedIn(nested.toFile())).isTrue();
+    }
+
+    @Test
+    @DisplayName("prettier.config.mjs counts too — every documented config name does")
+    void modernConfigNamesCount() throws IOException {
+        for (String name : PrettierFormatter.CONFIG_FILES) {
+            Path dir = Files.createDirectories(root.resolve("case-" + name.replace('.', '_')));
+            Files.createFile(dir.resolve(name));
+            assertThat(PrettierFormatter.projectOptedIn(dir.toFile()))
+                    .as("config file %s should opt the project in", name)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("package.json mentioning prettier (dep or options key) opts in")
+    void packageJsonOptsIn() throws IOException {
+        Files.writeString(root.resolve("package.json"),
+                "{ \"devDependencies\": { \"prettier\": \"^3.3.0\" } }");
+
+        assertThat(PrettierFormatter.projectOptedIn(root.toFile())).isTrue();
+    }
+
+    @Test
+    @DisplayName("A nested package.json without prettier does not stop the walk to a root config")
+    void monorepoWalksPastSilentPackageJson() throws IOException {
+        Files.createFile(root.resolve(".prettierrc.json"));
+        Path pkg = Files.createDirectories(root.resolve("packages/web"));
+        Files.writeString(pkg.resolve("package.json"), "{ \"name\": \"web\" }");
+
+        assertThat(PrettierFormatter.projectOptedIn(pkg.toFile())).isTrue();
+    }
+
+    @Test
+    @DisplayName("No config and no prettier mention anywhere: not opted in")
+    void bareProjectIsNotOptedIn() throws IOException {
+        Path dir = Files.createDirectories(root.resolve("plain"));
+        Files.writeString(dir.resolve("package.json"), "{ \"name\": \"plain\" }");
+
+        // the walk continues above the temp dir; a stray config there would be
+        // a test-environment accident, not something this repo can create
+        assertThat(PrettierFormatter.projectOptedIn(dir.toFile())).isFalse();
+    }
+
+    // ---- binary resolution -------------------------------------------------
+
+    @Test
+    @DisplayName("The nearest node_modules/.bin/prettier wins, found from a nested dir")
+    void localBinaryPreferred() throws IOException {
+        Path bin = Files.createDirectories(root.resolve("node_modules/.bin"));
+        Path prettier = Files.createFile(bin.resolve("prettier"));
+        assertThat(prettier.toFile().setExecutable(true)).isTrue();
+        Path nested = Files.createDirectories(root.resolve("src/deep"));
+
+        assertThat(PrettierFormatter.findLocalBinary(nested.toFile()))
+                .isEqualTo(prettier.toFile().getAbsolutePath());
+    }
+
+    @Test
+    @DisplayName("No local install anywhere up the tree: findLocalBinary is null")
+    void noLocalBinary() {
+        assertThat(PrettierFormatter.findLocalBinary(root.toFile())).isNull();
+    }
+
+    // ---- the format run ----------------------------------------------------
+
+    private PrettierFormatter withStub(List<List<String>> commands, PrettierFormatter.Result result)
+            throws IOException {
+        Files.createFile(root.resolve(".prettierrc"));
+        Path bin = Files.createDirectories(root.resolve("node_modules/.bin"));
+        File prettier = bin.resolve("prettier").toFile();
+        Files.createFile(prettier.toPath());
+        assertThat(prettier.setExecutable(true)).isTrue();
+        return new PrettierFormatter((command, workDir, stdin) -> {
+            commands.add(command);
+            return result;
+        });
+    }
+
+    @Test
+    @DisplayName("Happy path: formatted text comes back, invoked as prettier --stdin-filepath <file>")
+    void formatsThroughStdin() throws IOException {
+        List<List<String>> commands = new ArrayList<>();
+        PrettierFormatter formatter =
+                withStub(commands, new PrettierFormatter.Result(0, "const x = 1;\n"));
+        File file = root.resolve("index.js").toFile();
+
+        String out = formatter.format("const x=1", file);
+
+        assertThat(out).isEqualTo("const x = 1;\n");
+        assertThat(commands).hasSize(1);
+        assertThat(commands.get(0).get(0)).endsWith("prettier");
+        assertThat(commands.get(0)).containsSequence("--stdin-filepath", file.getAbsolutePath());
+    }
+
+    @Test
+    @DisplayName("Already-formatted text returns null so the save writes nothing new")
+    void unchangedTextIsNull() throws IOException {
+        PrettierFormatter formatter =
+                withStub(new ArrayList<>(), new PrettierFormatter.Result(0, "const x = 1;\n"));
+
+        assertThat(formatter.format("const x = 1;\n", root.resolve("a.js").toFile())).isNull();
+    }
+
+    @Test
+    @DisplayName("A non-zero exit (syntax error mid-edit) is a quiet no-op")
+    void syntaxErrorIsQuiet() throws IOException {
+        PrettierFormatter formatter =
+                withStub(new ArrayList<>(), new PrettierFormatter.Result(2, ""));
+
+        assertThat(formatter.format("const const", root.resolve("a.js").toFile())).isNull();
+    }
+
+    @Test
+    @DisplayName("A runner that throws IOException degrades to null, not an exception")
+    void ioFailureIsQuiet() throws IOException {
+        Files.createFile(root.resolve(".prettierrc"));
+        Path bin = Files.createDirectories(root.resolve("node_modules/.bin"));
+        File prettier = bin.resolve("prettier").toFile();
+        Files.createFile(prettier.toPath());
+        assertThat(prettier.setExecutable(true)).isTrue();
+        PrettierFormatter formatter = new PrettierFormatter((command, workDir, stdin) -> {
+            throw new IOException("boom");
+        });
+
+        assertThat(formatter.format("x", root.resolve("a.js").toFile())).isNull();
+    }
+
+    @Test
+    @DisplayName("A project that never opted in never spawns a process")
+    void noOptInNoProcess() {
+        AtomicInteger runs = new AtomicInteger();
+        PrettierFormatter formatter = new PrettierFormatter((command, workDir, stdin) -> {
+            runs.incrementAndGet();
+            return new PrettierFormatter.Result(0, "formatted");
+        });
+
+        assertThat(formatter.format("x", root.resolve("a.js").toFile())).isNull();
+        assertThat(runs).hasValue(0);
+    }
+
+    @Test
+    @DisplayName("The real process runner feeds stdin and drains stdout (fake prettier script)")
+    @org.junit.jupiter.api.condition.DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
+    void realRunnerRoundTrip() throws IOException {
+        Files.createFile(root.resolve(".prettierrc"));
+        Path bin = Files.createDirectories(root.resolve("node_modules/.bin"));
+        Path script = bin.resolve("prettier");
+        Files.writeString(script, "#!/bin/sh\ntr 'a-z' 'A-Z'\n");
+        assertThat(script.toFile().setExecutable(true)).isTrue();
+
+        String out = new PrettierFormatter().format("shout", root.resolve("a.js").toFile());
+
+        assertThat(out).isEqualTo("SHOUT");
+    }
+
+    @Test
+    @DisplayName("Oversized documents skip formatting rather than stall the save")
+    void oversizedDocumentSkips() throws IOException {
+        AtomicInteger runs = new AtomicInteger();
+        Files.createFile(root.resolve(".prettierrc"));
+        PrettierFormatter formatter = new PrettierFormatter((command, workDir, stdin) -> {
+            runs.incrementAndGet();
+            return new PrettierFormatter.Result(0, "formatted");
+        });
+
+        String huge = "x".repeat(PrettierFormatter.MAX_CHARS + 1);
+        assertThat(formatter.format(huge, root.resolve("a.js").toFile())).isNull();
+        assertThat(runs).hasValue(0);
+    }
+}


### PR DESCRIPTION
## What

Saving a JS/TS, CSS/SCSS/Less, HTML, JSON, YAML, Markdown, Vue, GraphQL, Svelte, or Astro file now runs the project's own Prettier over the buffer before the bytes hit disk.

## Design

- **Opt-in twice over.** The IDE-wide toggle (Options → Editor → Format on Save, default on) *and* the project's own Prettier config — any `.prettierrc*` / `prettier.config.*` up the directory tree, or a `package.json` that mentions prettier (monorepo roots count: the walk continues past a nested package.json that doesn't mention it). A project that never chose Prettier never gets rewritten.
- **The project's Prettier, not ours.** The nearest `node_modules/.bin/prettier` wins over a global install, so the editor's output matches what the project's CI produces.
- **Failure never interrupts a save.** Syntax error mid-edit, missing binary, hung process (killed at 5 s), oversized file (>512 KB) — all save the buffer unchanged with a log line, never a dialog.
- **The caret survives.** The applied edit is the minimal changed span (common prefix/suffix stripped), so caret, scroll position, folds and annotations keep their places instead of jumping to the top of the file.

## Implementation

- `PrettierFormatter` — opt-in walk, binary resolution, and a `Runner` seam so tests never need a real prettier; the real runner drains stdout on its own thread and enforces the timeout.
- `FormatOnSave` — `OnSaveTask` registered per mime (position 400, ahead of the platform's reformat task); minimal-edit apply.
- `FormatOnSaveOptionsController` — the toggle under Options → Editor.

## Tests

21 new tests: the opt-in walk (every documented config name, package.json mention, monorepo walk-past), local-binary preference, every failure mode collapsing to "no change", a real-process stdin/stdout round trip through a fake prettier script, minimal-edit correctness on every shape of change (Swing `Position`s survive a middle-of-file edit), and mime coverage read from the **generated layer** — the artifact that actually registers the hook, and the one that silently vanishes when annotation processing is misconfigured.

`mvn verify -pl editor` green: SpotBugs + find-sec-bugs 0 findings, JaCoCo floor met. Full `mvn clean package` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)