### PR TITLE
fix(editor): stop the Prettier opt-in walk at the repository boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,39 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.10.0] — 2026-07-01
 
 ### Added
 - **Format on save with Prettier.** Saving a JS/TS, CSS/SCSS/Less, HTML,
   JSON, YAML, Markdown, Vue, GraphQL, Svelte, or Astro file now runs the
-  project's own Prettier over the buffer first — strictly opt-in twice
-  over: the IDE-wide toggle (Options → Editor → Format on Save, default
-  on) and the project's own Prettier config (any `.prettierrc*` /
-  `prettier.config.*` up the tree, or a package.json that mentions
-  prettier — monorepo roots count). The project-pinned
-  `node_modules/.bin/prettier` is preferred over a global install so
-  output matches CI. Failures never interrupt the save: a syntax error
+  project's own Prettier over the buffer first. **Upgrading users get
+  format-on-save automatically in any project containing a Prettier
+  config; disable via Options → Editor → Format on Save.** The effective
+  gate is the project's own opt-in: any `.prettierrc*` /
+  `prettier.config.*` or a package.json that mentions prettier, searched
+  from the saved file up to the repository root (`.git`) and no further —
+  monorepo roots count, a personal `~/.prettierrc` above the checkout
+  does not. The project-pinned `node_modules/.bin/prettier` is preferred
+  over a global install so output matches CI, resolved within the same
+  repository boundary. Failures never interrupt the save: a syntax error
   mid-edit, a missing binary, or a hung process (5 s kill) all save the
   buffer unchanged with a log line. The applied edit is the minimal
   changed span, so the caret and scroll position survive the save.
+  Measured cost per save (prettier 3.9.4, M-series Mac): ~145 ms on a
+  300-line file, ~410 ms on a 3,600-line/392 KB one; files over 512 KB
+  skip formatting entirely.
 
 ### Tests
 - `PrettierFormatterTest`: the opt-in walk (config names, package.json
-  mention, monorepo walk-past), local-binary preference, every failure
-  mode collapsing to "no change", and a real-process round trip through
-  the stdin/stdout runner. `FormatOnSaveTest`: minimal-edit correctness
-  on every shape of change (Positions survive a middle-of-file edit),
-  and mime coverage read from the generated layer — the artifact that
-  actually registers the hook.
+  mention, monorepo walk-past, the repository boundary — configs and
+  node_modules above `.git` don't count, a config at the repo root
+  does, a `.git` *file* bounds like a directory), local-binary
+  preference, every failure mode collapsing to "no change", and a
+  real-process round trip through the stdin/stdout runner.
+  `FormatOnSaveTest`: minimal-edit correctness on every shape of change
+  (Positions survive a middle-of-file edit), and mime coverage read
+  from the generated layer — the artifact that actually registers the
+  hook.
 
 ## [1.9.0] — 2026-06-22
 

--- a/editor/src/main/java/org/nmox/studio/editor/format/PrettierFormatter.java
+++ b/editor/src/main/java/org/nmox/studio/editor/format/PrettierFormatter.java
@@ -99,10 +99,13 @@ public final class PrettierFormatter {
     }
 
     /**
-     * True when some directory from {@code startDir} upward carries a
-     * Prettier config file or a package.json that mentions prettier (a
-     * "prettier" options key or dependency). Walks past non-mentioning
-     * package.json files so a monorepo's root config still counts.
+     * True when some directory from {@code startDir} up to the repository
+     * root carries a Prettier config file or a package.json that mentions
+     * prettier (a "prettier" options key or dependency). Walks past
+     * non-mentioning package.json files so a monorepo's root config still
+     * counts, but never past the first {@code .git} — a personal
+     * ~/.prettierrc or a stray package.json above the checkout is not the
+     * project opting in.
      */
     static boolean projectOptedIn(File startDir) {
         for (File dir = startDir; dir != null; dir = dir.getParentFile()) {
@@ -115,8 +118,16 @@ public final class PrettierFormatter {
             if (packageJson.isFile() && mentionsPrettier(packageJson)) {
                 return true;
             }
+            if (isRepositoryRoot(dir)) {
+                return false;
+            }
         }
         return false;
+    }
+
+    /** {@code .git} is a directory in a checkout, a file in worktrees and submodules. */
+    private static boolean isRepositoryRoot(File dir) {
+        return new File(dir, ".git").exists();
     }
 
     /**
@@ -148,7 +159,11 @@ public final class PrettierFormatter {
         return global.contains(File.separator) ? global : null;
     }
 
-    /** The project-pinned prettier, or null when no ancestor has one. */
+    /**
+     * The project-pinned prettier, or null when no ancestor inside the
+     * repository has one — the same boundary as the opt-in walk, so the
+     * binary that runs always belongs to the checkout that opted in.
+     */
     static String findLocalBinary(File startDir) {
         for (File dir = startDir; dir != null; dir = dir.getParentFile()) {
             File bin = new File(dir, "node_modules/.bin/prettier");
@@ -158,6 +173,9 @@ public final class PrettierFormatter {
             File cmd = new File(dir, "node_modules/.bin/prettier.cmd");
             if (cmd.isFile()) {
                 return cmd.getAbsolutePath();
+            }
+            if (isRepositoryRoot(dir)) {
+                return null;
             }
         }
         return null;

--- a/editor/src/test/java/org/nmox/studio/editor/format/PrettierFormatterTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/format/PrettierFormatterTest.java
@@ -76,7 +76,51 @@ class PrettierFormatterTest {
         assertThat(PrettierFormatter.projectOptedIn(dir.toFile())).isFalse();
     }
 
+    @Test
+    @DisplayName("A config above the repository boundary (.git) does not opt the project in")
+    void configAboveRepoBoundaryDoesNotCount() throws IOException {
+        Files.createFile(root.resolve(".prettierrc")); // e.g. a personal ~/.prettierrc
+        Path repo = Files.createDirectories(root.resolve("repo"));
+        Files.createDirectories(repo.resolve(".git"));
+        Path src = Files.createDirectories(repo.resolve("src"));
+
+        assertThat(PrettierFormatter.projectOptedIn(src.toFile())).isFalse();
+    }
+
+    @Test
+    @DisplayName("A config at the repository root itself opts in — the boundary is inclusive")
+    void configAtRepoRootCounts() throws IOException {
+        Path repo = Files.createDirectories(root.resolve("repo"));
+        Files.createDirectories(repo.resolve(".git"));
+        Files.createFile(repo.resolve(".prettierrc"));
+        Path src = Files.createDirectories(repo.resolve("src"));
+
+        assertThat(PrettierFormatter.projectOptedIn(src.toFile())).isTrue();
+    }
+
+    @Test
+    @DisplayName("A .git file (worktree/submodule) bounds the walk just like a .git directory")
+    void gitFileBoundsWalkToo() throws IOException {
+        Files.createFile(root.resolve(".prettierrc"));
+        Path worktree = Files.createDirectories(root.resolve("wt"));
+        Files.writeString(worktree.resolve(".git"), "gitdir: ../repo/.git/worktrees/wt\n");
+
+        assertThat(PrettierFormatter.projectOptedIn(worktree.toFile())).isFalse();
+    }
+
     // ---- binary resolution -------------------------------------------------
+
+    @Test
+    @DisplayName("A node_modules above the repository boundary is not the project's binary")
+    void localBinaryStopsAtRepoBoundary() throws IOException {
+        Path bin = Files.createDirectories(root.resolve("node_modules/.bin"));
+        Path stray = Files.createFile(bin.resolve("prettier"));
+        assertThat(stray.toFile().setExecutable(true)).isTrue();
+        Path repo = Files.createDirectories(root.resolve("repo"));
+        Files.createDirectories(repo.resolve(".git"));
+
+        assertThat(PrettierFormatter.findLocalBinary(repo.toFile())).isNull();
+    }
 
     @Test
     @DisplayName("The nearest node_modules/.bin/prettier wins, found from a nested dir")


### PR DESCRIPTION
## What

Pre-release audit of format-on-save's default-on behavior found the config walk overreaching: it continued past the repository boundary to the filesystem root, so a personal `~/.prettierrc` (or any ancestor package.json mentioning prettier) would silently opt in every project beneath it.

## Fix

Both walks — config detection and `node_modules/.bin/prettier` resolution — now stop at the first `.git`, checked inclusively:

- a monorepo root's config still counts (boundary dir is checked before stopping)
- `.git` as a *file* (worktrees, submodules) bounds like a directory
- a non-git folder keeps walk-to-root, matching Prettier's own config resolution

Also finalizes the 1.10.0 CHANGELOG entry: the plain upgrade statement ("Upgrading users get format-on-save automatically in any project containing a Prettier config; disable via Options → Editor → Format on Save") and measured latency (~145 ms on a 300-line file, ~410 ms on a 3,600-line/392 KB file, prettier 3.9.4; >512 KB skips formatting).

## Tests

4 new: config above `.git` doesn't opt in, config at the repo root does, `.git`-file bounds the walk, stray `node_modules` above the boundary isn't the project's binary. `mvn verify -pl editor`: 194 tests, SpotBugs 0, JaCoCo floor met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)