### PR TITLE
fix(editor): markdown spellcheck reads prose, not code

### DIFF
--- a/editor/src/main/java/org/nmox/studio/editor/spell/CodeSpellTokenListProvider.java
+++ b/editor/src/main/java/org/nmox/studio/editor/spell/CodeSpellTokenListProvider.java
@@ -1,5 +1,6 @@
 package org.nmox.studio.editor.spell;
 
+import java.util.function.Predicate;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -75,24 +76,26 @@ public class CodeSpellTokenListProvider implements TokenListProvider {
 
     @Override
     public TokenList findTokenList(Document doc) {
-        return new CommentWordsTokenList(doc);
+        return new FilteredWordsTokenList(doc, CodeSpellTokenListProvider::isComment);
     }
 
     /**
      * Walks the document's token stream and yields only words that live
-     * inside comment tokens. Detection is lexer-agnostic: a token counts
-     * as comment when its id's primary category mentions "comment" (our
-     * JS/TS lexer) or any of its TextMate scopes do.
+     * inside tokens the filter accepts — comments for code files, prose
+     * for markdown. The word scan itself is shared; only the notion of
+     * "spellcheckable token" differs per provider.
      */
-    static final class CommentWordsTokenList implements TokenList {
+    static final class FilteredWordsTokenList implements TokenList {
 
         private final Document doc;
+        private final Predicate<Token<?>> spellcheckable;
         private int offset;
         private int wordStart;
         private CharSequence wordText;
 
-        CommentWordsTokenList(Document doc) {
+        FilteredWordsTokenList(Document doc, Predicate<Token<?>> spellcheckable) {
             this.doc = doc;
+            this.spellcheckable = spellcheckable;
         }
 
         @Override
@@ -122,7 +125,7 @@ public class CodeSpellTokenListProvider implements TokenListProvider {
             ts.move(offset);
             while (ts.moveNext()) {
                 Token<?> token = ts.token();
-                if (!isComment(token)) {
+                if (!spellcheckable.test(token)) {
                     continue;
                 }
                 CharSequence text = token.text();
@@ -147,15 +150,6 @@ public class CodeSpellTokenListProvider implements TokenListProvider {
             return false;
         }
 
-        private static boolean isComment(Token<?> token) {
-            // TextMate tokens carry a single id (TEXTMATE); the real scope
-            // stack lives in the "categories" property (a List of scope
-            // names like "comment.line.number-sign.ini"). The custom JS/TS
-            // lexer instead names the category "comment" on the id itself.
-            return isCommentScope(token.id().primaryCategory(),
-                    token.getProperty("categories"));
-        }
-
         @Override
         public int getCurrentWordStartOffset() {
             return wordStart;
@@ -173,6 +167,16 @@ public class CodeSpellTokenListProvider implements TokenListProvider {
         @Override
         public void removeChangeListener(ChangeListener l) {
         }
+    }
+
+    /**
+     * TextMate tokens carry a single id (TEXTMATE); the real scope stack
+     * lives in the "categories" property. The custom JS/TS lexer instead
+     * names the category "comment" on the id itself.
+     */
+    private static boolean isComment(Token<?> token) {
+        return isCommentScope(token.id().primaryCategory(),
+                token.getProperty("categories"));
     }
 
     /**

--- a/editor/src/main/java/org/nmox/studio/editor/spell/MarkdownSpellTokenListProvider.java
+++ b/editor/src/main/java/org/nmox/studio/editor/spell/MarkdownSpellTokenListProvider.java
@@ -1,0 +1,59 @@
+package org.nmox.studio.editor.spell;
+
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.editor.mimelookup.MimeRegistrations;
+import org.netbeans.api.lexer.Token;
+import org.netbeans.modules.spellchecker.spi.language.TokenList;
+import org.netbeans.modules.spellchecker.spi.language.TokenListProvider;
+
+/**
+ * Spellcheck for markdown the way it should read: prose is checked, code
+ * is not. Without this the platform treats the whole document as prose,
+ * so every identifier inside a fenced block — const, useState, npm — is
+ * flagged as a typo, and so is every URL.
+ *
+ * A token is prose unless its TextMate scope stack says otherwise:
+ * fenced and indented code blocks (markup.fenced_code / markup.raw,
+ * which also covers YAML front matter), inline code spans
+ * (markup.inline.raw), link destinations (markup.underline.link), and
+ * any embedded language (source.*) are all excluded.
+ */
+@MimeRegistrations({
+    // position 100: must sort ahead of the platform markdown module's
+    // PlainTokenListProvider (registered without a position), because the
+    // spellchecker takes the first provider that returns a token list
+    @MimeRegistration(mimeType = "text/x-markdown", service = TokenListProvider.class, position = 100),
+    @MimeRegistration(mimeType = "text/markdown", service = TokenListProvider.class, position = 100)
+})
+public class MarkdownSpellTokenListProvider implements TokenListProvider {
+
+    @Override
+    public TokenList findTokenList(Document doc) {
+        return new CodeSpellTokenListProvider.FilteredWordsTokenList(
+                doc, MarkdownSpellTokenListProvider::isProse);
+    }
+
+    private static boolean isProse(Token<?> token) {
+        return isProseScope(token.getProperty("categories"));
+    }
+
+    /**
+     * Whether a markdown token is prose the spellchecker should read.
+     * {@code categoriesProperty} is the TextMate scope stack (a List
+     * whose toString looks like "[text.html.markdown,
+     * markup.fenced_code.block.markdown, source.js]"); a null stack is
+     * plain paragraph text, which is prose.
+     */
+    static boolean isProseScope(Object categoriesProperty) {
+        if (categoriesProperty == null) {
+            return true;
+        }
+        String stack = categoriesProperty.toString();
+        return !(stack.contains("markup.fenced_code")
+                || stack.contains("markup.raw")
+                || stack.contains("markup.inline.raw")
+                || stack.contains("markup.underline.link")
+                || stack.contains("source."));
+    }
+}

--- a/editor/src/main/resources/org/nmox/studio/editor/layer.xml
+++ b/editor/src/main/resources/org/nmox/studio/editor/layer.xml
@@ -38,6 +38,21 @@
         </folder>
     </folder>
     
+    <!-- The platform's markdown module wires the spellchecker's
+         whole-file PlainTokenListProvider to text/markdown, which flags
+         every identifier in fenced/inline code as a typo. Our
+         MarkdownSpellTokenListProvider (prose-only) replaces it; hide
+         the plain one so the two are never combined. -->
+    <folder name="Editors">
+        <folder name="text">
+            <folder name="markdown">
+                <folder name="TokenListProvider">
+                    <file name="org-netbeans-modules-spellchecker-plain-PlainTokenListProvider.instance_hidden"/>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
+
     <!-- Lexer language bindings + token coloring. The language.instance
          entries are what make syntax highlighting actually happen: they
          hand the editor infrastructure our Language for each MIME type.

--- a/editor/src/test/java/org/nmox/studio/editor/spell/MarkdownSpellTokenListProviderTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/spell/MarkdownSpellTokenListProviderTest.java
@@ -1,0 +1,85 @@
+package org.nmox.studio.editor.spell;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Markdown spellcheck reads prose and skips code. The scope stacks here
+ * are the ones the platform's markdown grammar
+ * (org-netbeans-modules-markdown, text.html.markdown) actually emits for
+ * a README's parts — the exact fixture that surfaced the bug was a
+ * fenced ```js block whose `const` was squiggled as a typo.
+ */
+class MarkdownSpellTokenListProviderTest {
+
+    private static Object stack(String... scopes) {
+        return List.of(scopes);
+    }
+
+    @Test
+    @DisplayName("Prose is checked: paragraphs, headings, emphasis, quotes, list items")
+    void proseIsChecked() {
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(null)).isTrue();
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "meta.paragraph.markdown"))).isTrue();
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.heading.markdown",
+                        "entity.name.section.markdown"))).isTrue();
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.bold.markdown"))).isTrue();
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.quote.markdown"))).isTrue();
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.list.unnumbered.markdown"))).isTrue();
+    }
+
+    @Test
+    @DisplayName("Fenced code blocks are not prose — the ```js const that started this")
+    void fencedCodeIsSkipped() {
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.fenced_code.block.markdown"))).isFalse();
+        // the language tag on the fence line
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.fenced_code.block.markdown",
+                        "fenced_code.block.language.markdown"))).isFalse();
+        // embedded-language content keeps the fence scope plus source.*
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.fenced_code.block.markdown",
+                        "meta.embedded.block.javascript", "source.js"))).isFalse();
+    }
+
+    @Test
+    @DisplayName("Inline code spans and indented code blocks are not prose")
+    void rawSpansAreSkipped() {
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.inline.raw.string.markdown"))).isFalse();
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.raw.block.markdown"))).isFalse();
+    }
+
+    @Test
+    @DisplayName("Link destinations and YAML front matter are not prose")
+    void linksAndFrontMatterAreSkipped() {
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "meta.link.inline.markdown",
+                        "markup.underline.link.markdown"))).isFalse();
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.underline.link.image.markdown"))).isFalse();
+        // the grammar scopes front matter as markup.raw.yaml.front-matter
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "markup.raw.yaml.front-matter"))).isFalse();
+    }
+
+    @Test
+    @DisplayName("Link TEXT stays prose even though the destination is skipped")
+    void linkTextStaysProse() {
+        // [visible words](https://example.com) — the visible words carry
+        // meta.link + string.other.link.title, never markup.underline.link
+        assertThat(MarkdownSpellTokenListProvider.isProseScope(
+                stack("text.html.markdown", "meta.link.inline.markdown",
+                        "string.other.link.title.markdown"))).isTrue();
+    }
+}


### PR DESCRIPTION
## What

UX-pass finding 5: markdown files were spellchecked as one big prose blob (the platform markdown module wires the spellchecker's `PlainTokenListProvider`), so `const`, `npm`, `querySelectorAll` — anything in a fenced block, inline code span, or URL — got the red typo squiggle.

## Fix

- `MarkdownSpellTokenListProvider` (text/x-markdown + text/markdown, position 100): yields words only from prose tokens. Excluded scopes: `markup.fenced_code`, `markup.raw` (also covers YAML front matter), `markup.inline.raw`, `markup.underline.link`, and embedded `source.*`. Link *text*, headings, emphasis, quotes, and paragraphs stay checked.
- The word walker is factored out of the existing comment-only provider (`FilteredWordsTokenList` + token predicate) rather than duplicated.
- The platform's whole-file plain provider is hidden for `text/markdown` in our layer — with a markdown-aware provider present it is strictly wrong, and hiding follows the same pattern this layer already uses for the platform's Open File/New Project items.

## Verification

- Built-app fixture (screenshots in session): README with ```js fence, inline code, bare fence, and two deliberate prose typos — code spans clean, prose typos still squiggled.
- Unit tests pin the predicate against the scope stacks the platform's markdown grammar (`org-netbeans-modules-markdown`) actually emits.
- `mvn verify -pl editor`: SpotBugs 0, JaCoCo floor met.

## Note

Language-tagged fences currently lose their fence scope when TM4E prunes grammar rules whose embedded-language includes can't resolve — that's UX finding 6, next PR; this exclusion list already handles those scopes once restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)