### PR TITLE
fix(launcher): pick a Java the platform can run on, or fail fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+A user-experience pass walked four developer journeys through the built
+app (a Vite/React monorepo first-open, a zero-config static site, a
+CI-configs-and-docs repo, a messy legacy project) and fixed what they
+hit, smallest risk first.
+
+### Fixed
+- **The launcher picks a Java the platform can run on.** Launching
+  without a bundled runtime (portable zip, source builds) could select
+  sdkman's `current` link even when it pointed at Java 8 — then spawn a
+  JVM that printed "Cannot run on older versions of Java" and never
+  exited. The launcher conf now chooses, in order: an explicit
+  `jdkhome` / the installer's bundled JRE (still wins — it is applied
+  later), `--jdkhome` on the command line (steps past the whole block),
+  `JAVA_HOME` when it is 21+, the macOS `java_home` 21+ query, the
+  newest 21+ JDK in the standard install dirs, a 21+ `java` on PATH —
+  and if none qualifies, exits cleanly (code 3) with an actionable
+  message instead of handing a doomed choice to the platform.
+  `LauncherJavaSelectionTest` sources the real conf against fixture
+  JDKs to pin every branch.
+- **Markdown spellcheck reads prose, not code.** `const`, `npm`,
+  `querySelectorAll` — anything in a fenced block, inline code span,
+  URL, or YAML front matter — no longer gets the red typo squiggle;
+  paragraphs, headings, emphasis, and link text stay checked.
+- **Markdown fences highlight their language again.** TM4E prunes any
+  grammar rule whose cross-grammar include can't resolve, which was
+  silently stripping every language-tagged fence (191 rules per
+  session) and the front-matter rule, and degrading HTML/Vue/Svelte/
+  Astro `<script>` embeddings. Five embed-only grammars (source.js,
+  source.ts, source.tsx, source.yaml, text.html.derivative — vscode
+  1.95.0, like the rest of the pack) now register purely for scope
+  resolution under synthetic mimes no file opens with; a ```js fence
+  renders real JavaScript tokens.
+
 ## [1.10.0] — 2026-07-01
 
 ### Added

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -115,6 +115,12 @@
             <version>6.1.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -148,6 +154,18 @@
                         <branding.token>${brandingToken}</branding.token>
                     </systemPropertyVariables>
                 </configuration>
+                <executions>
+                    <!-- nbm-application packaging does not bind surefire's
+                         test phase on its own; without this the module's
+                         unit tests compile but never run -->
+                    <execution>
+                        <id>default-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/application/src/main/resources/nmoxstudio.conf
+++ b/application/src/main/resources/nmoxstudio.conf
@@ -15,9 +15,69 @@ default_options="--branding nmoxstudio --laf com.formdev.flatlaf.FlatDarkLaf -J-
 # for development purposes you may wish to append: -J-Dnetbeans.logger.console=true -J-ea
 
 # default location of JDK/JRE, can be overridden by using --jdkhome <dir> switch.
-# Deliberately unset for distribution: the launcher falls back to JAVA_HOME
-# and then to `java` on PATH. NMOX Studio requires JDK 17 or newer.
-#jdkhome="/path/to/jdk-17"
+#jdkhome="/path/to/jdk-21"
+
+# Pick a Java the platform can actually run on (21+). Without this the
+# platform launcher's own fallback prefers sdkman's "current" link even
+# when that is an ancient Java — it then spawns a JVM that prints
+# "Cannot run on older versions of Java" and never exits. Order here:
+# an explicit jdkhome above (or the installer-appended bundled-jre line
+# below, which runs later and therefore wins) > JAVA_HOME > the macOS
+# java_home query > the newest JDK in the standard install dirs > a
+# 21+ java on PATH. If none qualifies, exit with a clear message
+# instead of handing a doomed choice to the platform.
+# (Sourced by /bin/sh: POSIX only. The nmox_* variables exist so tests
+# can point the probes at fixtures. A --jdkhome on the command line is
+# parsed later, by the platform launcher — when it is present this
+# whole block steps aside, including the fail-fast exit.)
+case " $* " in
+    *" --jdkhome "*) nmox_cli_jdkhome=yes ;;
+    *) nmox_cli_jdkhome=no ;;
+esac
+if [ -z "$jdkhome" ] && [ "$nmox_cli_jdkhome" = no ]; then
+    nmox_java_major() {
+        [ -x "$1/bin/java" ] || { echo 0; return; }
+        nmox_v=`"$1/bin/java" -version 2>&1 | head -1 | sed 's/^[^"]*"\([0-9][0-9]*\).*/\1/'`
+        case "$nmox_v" in
+            1) echo 8 ;;                       # "1.8.0_xxx"
+            ''|*[!0-9]*) echo 0 ;;
+            *) echo "$nmox_v" ;;
+        esac
+    }
+    nmox_java_home_cmd="${nmox_java_home_cmd:-/usr/libexec/java_home}"
+    nmox_jvm_dirs="${nmox_jvm_dirs:-/Library/Java/JavaVirtualMachines/*/Contents/Home /usr/lib/jvm/*}"
+    if [ -n "$JAVA_HOME" ] && [ "`nmox_java_major \"$JAVA_HOME\"`" -ge 21 ]; then
+        jdkhome="$JAVA_HOME"
+    elif [ -x "$nmox_java_home_cmd" ] && nmox_jh=`"$nmox_java_home_cmd" -v 21+ 2>/dev/null` \
+            && [ -n "$nmox_jh" ] && [ -x "$nmox_jh/bin/java" ]; then
+        jdkhome="$nmox_jh"
+    else
+        nmox_best=0
+        for nmox_d in $nmox_jvm_dirs; do
+            nmox_m=`nmox_java_major "$nmox_d"`
+            if [ "$nmox_m" -ge 21 ] && [ "$nmox_m" -gt "$nmox_best" ]; then
+                nmox_best=$nmox_m
+                jdkhome="$nmox_d"
+            fi
+        done
+    fi
+    if [ -z "$jdkhome" ]; then
+        # last resort: a modern java already on PATH — leave jdkhome
+        # empty and let the platform launcher resolve that same java
+        nmox_path_java=`command -v java 2>/dev/null`
+        nmox_pv=0
+        if [ -n "$nmox_path_java" ]; then
+            nmox_pv=`java -version 2>&1 | head -1 | sed 's/^[^"]*"\([0-9][0-9]*\).*/\1/'`
+            case "$nmox_pv" in 1) nmox_pv=8 ;; ''|*[!0-9]*) nmox_pv=0 ;; esac
+        fi
+        if [ "$nmox_pv" -lt 21 ]; then
+            echo "NMOX Studio requires Java 21 or newer, and none was found." >&2
+            echo "Checked: JAVA_HOME, `uname` JDK locations, and java on PATH." >&2
+            echo "Install a JDK 21+ or launch with --jdkhome <path-to-jdk>." >&2
+            exit 3
+        fi
+    fi
+fi
 
 # clusters' paths separated by path.separator (semicolon on Windows, colon on Unices)
 #extra_clusters=

--- a/application/src/main/resources/nmoxstudio.conf
+++ b/application/src/main/resources/nmoxstudio.conf
@@ -29,7 +29,12 @@ default_options="--branding nmoxstudio --laf com.formdev.flatlaf.FlatDarkLaf -J-
 # (Sourced by /bin/sh: POSIX only. The nmox_* variables exist so tests
 # can point the probes at fixtures. A --jdkhome on the command line is
 # parsed later, by the platform launcher — when it is present this
-# whole block steps aside, including the fail-fast exit.)
+# whole block steps aside, including the fail-fast exit.
+# WINDOWS PARSER HAZARD: the .exe launcher greps this file for lines
+# starting with `jdkhome=` and would take a shell expression literally,
+# so the block works in nmox_pick and assigns the real variable through
+# eval on a line the .exe cannot match. Never write `jdkhome=` at the
+# start of a line in here.)
 case " $* " in
     *" --jdkhome "*) nmox_cli_jdkhome=yes ;;
     *) nmox_cli_jdkhome=no ;;
@@ -46,22 +51,23 @@ if [ -z "$jdkhome" ] && [ "$nmox_cli_jdkhome" = no ]; then
     }
     nmox_java_home_cmd="${nmox_java_home_cmd:-/usr/libexec/java_home}"
     nmox_jvm_dirs="${nmox_jvm_dirs:-/Library/Java/JavaVirtualMachines/*/Contents/Home /usr/lib/jvm/*}"
+    nmox_pick=""
     if [ -n "$JAVA_HOME" ] && [ "`nmox_java_major \"$JAVA_HOME\"`" -ge 21 ]; then
-        jdkhome="$JAVA_HOME"
+        nmox_pick="$JAVA_HOME"
     elif [ -x "$nmox_java_home_cmd" ] && nmox_jh=`"$nmox_java_home_cmd" -v 21+ 2>/dev/null` \
             && [ -n "$nmox_jh" ] && [ -x "$nmox_jh/bin/java" ]; then
-        jdkhome="$nmox_jh"
+        nmox_pick="$nmox_jh"
     else
         nmox_best=0
         for nmox_d in $nmox_jvm_dirs; do
             nmox_m=`nmox_java_major "$nmox_d"`
             if [ "$nmox_m" -ge 21 ] && [ "$nmox_m" -gt "$nmox_best" ]; then
                 nmox_best=$nmox_m
-                jdkhome="$nmox_d"
+                nmox_pick="$nmox_d"
             fi
         done
     fi
-    if [ -z "$jdkhome" ]; then
+    if [ -z "$nmox_pick" ]; then
         # last resort: a modern java already on PATH — leave jdkhome
         # empty and let the platform launcher resolve that same java
         nmox_path_java=`command -v java 2>/dev/null`
@@ -76,6 +82,8 @@ if [ -z "$jdkhome" ] && [ "$nmox_cli_jdkhome" = no ]; then
             echo "Install a JDK 21+ or launch with --jdkhome <path-to-jdk>." >&2
             exit 3
         fi
+    else
+        eval 'jdkhome="$nmox_pick"'
     fi
 fi
 

--- a/application/src/test/java/org/nmox/studio/application/LauncherJavaSelectionTest.java
+++ b/application/src/test/java/org/nmox/studio/application/LauncherJavaSelectionTest.java
@@ -157,6 +157,19 @@ class LauncherJavaSelectionTest {
     }
 
     @Test
+    @DisplayName("No line starts with jdkhome= — the Windows .exe greps the conf literally")
+    void windowsExeParserSeesNoShellJdkhome() throws IOException {
+        // nmoxstudio64.exe scans this same file for lines beginning
+        // `jdkhome=` and would take a shell expression as the literal
+        // path; the selection block must assign through eval instead
+        for (String line : Files.readAllLines(conf, StandardCharsets.UTF_8)) {
+            assertThat(line.stripLeading())
+                    .as("line would be misread by the Windows launcher: %s", line)
+                    .doesNotStartWith("jdkhome=");
+        }
+    }
+
+    @Test
     @DisplayName("PATH java at 21+ is accepted as the silent last resort (jdkhome stays empty)")
     void pathJavaLastResort() throws Exception {
         Path jdk = fakeJdk("path-jdk", "21.0.2");

--- a/application/src/test/java/org/nmox/studio/application/LauncherJavaSelectionTest.java
+++ b/application/src/test/java/org/nmox/studio/application/LauncherJavaSelectionTest.java
@@ -1,0 +1,170 @@
+package org.nmox.studio.application;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Java-selection block in nmoxstudio.conf is what stands between a
+ * fresh checkout and the platform launcher picking sdkman's Java 8 and
+ * spawning a JVM that refuses to run and never exits. These tests
+ * source the real conf file in a controlled /bin/sh with fixture JDKs
+ * (stub {@code bin/java} scripts that print a version banner) and
+ * assert which {@code jdkhome} comes out — the same way the real
+ * launcher consumes it.
+ */
+@DisabledOnOs(OS.WINDOWS)
+class LauncherJavaSelectionTest {
+
+    private static Path conf;
+
+    @TempDir
+    Path tmp;
+
+    @BeforeAll
+    static void locateConf() {
+        conf = Path.of("src/main/resources/nmoxstudio.conf").toAbsolutePath();
+        assertThat(conf).exists();
+    }
+
+    /** Creates a fake JDK home whose bin/java -version reports {@code banner}. */
+    private Path fakeJdk(String name, String banner) throws IOException {
+        Path home = tmp.resolve(name);
+        Files.createDirectories(home.resolve("bin"));
+        Path java = home.resolve("bin/java");
+        Files.writeString(java, "#!/bin/sh\necho 'openjdk version \"" + banner
+                + "\"' >&2\n");
+        assertThat(java.toFile().setExecutable(true)).isTrue();
+        return home;
+    }
+
+    /**
+     * Sources the conf with the given env and launcher args; prints the
+     * resulting jdkhome. Returns [exitCode, stdout].
+     */
+    private Object[] sourceConf(Map<String, String> env, String... launcherArgs)
+            throws IOException, InterruptedException {
+        List<String> cmd = new ArrayList<>(List.of("/bin/sh", "-c",
+                ". '" + conf + "'; printf '%s' \"$jdkhome\"", "sh"));
+        cmd.addAll(List.of(launcherArgs));
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.environment().remove("JAVA_HOME");
+        pb.environment().remove("jdkhome");
+        // default the probes to nowhere so the host machine's JDKs can't leak in
+        pb.environment().put("nmox_java_home_cmd", "/nonexistent-java-home-cmd");
+        pb.environment().put("nmox_jvm_dirs", "/nonexistent-jvm-dir/*");
+        pb.environment().put("PATH", "/usr/bin:/bin");
+        pb.environment().putAll(env);
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        String out = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(p.waitFor(20, TimeUnit.SECONDS)).isTrue();
+        return new Object[]{p.exitValue(), out};
+    }
+
+    @Test
+    @DisplayName("JAVA_HOME pointing at a 21+ JDK is honored")
+    void javaHomeHonored() throws Exception {
+        Path jdk = fakeJdk("jdk21", "21.0.3");
+        Object[] r = sourceConf(Map.of("JAVA_HOME", jdk.toString()));
+        assertThat(r[0]).isEqualTo(0);
+        assertThat(r[1].toString()).endsWith(jdk.toString());
+    }
+
+    @Test
+    @DisplayName("An old JAVA_HOME (1.8) is passed over for the newest scanned 21+ JDK")
+    void oldJavaHomeSkippedForScan() throws Exception {
+        Path jdk8 = fakeJdk("jdk8", "1.8.0_402");
+        Path jdk21 = fakeJdk("jvm/a-21/Contents/Home", "21.0.3");
+        Path jdk23 = fakeJdk("jvm/b-23/Contents/Home", "23.0.1");
+        Object[] r = sourceConf(Map.of(
+                "JAVA_HOME", jdk8.toString(),
+                "nmox_jvm_dirs", tmp.resolve("jvm") + "/*/Contents/Home"));
+        assertThat(r[0]).isEqualTo(0);
+        assertThat(r[1].toString())
+                .as("newest of the scanned JDKs wins")
+                .endsWith(jdk23.toString())
+                .doesNotContain("a-21");
+    }
+
+    @Test
+    @DisplayName("The java_home query is preferred over the directory scan")
+    void javaHomeCmdPreferred() throws Exception {
+        Path queried = fakeJdk("queried-jdk", "22.0.1");
+        Path cmd = tmp.resolve("java_home");
+        Files.writeString(cmd, "#!/bin/sh\nprintf '%s' '" + queried + "'\n");
+        assertThat(cmd.toFile().setExecutable(true)).isTrue();
+        Object[] r = sourceConf(Map.of("nmox_java_home_cmd", cmd.toString()));
+        assertThat(r[0]).isEqualTo(0);
+        assertThat(r[1].toString()).endsWith(queried.toString());
+    }
+
+    @Test
+    @DisplayName("No suitable Java anywhere: clean exit 3 with an actionable message")
+    void nothingSuitableFailsFast() throws Exception {
+        // the fake 8 sits FIRST on PATH so the host's real java (which
+        // /usr/bin/java would otherwise resolve) can't leak in — this also
+        // exercises the last-resort rejecting an old PATH java
+        Path jdk8 = fakeJdk("only-jdk8", "1.8.0_402");
+        Object[] r = sourceConf(Map.of(
+                "JAVA_HOME", jdk8.toString(),
+                "PATH", jdk8.resolve("bin") + File.pathSeparator + "/usr/bin:/bin"));
+        assertThat(r[0]).isEqualTo(3);
+        assertThat(r[1].toString())
+                .contains("Java 21 or newer")
+                .contains("--jdkhome");
+    }
+
+    @Test
+    @DisplayName("--jdkhome on the launcher command line disables the block, including fail-fast")
+    void cliJdkhomeStepsAside() throws Exception {
+        // no suitable java anywhere, but the user said --jdkhome: the
+        // conf must not exit 3 — the platform launcher parses the flag
+        Object[] r = sourceConf(Map.of(), "--jdkhome", "/some/jdk", "--nosplash");
+        assertThat(r[0]).isEqualTo(0);
+        assertThat(r[1].toString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A pre-set jdkhome (installer's bundled JRE) is never touched")
+    void presetJdkhomeUntouched() throws Exception {
+        List<String> cmd = List.of("/bin/sh", "-c",
+                "jdkhome=jre; . '" + conf + "'; printf '%s' \"$jdkhome\"");
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.environment().remove("JAVA_HOME");
+        pb.environment().put("nmox_java_home_cmd", "/nonexistent");
+        pb.environment().put("nmox_jvm_dirs", "/nonexistent/*");
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        String out = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(p.waitFor(20, TimeUnit.SECONDS)).isTrue();
+        assertThat(p.exitValue()).isEqualTo(0);
+        assertThat(out).isEqualTo("jre");
+    }
+
+    @Test
+    @DisplayName("PATH java at 21+ is accepted as the silent last resort (jdkhome stays empty)")
+    void pathJavaLastResort() throws Exception {
+        Path jdk = fakeJdk("path-jdk", "21.0.2");
+        Object[] r = sourceConf(Map.of(
+                "PATH", jdk.resolve("bin") + File.pathSeparator + "/usr/bin:/bin"));
+        assertThat(r[0]).isEqualTo(0);
+        assertThat(r[1].toString())
+                .as("left empty so the platform launcher resolves the PATH java itself")
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
## What

UX-pass finding 2. On machines where sdkman's `current` link points at an old Java, the portable-zip/source launch path picked it (the platform launcher's fallback prefers sdkman over everything), spawned a JVM that printed "Cannot run on older versions of Java than Java 21", and left that JVM running forever. `JAVA_HOME` was ignored on the macOS branch entirely.

## Fix

Java selection now happens in `nmoxstudio.conf` (the supported hook — sourced by the launcher before the platform's own fallback logic), in precedence order:

1. explicit `jdkhome` — including the **installer-appended bundled-JRE line, which is sourced later and therefore still wins** (release workflow appends `jdkhome="jre"`)
2. `--jdkhome` on the command line — the block steps aside entirely, including the fail-fast
3. `JAVA_HOME` if it points at a 21+ JDK
4. macOS `/usr/libexec/java_home -v 21+`
5. newest 21+ JDK in `/Library/Java/JavaVirtualMachines` / `/usr/lib/jvm`
6. a 21+ `java` on PATH (left to the platform launcher to resolve)

None found → **exit 3** with an actionable three-line message. That also eliminates the zombie JVM at the root: the doomed JVM is never spawned.

## Verification (real assembled launcher, this machine = the failure case)

- `unset JAVA_HOME` + sdkman `current`→8: **runs on jdk-23** (was: refusal + zombie)
- fake-8-only environment: **exit 3**, message printed, **0 JVMs left**
- `--jdkhome <jdk21>` in that same broken environment: IDE runs

## Tests

`LauncherJavaSelectionTest` (7 tests) sources the **real conf file** in a controlled `/bin/sh` with fixture JDKs whose stub `bin/java` prints version banners: JAVA_HOME honored / skipped when old, java_home query preferred over scan, newest-wins scan, fail-fast exit 3 + message, `--jdkhome` step-aside, bundled-JRE (`jdkhome=jre`) untouched, PATH-java last resort.

Infrastructure note: `nbm-application` packaging never bound surefire's test phase — the application module's unit tests compiled but never ran. Now bound explicitly (the pre-existing `ApplicationTest` runs too).

Also adds the `[Unreleased]` CHANGELOG section covering this and the two already-merged UX fixes (#68, #69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)