### PR TITLE
fix(editor): ship the dark editor color profile the dark IDE expects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ CI-configs-and-docs repo, a messy legacy project) and fixed what they
 hit, smallest risk first.
 
 ### Fixed
+- **The editor actually looks dark now.** The IDE always runs the
+  FlatLaf Dark look and feel, but the editor's color profile is a
+  separate switch that only the Options→Appearance panel ever flipped —
+  so every editor rendered light-profile colors on a dark IDE: JS/TS in
+  pale Phosphor on white, CSS/YAML/JSON/Markdown in plain black on
+  white. The dark profile ("FlatLaf Dark") is now the shipped default
+  (a user's explicit profile choice still wins), and the Phosphor
+  JS/TS palette no longer leaks into the light profile. Verified
+  per-mime from a wiped userdir: TS/TSX, JS, JSON and Markdown render
+  full Phosphor on dark, CSS the platform's dark colorings.
 - **The launcher picks a Java the platform can run on.** Launching
   without a bundled runtime (portable zip, source builds) could select
   sdkman's `current` link even when it pointed at Java 8 — then spawn a

--- a/editor/src/main/resources/org/nmox/studio/editor/layer.xml
+++ b/editor/src/main/resources/org/nmox/studio/editor/layer.xml
@@ -44,6 +44,19 @@
          MarkdownSpellTokenListProvider (prose-only) replaces it; hide
          the plain one so the two are never combined. -->
     <folder name="Editors">
+        <!-- The IDE always runs the FlatLaf Dark look and feel (forced in
+             nmoxstudio.conf), but the editor's color profile is a separate
+             switch: it defaults to the light "NetBeans" profile and is only
+             flipped by the Options->Appearance panel, which we bypass. Flip
+             it here so every editor uses the platform's FlatLafDark profile
+             (and our Phosphor palettes registered under it) instead of
+             light-profile colors on a dark IDE. A user's explicit choice in
+             Tools->Options still wins: that writes this same attribute into
+             the userdir's writable layer, which shadows this one.
+             The value is the profile's DISPLAY name ("FlatLaf Dark", from
+             the flatlaf module's bundle), not its folder name: the settings
+             storage validates the attribute against display names. -->
+        <attr name="currentFontColorProfile" stringvalue="FlatLaf Dark"/>
         <folder name="text">
             <folder name="markdown">
                 <folder name="TokenListProvider">
@@ -80,12 +93,11 @@
                     <attr name="instanceCreate" methodvalue="org.nmox.studio.editor.javascript.JavaScriptTokenId.language"/>
                     <attr name="instanceOf" stringvalue="org.netbeans.api.lexer.Language"/>
                 </file>
+                <!-- Phosphor is a dark palette: it belongs only to the dark
+                     profile. Mapping it under "NetBeans" (the light profile)
+                     painted pale-on-white JS whenever that profile was
+                     active. -->
                 <folder name="FontsColors">
-                    <folder name="NetBeans">
-                        <folder name="Defaults">
-                            <file name="FontsColors.xml" url="javascript/syntax-colors.xml"/>
-                        </folder>
-                    </folder>
                     <folder name="FlatLafDark">
                         <folder name="Defaults">
                             <file name="FontsColors.xml" url="javascript/syntax-colors.xml"/>
@@ -103,12 +115,9 @@
                     <attr name="instanceCreate" methodvalue="org.nmox.studio.editor.typescript.TypeScriptLanguage.language"/>
                     <attr name="instanceOf" stringvalue="org.netbeans.api.lexer.Language"/>
                 </file>
+                <!-- dark palette, dark profile only — see the javascript
+                     folder above -->
                 <folder name="FontsColors">
-                    <folder name="NetBeans">
-                        <folder name="Defaults">
-                            <file name="FontsColors.xml" url="javascript/syntax-colors.xml"/>
-                        </folder>
-                    </folder>
                     <folder name="FlatLafDark">
                         <folder name="Defaults">
                             <file name="FontsColors.xml" url="javascript/syntax-colors.xml"/>

--- a/editor/src/test/java/org/nmox/studio/editor/DarkProfileLayerTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/DarkProfileLayerTest.java
@@ -1,0 +1,52 @@
+package org.nmox.studio.editor;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The IDE forces the FlatLaf Dark look and feel, so the editor color
+ * profile must ship flipped to match — and the value has to be the
+ * profile's DISPLAY name: the settings storage validates the attribute
+ * against display names, and the folder-name form ("FlatLafDark")
+ * silently falls back to the light profile. These assertions read the
+ * module layer the platform actually merges.
+ */
+class DarkProfileLayerTest {
+
+    private static String layer() throws Exception {
+        try (InputStream in = DarkProfileLayerTest.class
+                .getResourceAsStream("/org/nmox/studio/editor/layer.xml")) {
+            assertThat(in).as("editor module layer must exist").isNotNull();
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    @DisplayName("The dark profile ships as the default, by display name")
+    void darkProfileIsDefault() throws Exception {
+        assertThat(layer()).contains(
+                "<attr name=\"currentFontColorProfile\" stringvalue=\"FlatLaf Dark\"/>");
+    }
+
+    @Test
+    @DisplayName("The Phosphor palette never maps into the light NetBeans profile")
+    void darkPaletteStaysOutOfLightProfile() throws Exception {
+        // a dark palette under the light profile is what painted
+        // pale-on-white JS/TS whenever "NetBeans" was active
+        String layer = layer();
+        for (int at = layer.indexOf("syntax-colors.xml"); at >= 0;
+                at = layer.indexOf("syntax-colors.xml", at + 1)) {
+            String before = layer.substring(Math.max(0, at - 400), at);
+            int dark = before.lastIndexOf("\"FlatLafDark\"");
+            int light = before.lastIndexOf("\"NetBeans\"");
+            assertThat(dark)
+                    .as("every syntax-colors.xml mapping sits under FlatLafDark, "
+                            + "and no light-profile folder opens after it")
+                    .isGreaterThan(light);
+        }
+    }
+}


### PR DESCRIPTION
## What

UX-pass finding 1 — the most visible bug in the product: every editor rendered **light-profile colors on a dark IDE**. JS/TS drew the pale Phosphor palette on a white canvas (imports near-invisible); CSS, YAML, JSON, and Markdown were plain black-on-white with zero token color.

## Root cause

The LAF and the editor color profile are two separate switches. `nmoxstudio.conf` forces `--laf com.formdev.flatlaf.FlatDarkLaf`, but the profile defaults to the light `"NetBeans"` and is only flipped by the Options→Appearance panel — which a forced LAF bypasses. Two compounding mistakes in our layer: nothing set the profile, and the dark Phosphor JS/TS palette was *also* mapped under the light profile (hence pale-on-white rather than default-black).

## Fix (two layer edits, no code)

- `Editors` folder attr `currentFontColorProfile = "FlatLaf Dark"` — the profile's **display name**, which is what the settings storage validates against (the folder-name `FlatLafDark` silently falls back to "NetBeans"; found the hard way, documented in the layer comment). A user's explicit choice in Tools→Options still wins — it writes the same attribute into the userdir's writable layer, which shadows the module layer.
- The Phosphor JS/TS palette now registers **only** under `FlatLafDark`, not under the light profile.

## Verification (built app, wiped userdir + cache, per-mime screenshots)

| mime | before | after |
|---|---|---|
| TSX/TS | pale-on-white | full Phosphor on dark |
| JS | pale-on-white | full Phosphor on dark |
| JSON | black-on-white | green keys / yellow numbers / orange booleans on dark |
| Markdown | black-on-white | magenta headings, colored ```js fence tokens on dark |
| CSS | black-on-white | platform FlatLafDark colorings |
| YAML | black-on-white | dark canvas (platform ships no dark YAML colorings — matches stock NetBeans) |

`mvn verify -pl editor`: 203 tests, SpotBugs 0, JaCoCo floor met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)