### PR TITLE
ci: audit that every test-bearing module actually ran its tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Build with Maven
         run: mvn -B verify
 
+      # Every module that ships test sources must have actually run them.
+      # Guards the unbound-surefire class: the application module's tests
+      # compiled but never executed until PR #70, and nothing flagged it.
+      # Runs right after verify, while the surefire reports are fresh.
+      - name: Test-execution audit
+        run: ./scripts/test-execution-audit.sh
+
       # --- Release-gating checks against the ASSEMBLED app -----------------
       # These run after verify (which packages application/target/nmoxstudio)
       # and exercise the real cluster, not a test harness — the gap that let

--- a/scripts/test-execution-audit.sh
+++ b/scripts/test-execution-audit.sh
@@ -52,12 +52,32 @@ for pom in */pom.xml; do
         continue
     fi
 
+    # Freshness guard against a stale report faking a green: if this build
+    # recompiled the tests but did not run them, the compiled test classes
+    # are newer than every report. When target/test-classes exists, at
+    # least one TEST-*.xml must be newer than it. In CI this never triggers
+    # (the runner checks out fresh, so reports are always written after the
+    # compile in the same run); it closes the local "audit without a
+    # rebuild after breaking test execution" hole.
+    testclasses="$module/target/test-classes"
+    if [ -d "$testclasses" ] \
+        && [ -z "$(find "$reports" -name 'TEST-*.xml' -newer "$testclasses" 2>/dev/null)" ]; then
+        echo "AUDIT FAIL: $module — surefire reports are older than its compiled" >&2
+        echo "            test classes: the reports are stale, tests did not run" >&2
+        echo "            in this build. Re-run after 'mvn verify' (or 'mvn clean')." >&2
+        FAILED=1
+        continue
+    fi
+
     # Sum tests="N" across every TEST-*.xml the run produced. Reading the
     # XML (not the .txt summary) is robust to locale and to the summary
     # line format changing between surefire versions.
     ran="$(grep -ho 'tests="[0-9]*"' "$reports"/TEST-*.xml 2>/dev/null \
         | grep -o '[0-9]*' \
         | awk '{ s += $1 } END { print s + 0 }')"
+    # awk always prints a number, but guard the arithmetic test anyway so a
+    # surprise non-numeric can never abort the loop under set -e.
+    case "$ran" in ''|*[!0-9]*) ran=0 ;; esac
 
     if [ "$ran" -eq 0 ]; then
         echo "AUDIT FAIL: $module has $testcount test source(s) but its" >&2

--- a/scripts/test-execution-audit.sh
+++ b/scripts/test-execution-audit.sh
@@ -30,17 +30,22 @@ for pom in */pom.xml; do
     testdir="$module/src/test"
 
     # Only modules that actually declare tests are in scope. "Declares
-    # tests" = at least one *Test.java (the project's naming convention;
-    # surefire's default include is the same **/*Test.java pattern).
+    # tests" is matched against surefire's OWN default include patterns
+    # (*Test, Test*, *Tests, *TestCase) — not just the repo's current
+    # *Test.java convention — so a future FooTests.java that surefire
+    # would run but a narrower glob would miss can't create a blind spot
+    # where an unbound surefire goes unnoticed.
     [ -d "$testdir" ] || continue
-    testcount="$(find "$testdir" -name '*Test.java' 2>/dev/null | wc -l | tr -d ' ')"
+    testcount="$(find "$testdir" \( -name '*Test.java' -o -name 'Test*.java' \
+        -o -name '*Tests.java' -o -name '*TestCase.java' \) 2>/dev/null \
+        | wc -l | tr -d ' ')"
     [ "$testcount" -gt 0 ] || continue
 
     CHECKED=$((CHECKED + 1))
     reports="$module/target/surefire-reports"
 
     if [ ! -d "$reports" ]; then
-        echo "AUDIT FAIL: $module has $testcount *Test.java source(s) but produced" >&2
+        echo "AUDIT FAIL: $module has $testcount test source(s) but produced" >&2
         echo "            no surefire-reports directory — its tests never ran." >&2
         echo "            (unbound surefire? wrong packaging? check the module pom.)" >&2
         FAILED=1
@@ -55,7 +60,7 @@ for pom in */pom.xml; do
         | awk '{ s += $1 } END { print s + 0 }')"
 
     if [ "$ran" -eq 0 ]; then
-        echo "AUDIT FAIL: $module has $testcount *Test.java source(s) but its" >&2
+        echo "AUDIT FAIL: $module has $testcount test source(s) but its" >&2
         echo "            surefire reports show 0 tests executed." >&2
         FAILED=1
         continue

--- a/scripts/test-execution-audit.sh
+++ b/scripts/test-execution-audit.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Test-execution audit: every module that declares tests must actually run
+# them. Guards the unbound-surefire class of bug.
+#
+# Why this exists: the application module's surefire was never bound to a
+# lifecycle phase, so its test sources compiled but never executed — its
+# LauncherJavaSelectionTest and ApplicationTest were dead weight, and that
+# was discovered incidentally during PR #70, not by CI. A module can lose
+# its test execution silently (wrong packaging, a botched plugin config, a
+# skip flag) and every remaining test still passes, so "BUILD SUCCESS"
+# proves nothing about the module that went dark.
+#
+# This runs AFTER `mvn verify`: for each module containing *Test.java
+# sources, it asserts the module produced surefire reports that ran at
+# least one test. A module with test sources but zero executed tests fails
+# the audit.
+#
+# Usage: scripts/test-execution-audit.sh
+# Exit:  0 every test-bearing module executed tests; 1 otherwise.
+set -eu
+
+# Modules are the immediate child dirs with a pom.xml. Keeping this
+# derived (not a hardcoded list) means a new module is covered the day it
+# is added, without editing this script.
+FAILED=0
+CHECKED=0
+
+for pom in */pom.xml; do
+    module="${pom%/pom.xml}"
+    testdir="$module/src/test"
+
+    # Only modules that actually declare tests are in scope. "Declares
+    # tests" = at least one *Test.java (the project's naming convention;
+    # surefire's default include is the same **/*Test.java pattern).
+    [ -d "$testdir" ] || continue
+    testcount="$(find "$testdir" -name '*Test.java' 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$testcount" -gt 0 ] || continue
+
+    CHECKED=$((CHECKED + 1))
+    reports="$module/target/surefire-reports"
+
+    if [ ! -d "$reports" ]; then
+        echo "AUDIT FAIL: $module has $testcount *Test.java source(s) but produced" >&2
+        echo "            no surefire-reports directory — its tests never ran." >&2
+        echo "            (unbound surefire? wrong packaging? check the module pom.)" >&2
+        FAILED=1
+        continue
+    fi
+
+    # Sum tests="N" across every TEST-*.xml the run produced. Reading the
+    # XML (not the .txt summary) is robust to locale and to the summary
+    # line format changing between surefire versions.
+    ran="$(grep -ho 'tests="[0-9]*"' "$reports"/TEST-*.xml 2>/dev/null \
+        | grep -o '[0-9]*' \
+        | awk '{ s += $1 } END { print s + 0 }')"
+
+    if [ "$ran" -eq 0 ]; then
+        echo "AUDIT FAIL: $module has $testcount *Test.java source(s) but its" >&2
+        echo "            surefire reports show 0 tests executed." >&2
+        FAILED=1
+        continue
+    fi
+
+    echo "audit: $module — $testcount test source(s), $ran test(s) executed"
+done
+
+if [ "$CHECKED" -eq 0 ]; then
+    # A repo-shape change (no module has test sources) should not silently
+    # pass a check whose entire job is to find zero-execution modules.
+    echo "AUDIT FAIL: found no modules with *Test.java sources — did the module" >&2
+    echo "            layout change, or is this being run from the wrong dir?" >&2
+    exit 1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "test-execution audit FAILED — a module with tests ran none of them." >&2
+    exit 1
+fi
+
+echo "test-execution audit OK — all $CHECKED test-bearing module(s) executed their tests."
+exit 0


### PR DESCRIPTION
## What

Second verification-hardening check. Guards the **unbound-surefire class**: the application module's surefire was never bound to a lifecycle phase, so `LauncherJavaSelectionTest` and `ApplicationTest` compiled but never ran — `BUILD SUCCESS` reported nothing was wrong, and it was found only incidentally during PR #70.

`scripts/test-execution-audit.sh` runs right after `mvn verify` and fails if any module with `*Test.java` sources ran zero tests.

## What it asserts

For each immediate child module with test sources:
- a `target/surefire-reports/` directory exists, and
- summing `tests="N"` across its `TEST-*.xml` reports is > 0.

Plus: if **no** module has test sources at all (a repo-shape change), the audit fails rather than silently passing — a zero-execution finder that finds nothing because it looked nowhere is itself a false green.

Design choices: the module list is **derived from the tree** (a new module is covered the day it's added, no edit here); it reads the **XML** `tests=` attribute, not the localized `.txt` summary line, so a surefire version or locale change can't fool it.

## Proven by breaking it

Unbound the application module's surefire execution (reverting PR #70's fix) and re-ran `mvn clean test -pl application`:
```
AUDIT FAIL: application has 2 *Test.java source(s) but produced
            no surefire-reports directory — its tests never ran.
```
Restored → green, all 8 test-bearing modules accounted for:
```
audit: application — 2 test source(s), 9 test(s) executed
audit: editor — 20 test source(s), 204 test(s) executed
audit: rack — 33 test source(s), 322 test(s) executed
… test-execution audit OK — all 8 test-bearing module(s) executed their tests.
```

Wired into the release-gating CI job on both platforms. This PR's CI run is the live proof against a real `mvn verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)