### PR TITLE
ci: rendering probe — assert the editor resolves the dark color scheme

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,3 +52,14 @@ jobs:
       - name: Boot smoke test (macOS)
         if: runner.os == 'macOS'
         run: ./scripts/boot-smoke-test.sh
+
+      # Boot once more with the color probe on and assert the editor's
+      # RESOLVED colors are the dark scheme — the v1.10.1 white-editor
+      # class, which packaged green for months. Same display requirement
+      # as the boot smoke test.
+      - name: Rendering probe (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a ./scripts/rendering-probe.sh
+      - name: Rendering probe (macOS)
+        if: runner.os == 'macOS'
+        run: ./scripts/rendering-probe.sh

--- a/editor/src/main/java/org/nmox/studio/editor/probe/RenderingProbe.java
+++ b/editor/src/main/java/org/nmox/studio/editor/probe/RenderingProbe.java
@@ -72,19 +72,43 @@ public final class RenderingProbe implements Runnable {
         emit(result);
     }
 
+    /** Attempts to let settings finish resolving before concluding they
+     *  are unavailable — @OnStart can fire just ahead of the settings
+     *  storage on a slow runner. Bounded and only retried while the values
+     *  are NULL (not-ready); a resolved-but-light value is a real failure
+     *  and returns immediately, so the retry can never mask the bug. */
+    static final int RESOLVE_ATTEMPTS = 20;
+    static final long RESOLVE_WAIT_MS = 250;
+
     /** The assertions, as a PASS line or the first FAIL reason. */
     static String evaluate() {
-        FontColorSettings fcs = MimeLookup.getLookup(MimePath.parse(PROBED_MIME))
-                .lookup(FontColorSettings.class);
-        if (fcs == null) {
-            return "FAIL: no FontColorSettings for " + PROBED_MIME
-                    + " (editor settings not resolved at probe time)";
-        }
+        for (int attempt = 1; ; attempt++) {
+            FontColorSettings fcs = MimeLookup.getLookup(MimePath.parse(PROBED_MIME))
+                    .lookup(FontColorSettings.class);
+            Color background = fcs == null ? null
+                    : attr(fcs.getFontColors(FontColorNames.DEFAULT_COLORING),
+                            StyleConstants.Background);
+            Color keyword = fcs == null ? null
+                    : attr(fcs.getTokenFontColors("keyword"), StyleConstants.Foreground);
 
-        Color background = attr(fcs.getFontColors(FontColorNames.DEFAULT_COLORING),
-                StyleConstants.Background);
-        Color keyword = attr(fcs.getTokenFontColors("keyword"), StyleConstants.Foreground);
-        return classify(background, keyword);
+            if ((background == null || keyword == null) && attempt < RESOLVE_ATTEMPTS) {
+                sleep(RESOLVE_WAIT_MS);
+                continue; // settings not resolved yet — keep waiting, don't judge
+            }
+            if (fcs == null) {
+                return "FAIL: no FontColorSettings for " + PROBED_MIME
+                        + " (editor settings never resolved)";
+            }
+            return classify(background, keyword);
+        }
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     /**

--- a/editor/src/main/java/org/nmox/studio/editor/probe/RenderingProbe.java
+++ b/editor/src/main/java/org/nmox/studio/editor/probe/RenderingProbe.java
@@ -1,0 +1,149 @@
+package org.nmox.studio.editor.probe;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.StyleConstants;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.editor.mimelookup.MimePath;
+import org.netbeans.api.editor.settings.FontColorNames;
+import org.netbeans.api.editor.settings.FontColorSettings;
+import org.openide.modules.OnStart;
+
+/**
+ * A headless-CI probe for the editor-coloring failure class: the IDE runs
+ * FlatLaf Dark but the editor rendered light-profile colors (v1.10.1's
+ * white-editor bug). CI packaged the app for months without ever
+ * observing the editor was unreadable. This asserts the RUNTIME resolved
+ * color state — not the source layer, which {@code DarkProfileLayerTest}
+ * already guards — so a platform default or a future module that changes
+ * the active profile is caught too.
+ *
+ * Both halves of the v1.10.1 bug show up in what {@link FontColorSettings}
+ * resolves for a code mime under the <em>active</em> profile, so both
+ * assertions read that one public API — no dependency on the profile-name
+ * impl class, whose package a module might not export:
+ * <ol>
+ *   <li>the default editor background is dark — a light background means
+ *       the active profile fell back to "NetBeans" (bug half 1);</li>
+ *   <li>the JS keyword foreground is Phosphor's — anything else means the
+ *       Phosphor palette isn't registered under the active profile
+ *       (bug half 2).</li>
+ * </ol>
+ *
+ * Inert unless {@code -Dnmox.rendering.probe=true}. Runs at
+ * {@code @OnStart} (modules up, colorings resolvable without a shown
+ * window — the resolved colors are model state, not painted pixels),
+ * writes one {@code PASS}/{@code FAIL: ...} line to
+ * {@code -Dnmox.rendering.probe.out} and to stderr, then the boot quits
+ * via {@code netbeans.close}. A result file rather than a thrown
+ * assertion keeps the probe out of the platform's startup error handling.
+ */
+@OnStart
+public final class RenderingProbe implements Runnable {
+
+    static final String ENABLED_PROP = "nmox.rendering.probe";
+    static final String OUTPUT_PROP = "nmox.rendering.probe.out";
+
+    /** Phosphor's JS keyword foreground — the palette-under-active-profile tell. */
+    static final Color EXPECTED_JS_KEYWORD = new Color(0xff6ac1);
+    static final String PROBED_MIME = "text/javascript";
+    /** A background at or below this luminance reads as "dark". FlatLaf
+     *  Dark's editor background is ~#2b2b2b (luminance ~43); the light
+     *  "NetBeans" profile is white (255). 96 leaves generous margin on
+     *  both sides so a shade tweak doesn't flip the verdict. */
+    static final int DARK_MAX_LUMINANCE = 96;
+
+    @Override
+    public void run() {
+        if (!Boolean.getBoolean(ENABLED_PROP)) {
+            return;
+        }
+        String result;
+        try {
+            result = evaluate();
+        } catch (RuntimeException ex) {
+            result = "FAIL: probe threw " + ex;
+        }
+        emit(result);
+    }
+
+    /** The assertions, as a PASS line or the first FAIL reason. */
+    static String evaluate() {
+        FontColorSettings fcs = MimeLookup.getLookup(MimePath.parse(PROBED_MIME))
+                .lookup(FontColorSettings.class);
+        if (fcs == null) {
+            return "FAIL: no FontColorSettings for " + PROBED_MIME
+                    + " (editor settings not resolved at probe time)";
+        }
+
+        Color background = attr(fcs.getFontColors(FontColorNames.DEFAULT_COLORING),
+                StyleConstants.Background);
+        Color keyword = attr(fcs.getTokenFontColors("keyword"), StyleConstants.Foreground);
+        return classify(background, keyword);
+    }
+
+    /**
+     * The verdict for a resolved (background, keyword) pair — split out
+     * from the platform lookup so the dark/light and palette decisions are
+     * unit-testable without booting the IDE.
+     */
+    static String classify(Color background, Color keyword) {
+        if (background == null) {
+            return "FAIL: no resolved default background for " + PROBED_MIME;
+        }
+        int lum = luminance(background);
+        if (lum > DARK_MAX_LUMINANCE) {
+            return "FAIL: editor background " + hex(background) + " (luminance " + lum
+                    + ") is light — the active profile is not the dark one";
+        }
+        if (keyword == null) {
+            return "FAIL: no resolved keyword foreground for " + PROBED_MIME;
+        }
+        if (!sameRgb(keyword, EXPECTED_JS_KEYWORD)) {
+            return "FAIL: " + PROBED_MIME + " keyword resolves to " + hex(keyword)
+                    + ", expected Phosphor " + hex(EXPECTED_JS_KEYWORD)
+                    + " (palette not under the active profile?)";
+        }
+        return "PASS: background=" + hex(background) + " (dark), "
+                + PROBED_MIME + " keyword=" + hex(keyword);
+    }
+
+    private static Color attr(AttributeSet attrs, Object key) {
+        if (attrs == null) {
+            return null;
+        }
+        Object v = attrs.getAttribute(key);
+        return v instanceof Color ? (Color) v : null;
+    }
+
+    /** Rec. 601 luma, 0 (black) .. 255 (white). */
+    private static int luminance(Color c) {
+        return (c.getRed() * 299 + c.getGreen() * 587 + c.getBlue() * 114) / 1000;
+    }
+
+    private static boolean sameRgb(Color a, Color b) {
+        return (a.getRGB() & 0xFFFFFF) == (b.getRGB() & 0xFFFFFF);
+    }
+
+    private static String hex(Color c) {
+        return String.format("#%06x", c.getRGB() & 0xFFFFFF);
+    }
+
+    private void emit(String result) {
+        String out = System.getProperty(OUTPUT_PROP);
+        if (out != null && !out.isEmpty()) {
+            try {
+                Files.writeString(Path.of(out), result + System.lineSeparator(),
+                        StandardCharsets.UTF_8);
+            } catch (IOException ex) {
+                throw new UncheckedIOException("rendering probe could not write " + out, ex);
+            }
+        }
+        System.err.println("NMOX-RENDER-PROBE " + result);
+    }
+}

--- a/editor/src/test/java/org/nmox/studio/editor/probe/RenderingProbeTest.java
+++ b/editor/src/test/java/org/nmox/studio/editor/probe/RenderingProbeTest.java
@@ -1,0 +1,67 @@
+package org.nmox.studio.editor.probe;
+
+import java.awt.Color;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The probe's verdict logic, pinned without booting the IDE. Both halves
+ * of the v1.10.1 bug must read as FAIL; the shipped dark scheme as PASS.
+ * The boot-level red/green proof lives in scripts/rendering-probe.sh; this
+ * guards the thresholds and the expected Phosphor color against a
+ * fat-finger.
+ */
+class RenderingProbeTest {
+
+    private static final Color PHOSPHOR_KEYWORD = new Color(0xff6ac1);
+    private static final Color FLATLAF_DARK_BG = new Color(0x2b, 0x2b, 0x2b);
+    private static final Color WHITE = Color.WHITE;
+
+    @Test
+    @DisplayName("The shipped dark scheme passes")
+    void darkSchemePasses() {
+        assertThat(RenderingProbe.classify(FLATLAF_DARK_BG, PHOSPHOR_KEYWORD))
+                .startsWith("PASS");
+    }
+
+    @Test
+    @DisplayName("A light background fails — bug half 1, the profile fell back to NetBeans")
+    void lightBackgroundFails() {
+        String verdict = RenderingProbe.classify(WHITE, PHOSPHOR_KEYWORD);
+        assertThat(verdict).startsWith("FAIL").contains("light");
+    }
+
+    @Test
+    @DisplayName("A non-Phosphor keyword fails — bug half 2, palette not under active profile")
+    void wrongKeywordFails() {
+        // dark background (profile is right) but the platform-default
+        // keyword color instead of Phosphor's
+        String verdict = RenderingProbe.classify(FLATLAF_DARK_BG, new Color(0x808080));
+        assertThat(verdict).startsWith("FAIL").contains("keyword");
+    }
+
+    @Test
+    @DisplayName("Missing colors fail rather than passing on nulls")
+    void missingColorsFail() {
+        assertThat(RenderingProbe.classify(null, PHOSPHOR_KEYWORD))
+                .startsWith("FAIL").contains("background");
+        assertThat(RenderingProbe.classify(FLATLAF_DARK_BG, null))
+                .startsWith("FAIL").contains("keyword");
+    }
+
+    @Test
+    @DisplayName("The luminance threshold sits clear of both real values")
+    void thresholdHasMargin() {
+        // FlatLaf Dark background must classify dark, white must classify
+        // light, with the threshold comfortably between the two
+        assertThat(RenderingProbe.DARK_MAX_LUMINANCE)
+                .isGreaterThan(luminance(FLATLAF_DARK_BG))
+                .isLessThan(luminance(WHITE));
+    }
+
+    private static int luminance(Color c) {
+        return (c.getRed() * 299 + c.getGreen() * 587 + c.getBlue() * 114) / 1000;
+    }
+}

--- a/scripts/rendering-probe.sh
+++ b/scripts/rendering-probe.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Rendering probe: boot the ASSEMBLED app headless and assert the editor's
+# RESOLVED colors are the dark scheme — the failure class that shipped in
+# v1.10.1, when the IDE ran FlatLaf Dark but every editor rendered
+# light-profile colors on a white canvas, green through all of CI.
+#
+# The assertions live in RenderingProbe (@OnStart, in the editor module):
+# under the active font-color profile, the default editor background must
+# be dark and the JS keyword must resolve to Phosphor's color. They read
+# the runtime FontColorSettings, so they catch both halves of the bug —
+# the profile falling back to light AND the palette not being registered
+# under the active profile — which a source-layer test (DarkProfileLayerTest)
+# cannot. The probe writes PASS / FAIL:<reason> to a result file; this
+# script boots with the probe enabled and asserts PASS.
+#
+# Same fresh-userdir discipline as the boot smoke test: a stale profile
+# choice in a reused userdir would mask the shipped default.
+#
+# Usage: scripts/rendering-probe.sh [path-to-nmoxstudio-app-dir]
+# Exit:  0 dark scheme resolved, non-zero otherwise (with the FAIL reason).
+set -eu
+
+APP_DIR="${1:-application/target/nmoxstudio}"
+LAUNCHER="$APP_DIR/bin/nmoxstudio"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-180}"
+
+if [ ! -x "$LAUNCHER" ]; then
+    echo "rendering-probe: launcher not found at $LAUNCHER — build the app first" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/nmox-render.XXXXXX")"
+USERDIR="$WORK/userdir"
+CACHEDIR="$WORK/cachedir"
+RESULT="$WORK/probe-result.txt"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM
+
+JDK_ARGS=""
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    JDK_ARGS="--jdkhome $JAVA_HOME"
+fi
+
+echo "rendering-probe: booting $LAUNCHER with the color probe enabled"
+
+# shellcheck disable=SC2086
+"$LAUNCHER" \
+    --userdir "$USERDIR" \
+    --cachedir "$CACHEDIR" \
+    $JDK_ARGS \
+    --nosplash \
+    -J-Dnetbeans.close=true \
+    -J-Dnmox.rendering.probe=true \
+    -J-Dnmox.rendering.probe.out="$RESULT" \
+    > "$WORK/stdout.log" 2>&1 &
+APP_PID=$!
+
+# The probe writes its result at @OnStart, before the window even shows,
+# so the file usually lands within a couple seconds. Wait for the file or
+# the process exit or the watchdog.
+waited=0
+while kill -0 "$APP_PID" 2>/dev/null; do
+    [ -f "$RESULT" ] && break
+    if [ "$waited" -ge "$BOOT_TIMEOUT" ]; then
+        echo "rendering-probe: FAIL — no probe result within ${BOOT_TIMEOUT}s (boot hung?)" >&2
+        kill -TERM "$APP_PID" 2>/dev/null || true; sleep 3; kill -KILL "$APP_PID" 2>/dev/null || true
+        tail -25 "$USERDIR/var/log/messages.log" 2>/dev/null >&2 || cat "$WORK/stdout.log" >&2
+        exit 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+done
+
+# Let the app finish its clean shutdown (it quits via netbeans.close).
+kill -0 "$APP_PID" 2>/dev/null && { wait "$APP_PID" 2>/dev/null || true; }
+
+if [ ! -f "$RESULT" ]; then
+    echo "rendering-probe: FAIL — the probe never wrote a result" >&2
+    echo "  (RenderingProbe not on the classpath, or @OnStart never ran)" >&2
+    tail -25 "$USERDIR/var/log/messages.log" 2>/dev/null >&2 || true
+    exit 1
+fi
+
+VERDICT="$(cat "$RESULT")"
+case "$VERDICT" in
+    PASS*)
+        echo "rendering-probe: OK — $VERDICT"
+        exit 0
+        ;;
+    *)
+        echo "rendering-probe: FAIL — the editor is not rendering the dark scheme:" >&2
+        echo "  $VERDICT" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/rendering-probe.sh
+++ b/scripts/rendering-probe.sh
@@ -71,8 +71,16 @@ while kill -0 "$APP_PID" 2>/dev/null; do
     waited=$((waited + 2))
 done
 
-# Let the app finish its clean shutdown (it quits via netbeans.close).
-kill -0 "$APP_PID" 2>/dev/null && { wait "$APP_PID" 2>/dev/null || true; }
+# The rendering verdict is complete the moment the result file lands —
+# whether the app then shuts down cleanly is the boot smoke test's job,
+# not this check's. So terminate the app rather than waiting on its exit,
+# which would hang CI forever if a PASS were followed by a stalled
+# shutdown.
+if kill -0 "$APP_PID" 2>/dev/null; then
+    kill -TERM "$APP_PID" 2>/dev/null || true
+    sleep 3
+    kill -KILL "$APP_PID" 2>/dev/null || true
+fi
 
 if [ ! -f "$RESULT" ]; then
     echo "rendering-probe: FAIL — the probe never wrote a result" >&2


### PR DESCRIPTION
## What

Third and last verification-hardening check. v1.10.1 shipped a dark IDE with an **unreadable white editor** for who knows how long, green through all of CI — because CI packaged the app but never observed a single resolved editor color. `DarkProfileLayerTest` guards the source layer; this guards what the platform *actually activates at runtime*.

## What it asserts

`RenderingProbe` (`@OnStart` in the editor module, inert unless `-Dnmox.rendering.probe=true`) reads the runtime `FontColorSettings` for `text/javascript` under the active profile:

1. **default background is dark** (luminance ≤ 96) — catches the profile falling back to light "NetBeans" (bug half 1);
2. **keyword resolves to Phosphor `#ff6ac1`** — catches the palette not being registered under the active profile (bug half 2).

Both read the genuinely-public `FontColorSettings` API — no dependency on the profile-name impl class, whose package a module might not export. It runs at `@OnStart` (not `@OnShowing`) because the resolved colors are model state needing no shown window — which is also why it survives the headless boot where `@OnShowing` would race `netbeans.close`.

`scripts/rendering-probe.sh` boots the assembled app with the probe on (fresh userdir), and asserts the result is `PASS`.

## Why colors, not the profile name

Asserting the *resolved* colors is strictly stronger than asserting the profile string: it catches a light fallback AND a palette-under-wrong-profile regression, which are the two independent ways the v1.10.1 bug actually manifested.

## Proven by breaking it

Reverted the profile attr to the folder-name form `"FlatLafDark"` (which the settings storage validates to the *light* profile — the exact v1.10.1 regression), rebuilt → driver goes **red**:
```
rendering-probe: FAIL — the editor is not rendering the dark scheme:
  FAIL: editor background #ffffff (luminance 255) is light — the active profile is not the dark one
```
Restored → **green**:
```
rendering-probe: OK — PASS: background=#2b2b2b (dark), text/javascript keyword=#ff6ac1
```

## Tests

`RenderingProbeTest` (5) pins the verdict logic without booting: dark scheme → PASS, light background → FAIL, non-Phosphor keyword → FAIL, null colors → FAIL, threshold margin. `mvn verify -pl editor`: SpotBugs 0, JaCoCo floor met. Wired into CI on both platforms (Linux xvfb, macOS direct); this PR's CI run is the live headless proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)