### PR TITLE
Experiments + the platform used properly (Quick Search, status line, one Options category)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ kill work behind your back, the environment your commands run in is
 finally file-based, honest, and leak-free — and the app itself stops
 carrying another IDE's furniture.
 
+### Added — the platform, used properly
+- **Experiments: throwaway work is first-class.** File → New
+  Experiment… (Cmd+Shift+E) generates any template into
+  `~/.nmox/experiments` — no git repo, no recents pollution, the
+  directory pre-trusted so devices run without prompts — and aims the
+  rack at it. Keepers graduate (promote = move + git init + marker
+  removed); the rest are discarded, which stops anything running there
+  first and refuses to delete unmarked directories by contract.
+- **Quick Search knows the product.** The toolbar search (Cmd+I) now
+  matches recent projects (Enter re-aims the IDE through the switch
+  guard) and the device catalog (Enter racks the device) alongside the
+  platform's actions and files.
+- **The status line answers "is anything running?"** A green lane
+  count with device names on hover appears while servers, tunnels, or
+  watch builds are live — visible from any window, gone when quiet.
+- **One Options category.** Tools → Options → NMOX Studio, with Rack &
+  Cloud and Format on Save as subpanels — no more settings scattered
+  across top-level categories.
+
 ### Changed — crisp
 - **Evicted the VCS museum.** Mercurial, Subversion, the CVS installer
   shim, the Jenkins (hudson) client, and the Selenium server bridge no

--- a/editor/src/main/java/org/nmox/studio/editor/format/FormatOnSaveOptionsController.java
+++ b/editor/src/main/java/org/nmox/studio/editor/format/FormatOnSaveOptionsController.java
@@ -26,10 +26,11 @@ import org.openide.util.NbBundle;
     "FormatOnSave_Keywords=format save prettier formatter"
 })
 @OptionsPanelController.SubRegistration(
-        location = "Editor",
+        location = "NmoxStudio",
         displayName = "#FormatOnSave_DisplayName",
         keywords = "#FormatOnSave_Keywords",
-        keywordsCategory = "Editor/FormatOnSave"
+        keywordsCategory = "NmoxStudio/FormatOnSave",
+        position = 200
 )
 public class FormatOnSaveOptionsController extends OptionsPanelController {
 

--- a/rack/pom.xml
+++ b/rack/pom.xml
@@ -111,6 +111,13 @@
             <version>20260522</version>
         </dependency>
 
+        <!-- Quick Search providers (toolbar Cmd+I) -->
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-spi-quicksearch</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+
         <!-- Testing dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -153,6 +160,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <OpenIDE-Module-Layer>org/nmox/studio/rack/layer.xml</OpenIDE-Module-Layer>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/rack/src/main/java/org/nmox/studio/rack/options/RackOptionsPanelController.java
+++ b/rack/src/main/java/org/nmox/studio/rack/options/RackOptionsPanelController.java
@@ -21,12 +21,17 @@ import org.openide.util.NbPreferences;
  * scattered dialogs - cloud API tokens for the infra designer and the
  * REFLEX watcher's poll interval - in one honest panel.
  */
-@OptionsPanelController.TopLevelRegistration(
-        categoryName = "NMOX Rack",
-        iconBase = "org/nmox/studio/rack/options/rack32.png",
-        keywords = "nmox rack reflex token digitalocean hetzner cloudflare",
-        keywordsCategory = "NmoxRack"
+@OptionsPanelController.SubRegistration(
+        location = "NmoxStudio",
+        displayName = "#RackOptions_DisplayName",
+        keywords = "#RackOptions_Keywords",
+        keywordsCategory = "NmoxStudio/Rack",
+        position = 100
 )
+@org.openide.util.NbBundle.Messages({
+    "RackOptions_DisplayName=Rack & Cloud",
+    "RackOptions_Keywords=rack reflex token digitalocean hetzner cloudflare"
+})
 public class RackOptionsPanelController extends OptionsPanelController {
 
     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);

--- a/rack/src/main/java/org/nmox/studio/rack/options/package-info.java
+++ b/rack/src/main/java/org/nmox/studio/rack/options/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * One "NMOX Studio" category in Tools &gt; Options: every product
+ * setting registers as a subpanel here instead of scattering across
+ * top-level categories.
+ */
+@OptionsPanelController.ContainerRegistration(
+        id = "NmoxStudio",
+        categoryName = "#OptionsCategory_Name_NmoxStudio",
+        iconBase = "org/nmox/studio/rack/options/rack32.png",
+        keywords = "#OptionsCategory_Keywords_NmoxStudio",
+        keywordsCategory = "NmoxStudio")
+@org.openide.util.NbBundle.Messages({
+    "OptionsCategory_Name_NmoxStudio=NMOX Studio",
+    "OptionsCategory_Keywords_NmoxStudio=nmox studio rack cloud format"
+})
+package org.nmox.studio.rack.options;
+
+import org.netbeans.spi.options.OptionsPanelController;

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/Experiments.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/Experiments.java
@@ -1,0 +1,122 @@
+package org.nmox.studio.rack.projectstudio;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.nmox.studio.rack.model.Rack;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.service.RackService;
+import org.nmox.studio.rack.service.WorkspaceTrust;
+
+/**
+ * Throwaway workspaces, first-class: an experiment is a real project
+ * generated from a template into {@code ~/.nmox/experiments}, minus the
+ * ceremony - no git repo, no recents pollution, the parent directory
+ * trusted once so devices run without prompts. Promote turns a keeper
+ * into a normal project (move + git init); discard stops anything
+ * running there and deletes the tree. The {@code .nmox-experiment}
+ * marker is the contract: only marked directories can be discarded.
+ */
+public final class Experiments {
+
+    public static final String MARKER = ".nmox-experiment";
+
+    private Experiments() {
+    }
+
+    public static File root() {
+        return new File(System.getProperty("user.home"), ".nmox/experiments");
+    }
+
+    /** Generates a fresh experiment and returns its directory. */
+    public static File create(ProjectTemplates template, String name) throws IOException {
+        File root = root();
+        Files.createDirectories(root.toPath());
+        WorkspaceTrust.trust(root); // parent-path match pre-trusts every experiment
+        String base = name == null || name.isBlank()
+                ? template.name().toLowerCase().replace('_', '-')
+                : name.trim().replaceAll("[^A-Za-z0-9._-]", "-");
+        File dir = unique(root, base);
+        template.generate(dir, dir.getName()); // deliberately no git init
+        Files.writeString(new File(dir, MARKER).toPath(),
+                "created=" + java.time.LocalDate.now() + "\ntemplate=" + template.name() + "\n");
+        return dir;
+    }
+
+    private static File unique(File root, String base) {
+        File dir = new File(root, base);
+        int n = 2;
+        while (dir.exists()) {
+            dir = new File(root, base + "-" + n++);
+        }
+        return dir;
+    }
+
+    public static boolean isExperiment(File dir) {
+        return dir != null && new File(dir, MARKER).isFile();
+    }
+
+    /** Existing experiments, most recently touched first. */
+    public static List<File> list() {
+        File[] kids = root().listFiles(File::isDirectory);
+        List<File> result = new ArrayList<>();
+        if (kids != null) {
+            for (File kid : kids) {
+                if (isExperiment(kid)) {
+                    result.add(kid);
+                }
+            }
+        }
+        result.sort(Comparator.comparingLong(File::lastModified).reversed());
+        return result;
+    }
+
+    /**
+     * A keeper graduates: moved under destParent, marker removed, git
+     * repo initialized - from here on it is an ordinary project.
+     */
+    public static File promote(File experiment, File destParent) throws IOException {
+        if (!isExperiment(experiment)) {
+            throw new IOException("Not an experiment: " + experiment);
+        }
+        File dest = new File(destParent, experiment.getName());
+        if (dest.exists()) {
+            throw new IOException("Already exists: " + dest);
+        }
+        Files.createDirectories(destParent.toPath());
+        Files.move(experiment.toPath(), dest.toPath());
+        Files.deleteIfExists(new File(dest, MARKER).toPath());
+        ProjectTemplates.initGitRepo(dest);
+        return dest;
+    }
+
+    /**
+     * Stops anything running there and deletes the tree. Refuses
+     * directories without the marker - this method never becomes a
+     * general-purpose rm -rf.
+     */
+    public static void discard(File experiment) throws IOException {
+        if (!isExperiment(experiment)) {
+            throw new IOException("Not an experiment: " + experiment);
+        }
+        Rack rack = RackService.getDefault().getRack();
+        if (experiment.equals(rack.getProjectDir())) {
+            for (RackDevice d : rack.getDevices()) {
+                d.panic();
+            }
+        }
+        deleteTree(experiment.toPath());
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        try (var walk = Files.walk(root)) {
+            for (Path p : walk.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(p);
+            }
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/search/DeviceSearchProvider.java
+++ b/rack/src/main/java/org/nmox/studio/rack/search/DeviceSearchProvider.java
@@ -1,0 +1,42 @@
+package org.nmox.studio.rack.search;
+
+import java.util.Locale;
+import org.netbeans.spi.quicksearch.SearchProvider;
+import org.netbeans.spi.quicksearch.SearchRequest;
+import org.netbeans.spi.quicksearch.SearchResponse;
+import org.nmox.studio.rack.devices.DeviceType;
+import org.nmox.studio.rack.service.RackService;
+
+/**
+ * Quick Search over the device catalog: type "tunnel" or "docker" in
+ * the toolbar search and Enter racks the device and opens the rack -
+ * faster than scrolling the palette when you know what you want.
+ */
+public class DeviceSearchProvider implements SearchProvider {
+
+    @Override
+    public void evaluate(SearchRequest request, SearchResponse response) {
+        String needle = request.getText() == null ? ""
+                : request.getText().toLowerCase(Locale.ROOT);
+        if (needle.isBlank()) {
+            return;
+        }
+        for (DeviceType type : DeviceType.values()) {
+            if (type.getTitle().toLowerCase(Locale.ROOT).contains(needle)
+                    || type.getDescription().toLowerCase(Locale.ROOT).contains(needle)) {
+                boolean more = response.addResult(() -> javax.swing.SwingUtilities.invokeLater(() -> {
+                    RackService.getDefault().getRack().addDevice(type.create());
+                    org.openide.windows.TopComponent rack = org.openide.windows.WindowManager
+                            .getDefault().findTopComponent("RackTopComponent");
+                    if (rack != null) {
+                        rack.open();
+                        rack.requestActive();
+                    }
+                }), type.getTitle() + "  —  " + type.getDescription());
+                if (!more) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/search/RecentProjectSearchProvider.java
+++ b/rack/src/main/java/org/nmox/studio/rack/search/RecentProjectSearchProvider.java
@@ -1,0 +1,37 @@
+package org.nmox.studio.rack.search;
+
+import java.io.File;
+import java.util.Locale;
+import org.netbeans.spi.quicksearch.SearchProvider;
+import org.netbeans.spi.quicksearch.SearchRequest;
+import org.netbeans.spi.quicksearch.SearchResponse;
+import org.nmox.studio.rack.service.RackService;
+
+/**
+ * Quick Search over recent projects: type a project's name in the
+ * toolbar search (Cmd+I) and Enter re-aims the whole IDE - through the
+ * same live-process guard as every other switch path.
+ */
+public class RecentProjectSearchProvider implements SearchProvider {
+
+    @Override
+    public void evaluate(SearchRequest request, SearchResponse response) {
+        String needle = request.getText() == null ? ""
+                : request.getText().toLowerCase(Locale.ROOT);
+        if (needle.isBlank()) {
+            return;
+        }
+        for (File dir : RackService.getDefault().getRecentProjects()) {
+            if (dir.getName().toLowerCase(Locale.ROOT).contains(needle)
+                    || dir.getAbsolutePath().toLowerCase(Locale.ROOT).contains(needle)) {
+                boolean more = response.addResult(
+                        () -> javax.swing.SwingUtilities.invokeLater(
+                                () -> RackService.getDefault().openProject(dir)),
+                        dir.getName() + "  —  " + dir.getAbsolutePath());
+                if (!more) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/RackService.java
@@ -167,6 +167,22 @@ public class RackService {
     }
 
     /**
+     * Aims the rack without touching the recent-projects list - for
+     * experiments, which must not evict real work from the ten slots.
+     * The live-process guard still applies.
+     */
+    public void openProjectQuietly(File dir) {
+        if (dir == null || !dir.isDirectory()) {
+            return;
+        }
+        if (!stopLiveForSwitch(dir)) {
+            return;
+        }
+        aimed = true;
+        getRack().setProjectDir(dir);
+    }
+
+    /**
      * Test seam: production asks via a platform dialog; tests inject an
      * answer. Returns true when the switch may proceed.
      */

--- a/rack/src/main/java/org/nmox/studio/rack/service/RackStatusLine.java
+++ b/rack/src/main/java/org/nmox/studio/rack/service/RackStatusLine.java
@@ -1,0 +1,51 @@
+package org.nmox.studio.rack.service;
+
+import java.awt.Component;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.Timer;
+import org.nmox.studio.rack.model.RackDevice;
+import org.openide.awt.StatusLineElementProvider;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * The status line answers "is anything running?" without opening the
+ * rack: a green lane count appears while dev servers, tunnels, or
+ * watch builds are live, and vanishes when the rack is quiet.
+ */
+@ServiceProvider(service = StatusLineElementProvider.class, position = 600)
+public class RackStatusLine implements StatusLineElementProvider {
+
+    @Override
+    public Component getStatusLineElement() {
+        JLabel label = new JLabel("");
+        label.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
+        Timer poll = new Timer(2_000, e -> {
+            int live = 0;
+            StringBuilder names = new StringBuilder();
+            try {
+                for (RackDevice d : RackService.getDefault().getRack().getDevices()) {
+                    if (d.isLive()) {
+                        live++;
+                        if (names.length() > 0) {
+                            names.append(", ");
+                        }
+                        names.append(d.getTitle());
+                    }
+                }
+            } catch (RuntimeException ex) {
+                return; // rack unavailable mid-shutdown; keep the last text
+            }
+            if (live == 0) {
+                label.setText("");
+                label.setToolTipText(null);
+            } else {
+                label.setText("● " + live + " running");
+                label.setForeground(new java.awt.Color(80, 200, 110));
+                label.setToolTipText(names.toString());
+            }
+        });
+        poll.start();
+        return label;
+    }
+}

--- a/rack/src/main/resources/org/nmox/studio/rack/layer.xml
+++ b/rack/src/main/resources/org/nmox/studio/rack/layer.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "https://netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <!-- Quick Search (Cmd+I) providers: recent projects and the device
+         catalog. The platform contributes Actions/Files/Recent Files;
+         these make the rack itself searchable. -->
+    <folder name="QuickSearch">
+        <folder name="Projects">
+            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.nmox.studio.rack.search.Bundle"/>
+            <attr name="position" intvalue="250"/>
+            <file name="org-nmox-studio-rack-search-RecentProjectSearchProvider.instance"/>
+        </folder>
+        <folder name="Rack">
+            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.nmox.studio.rack.search.Bundle"/>
+            <attr name="position" intvalue="300"/>
+            <file name="org-nmox-studio-rack-search-DeviceSearchProvider.instance"/>
+        </folder>
+    </folder>
+</filesystem>

--- a/rack/src/main/resources/org/nmox/studio/rack/search/Bundle.properties
+++ b/rack/src/main/resources/org/nmox/studio/rack/search/Bundle.properties
@@ -1,0 +1,2 @@
+QuickSearch/Rack=Rack Devices
+QuickSearch/Projects=Projects

--- a/rack/src/test/java/org/nmox/studio/rack/projectstudio/ExperimentsTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/projectstudio/ExperimentsTest.java
@@ -1,0 +1,72 @@
+package org.nmox.studio.rack.projectstudio;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The experiment lifecycle contract: throwaway means no git and a
+ * marker; promote means move + un-mark; discard refuses anything that
+ * is not marked - it must never become a general-purpose rm -rf.
+ */
+class ExperimentsTest {
+
+    @Test
+    @DisplayName("Promote moves the tree, drops the marker, keeps the files")
+    void promoteGraduatesTheExperiment(@TempDir Path work) throws IOException {
+        File exp = new File(work.toFile(), "exp");
+        Files.createDirectories(exp.toPath());
+        Files.writeString(new File(exp, Experiments.MARKER).toPath(), "created=today\n");
+        Files.writeString(new File(exp, "index.html").toPath(), "<html/>");
+
+        File dest = Experiments.promote(exp, new File(work.toFile(), "projects"));
+
+        assertThat(exp).doesNotExist();
+        assertThat(new File(dest, "index.html")).exists();
+        assertThat(new File(dest, Experiments.MARKER)).doesNotExist();
+    }
+
+    @Test
+    @DisplayName("Promote and discard refuse unmarked directories")
+    void refusesUnmarkedDirectories(@TempDir Path work) throws IOException {
+        File notAnExperiment = new File(work.toFile(), "real-project");
+        Files.createDirectories(notAnExperiment.toPath());
+        Files.writeString(new File(notAnExperiment, "precious.txt").toPath(), "data");
+
+        assertThatThrownBy(() -> Experiments.discard(notAnExperiment))
+                .isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> Experiments.promote(notAnExperiment, work.toFile()))
+                .isInstanceOf(IOException.class);
+        assertThat(new File(notAnExperiment, "precious.txt")).exists();
+    }
+
+    @Test
+    @DisplayName("Discard deletes a marked tree completely")
+    void discardDeletesMarkedTree(@TempDir Path work) throws IOException {
+        File exp = new File(work.toFile(), "exp");
+        Files.createDirectories(new File(exp, "src").toPath());
+        Files.writeString(new File(exp, Experiments.MARKER).toPath(), "created=today\n");
+        Files.writeString(new File(exp, "src/app.js").toPath(), "console.log(1)");
+
+        Experiments.discard(exp);
+
+        assertThat(exp).doesNotExist();
+    }
+
+    @Test
+    @DisplayName("isExperiment is exactly the marker check")
+    void markerIsTheContract(@TempDir Path work) throws IOException {
+        File dir = new File(work.toFile(), "d");
+        Files.createDirectories(dir.toPath());
+        assertThat(Experiments.isExperiment(dir)).isFalse();
+        Files.writeString(new File(dir, Experiments.MARKER).toPath(), "x");
+        assertThat(Experiments.isExperiment(dir)).isTrue();
+    }
+}

--- a/ui/src/main/java/org/nmox/studio/ui/actions/NewExperimentAction.java
+++ b/ui/src/main/java/org/nmox/studio/ui/actions/NewExperimentAction.java
@@ -1,0 +1,83 @@
+package org.nmox.studio.ui.actions;
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import org.nmox.studio.rack.projectstudio.Experiments;
+import org.nmox.studio.rack.projectstudio.ProjectTemplates;
+import org.nmox.studio.rack.service.RackService;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+
+/**
+ * New Experiment: a throwaway workspace in two clicks. Pick a template,
+ * optionally name it, and the studio generates it under
+ * ~/.nmox/experiments - no git, no recents pollution, pre-trusted -
+ * and aims the rack at it. Keepers graduate via Experiments.promote;
+ * the rest die without ceremony.
+ */
+@ActionID(category = "File", id = "org.nmox.studio.ui.actions.NewExperimentAction")
+@ActionRegistration(displayName = "#CTL_NewExperimentAction")
+@ActionReferences({
+    @ActionReference(path = "Menu/File", position = 115),
+    @ActionReference(path = "Shortcuts", name = "DS-E")
+})
+@Messages("CTL_NewExperimentAction=New Experiment...")
+public final class NewExperimentAction implements ActionListener {
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        JComboBox<ProjectTemplates> template = new JComboBox<>(ProjectTemplates.values());
+        template.setRenderer(new javax.swing.DefaultListCellRenderer() {
+            @Override
+            public java.awt.Component getListCellRendererComponent(javax.swing.JList<?> l,
+                    Object v, int i, boolean s, boolean f) {
+                ProjectTemplates t = (ProjectTemplates) v;
+                return super.getListCellRendererComponent(l,
+                        t.getDisplayName() + "  —  " + t.getDescription(), i, s, f);
+            }
+        });
+        JTextField name = new JTextField();
+        JPanel panel = new JPanel(new BorderLayout(0, 6));
+        panel.setBorder(javax.swing.BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        JPanel rows = new JPanel(new java.awt.GridLayout(0, 1, 0, 4));
+        rows.add(new JLabel("Template:"));
+        rows.add(template);
+        rows.add(new JLabel("Name (optional — a throwaway name is fine):"));
+        rows.add(name);
+        rows.add(new JLabel("<html><small>Lives in ~/.nmox/experiments — no git, no recents. "
+                + "Promote it later if it turns into something.</small></html>"));
+        panel.add(rows, BorderLayout.CENTER);
+
+        DialogDescriptor descriptor = new DialogDescriptor(panel, "New Experiment");
+        if (DialogDisplayer.getDefault().notify(descriptor) != DialogDescriptor.OK_OPTION) {
+            return;
+        }
+        try {
+            File dir = Experiments.create(
+                    (ProjectTemplates) template.getSelectedItem(), name.getText());
+            RackService.getDefault().openProjectQuietly(dir);
+            org.openide.windows.TopComponent workbench = org.openide.windows.WindowManager
+                    .getDefault().findTopComponent("ProjectExplorerTopComponent");
+            if (workbench != null) {
+                workbench.open();
+                workbench.requestActive();
+            }
+        } catch (Exception ex) {
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
+                    "Could not create the experiment: " + ex.getMessage(),
+                    NotifyDescriptor.ERROR_MESSAGE));
+        }
+    }
+}

--- a/ui/src/main/resources/org/nmox/studio/ui/layer.xml
+++ b/ui/src/main/resources/org/nmox/studio/ui/layer.xml
@@ -19,6 +19,16 @@
              reaches our New Project action instead -->
         <file name="DS-N.shadow_hidden"/>
     </folder>
+    <!-- The Quick Search widget in the toolbar: the platform ships the
+         action (Cmd+I) and the Actions/Files providers; this puts the
+         search field where every modern tool has one. -->
+    <folder name="Toolbars">
+        <folder name="QuickSearch">
+            <file name="org-netbeans-modules-quicksearch-QuickSearchAction.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-quicksearch-QuickSearchAction.instance"/>
+            </file>
+        </folder>
+    </folder>
     <folder name="Keymaps">
         <folder name="NetBeans">
             <!-- jumpto's keymap profile grabs Cmd+O for "Go to Type" (a


### PR DESCRIPTION
## Summary

Final tranche of the daily-driver sprint:

- **Experiments**: throwaway workspaces as a first-class concept — `File → New Experiment…` (Cmd+Shift+E), generated into `~/.nmox/experiments` with no git/no recents/pre-trusted, promote-or-discard lifecycle with a marker-file safety contract (`discard` can never delete an unmarked directory).
- **Quick Search** (Cmd+I) in the toolbar, extended with recent-project and device-catalog providers.
- **Status line** lane counter — "is anything running?" answered from any window.
- **One Options category** — Rack & Cloud + Format on Save under NMOX Studio.

## Verification

Full `mvn verify` green (all modules + gates). Local boot smoke passes with the new layer/service registrations. 4 new `ExperimentsTest` lifecycle tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)