### PR TITLE
Testing rigor: named failures + re-run failed, coverage and throughput floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.13.0] — 2026-07-02
+
+Testing rigor: failures get names and one-click re-runs, and coverage
+and throughput join quality as gates that can close the OK jack.
+
+### Added
+- **VERITAS names its failures.** Failing tests are captured by name
+  across runner families (jest/vitest ✕ lines, pytest FAILED node ids,
+  cargo, go); the FAILURES button lists them and **Re-run failed**
+  runs exactly those — `jest -t`, `vitest -t`, pytest node ids,
+  `cargo test <names>`, `go -run` — no full-suite penance for one red
+  test.
+- **Coverage is a number and a floor.** With COVER on, the measured
+  percentage (istanbul, pytest-cov, go -cover) lands on the tally LCD
+  (`P:41 F:0 C:85%`); dial MIN COV and a green-but-thin suite fires
+  FAIL instead of OK. Unmeasured coverage never gates — the device
+  refuses to punish runners it can't read.
+- **GAUNTLET can fail a pipeline.** MIN R/S puts a throughput floor
+  under the bench: below it, FAIL fires — a load test that always
+  "passes" can't gate anything. Both floors ride the
+  `overallSuccess` hook, so LEDs and jacks tell the same truth.
+
 ## [1.12.0] — 2026-07-02
 
 Three devices that close the last gaps between "runs your toolchain"

--- a/rack/src/main/java/org/nmox/studio/rack/devices/BenchDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BenchDevice.java
@@ -24,11 +24,16 @@ public class BenchDevice extends CommandDevice {
     private static final Pattern SUMMARY =
             Pattern.compile("([\\d.]+)([km]?) requests in ([\\d.]+)s, ([\\d.]+ \\w+) read");
 
+    private static final String[] MINIMUMS = {"off", "100", "500", "1k", "5k"};
+    private static final int[] MINIMUM_RPS = {0, 100, 500, 1_000, 5_000};
+
     private final Knob durationKnob;
     private final Knob connectionsKnob;
+    private final Knob minKnob;
     private final LcdDisplay urlLcd;
     private final LcdDisplay resultLcd;
     private final VuMeter reqMeter;
+    private volatile long lastReqPerSec = -1;
 
     public BenchDevice() {
         super("bench", "GAUNTLET", "LOAD BENCH", new Color(224, 122, 47), 2);
@@ -45,6 +50,8 @@ public class BenchDevice extends CommandDevice {
         resultLcd = place(new LcdDisplay(120, 1), 328, 82);
         resultLcd.setText("—");
         reqMeter = place(new VuMeter("REQ/S", false), 460, 82);
+        minKnob = place(new Knob("MIN R/S", MINIMUMS, 0), 560, 40);
+        minKnob.setToolTipText("Throughput floor: below it, FAIL fires instead of OK");
 
         fire.addActionListener(e -> primaryAction());
 
@@ -55,6 +62,29 @@ public class BenchDevice extends CommandDevice {
         param("duration", durationKnob);
         param("connections", connectionsKnob);
         param("url", urlLcd);
+        param("min", minKnob);
+    }
+
+    /**
+     * A bench that always "passes" can't gate a pipeline. With MIN R/S
+     * dialed, throughput under the floor is a failure - LEDs and jacks
+     * both. Off (the default) keeps the old exit-code behavior.
+     */
+    @Override
+    protected boolean overallSuccess(int exitCode) {
+        if (exitCode != 0) {
+            return false;
+        }
+        int floor = MINIMUM_RPS[minKnob.getSelectedIndex()];
+        if (floor > 0 && lastReqPerSec >= 0 && lastReqPerSec < floor) {
+            long measured = lastReqPerSec;
+            onEdt(() -> {
+                resultLcd.setTextColor(new Color(255, 90, 80));
+                resultLcd.setText(measured + " r/s < MIN " + floor);
+            });
+            return false;
+        }
+        return true;
     }
 
     @Override
@@ -76,6 +106,7 @@ public class BenchDevice extends CommandDevice {
 
     @Override
     protected void primaryAction() {
+        lastReqPerSec = -1;
         onEdt(() -> {
             resultLcd.setTextColor(RackStyle.LCD_AMBER);
             resultLcd.setText("FIRING…");
@@ -106,6 +137,7 @@ public class BenchDevice extends CommandDevice {
         }
         double seconds = Double.parseDouble(m.group(3));
         long reqPerSec = seconds > 0 ? Math.round(count / seconds) : 0;
+        lastReqPerSec = reqPerSec;
         String read = m.group(4);
         reqMeter.setLevel(Math.min(1.0, reqPerSec / 10_000.0));
         onEdt(() -> {

--- a/rack/src/main/java/org/nmox/studio/rack/devices/TestDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/TestDevice.java
@@ -20,12 +20,29 @@ public class TestDevice extends CommandDevice {
     private static final String[] FRAMEWORKS = {"auto", "jest", "vitest", "mocha", "playwright", "cypress", "pytest", "cargo", "go", "mvn", "rspec", "phpunit", "mix", "rebar3", "clojure", "swift", "dotnet", "dart", "sbt", "stack", "zig", "dune", "crystal"};
     private static final Pattern PASSED = Pattern.compile("(\\d+)\\s+(?:passed|passing)");
     private static final Pattern FAILED = Pattern.compile("(\\d+)\\s+(?:failed|failing)");
+    private static final String[] COVERAGE_MINIMUMS = {"off", "50", "60", "70", "80", "90"};
+    /** Failing test names, per runner family. */
+    private static final Pattern[] FAILURE_LINES = {
+        Pattern.compile("^\\s*[✕×✗]\\s+(.+?)(?:\\s+\\(?\\d+\\s*ms\\)?)?$"), // jest/vitest
+        Pattern.compile("^FAILED\\s+(\\S+)"),                                  // pytest node id
+        Pattern.compile("^test (\\S+) \\.\\.\\. FAILED$"),                     // cargo
+        Pattern.compile("^--- FAIL: (\\S+)"),                                  // go
+    };
+    /** Coverage summaries: istanbul text-summary, pytest-cov TOTAL, go -cover. */
+    private static final Pattern[] COVERAGE_LINES = {
+        Pattern.compile("^Lines\\s*:\\s*([\\d.]+)%"),
+        Pattern.compile("^TOTAL\\s+\\d+\\s+\\d+\\s+([\\d.]+)%"),
+        Pattern.compile("coverage:\\s+([\\d.]+)% of statements"),
+    };
 
     private final Knob frameworkKnob;
     private final ToggleSwitch coverageSwitch;
+    private final Knob covMinKnob;
     private final LcdDisplay tallyLcd;
+    private final java.util.List<String> failures = new java.util.concurrent.CopyOnWriteArrayList<>();
     private volatile int passed;
     private volatile int failed;
+    private volatile double coverage = -1;
 
     public TestDevice() {
         super("test", "VERITAS", "TEST HARNESS", new Color(99, 197, 70), 2);
@@ -35,25 +52,144 @@ public class TestDevice extends CommandDevice {
         RackButton stop = place(new RackButton("STOP", RackStyle.STOP), RackStyle.TRANSPORT_STOP_X, 52);
         frameworkKnob = place(new Knob("RUNNER", FRAMEWORKS, 0), 180, 40);
         coverageSwitch = place(new ToggleSwitch("COVER", false), 254, 42);
-        tallyLcd = place(new LcdDisplay(120, 1), 324, 52);
+        covMinKnob = place(new Knob("MIN COV", COVERAGE_MINIMUMS, 0), 324, 40);
+        covMinKnob.setToolTipText("Coverage floor (needs COVER on): below it, FAIL fires instead of OK");
+        tallyLcd = place(new LcdDisplay(160, 1), 44, 82);
         tallyLcd.setText("P:0 F:0");
+        RackButton failuresButton = place(new RackButton("FAILURES", RackStyle.QUERY), 220, 84);
+        failuresButton.setToolTipText("The failing tests by name — with one-click re-run of just those");
 
         run.addActionListener(e -> primaryAction());
         stop.addActionListener(e -> stopProcess());
+        failuresButton.addActionListener(e -> showFailures());
 
         param("framework", frameworkKnob);
         param("coverage", coverageSwitch);
+        param("covMin", covMinKnob);
     }
 
     @Override
     protected void primaryAction() {
         passed = 0;
         failed = 0;
+        coverage = -1;
+        failures.clear();
         onEdt(() -> {
             tallyLcd.setTextColor(org.nmox.studio.rack.ui.controls.RackStyle.LCD_TEXT);
             tallyLcd.setText("P:0 F:0");
         });
         launch(buildCommand());
+    }
+
+    /**
+     * A green suite with thin coverage is not green. With COVER on and
+     * MIN COV dialed, a measured percentage under the floor fails the
+     * run - jacks and LEDs alike. Unmeasured coverage never gates:
+     * the device refuses to punish runners it can't read.
+     */
+    @Override
+    protected boolean overallSuccess(int exitCode) {
+        if (exitCode != 0) {
+            return false;
+        }
+        int floor = coverageMinimum();
+        if (floor > 0 && coverage >= 0 && coverage < floor) {
+            double measured = coverage;
+            onEdt(() -> {
+                tallyLcd.setTextColor(new Color(255, 90, 80));
+                tallyLcd.setText("COV " + Math.round(measured) + "% < MIN " + floor);
+            });
+            return false;
+        }
+        return true;
+    }
+
+    int coverageMinimum() {
+        String sel = covMinKnob.getSelectedOption();
+        return "off".equals(sel) ? 0 : Integer.parseInt(sel);
+    }
+
+    /** The failing test's name if this line reports one, else null. */
+    static String failedTestName(String line) {
+        for (Pattern p : FAILURE_LINES) {
+            Matcher m = p.matcher(line);
+            if (m.find()) {
+                return m.group(1).trim();
+            }
+        }
+        return null;
+    }
+
+    /** The coverage percentage if this line carries one, else -1. */
+    static double coveragePercent(String line) {
+        for (Pattern p : COVERAGE_LINES) {
+            Matcher m = p.matcher(line);
+            if (m.find()) {
+                return Double.parseDouble(m.group(1));
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * The re-run command for exactly the named failures, per runner -
+     * null when the runner has no name filter worth trusting.
+     */
+    static List<String> rerunFailedCommand(String framework, List<String> names) {
+        if (names.isEmpty()) {
+            return null;
+        }
+        String alternation = String.join("|", names);
+        return switch (framework) {
+            case "jest" -> List.of("npx", "jest", "-t", alternation);
+            case "vitest" -> List.of("npx", "vitest", "run", "-t", alternation);
+            case "pytest" -> {
+                List<String> cmd = new ArrayList<>(List.of("python3", "-m", "pytest"));
+                cmd.addAll(names); // node ids re-run directly
+                yield cmd;
+            }
+            case "cargo" -> {
+                List<String> cmd = new ArrayList<>(List.of("cargo", "test"));
+                cmd.addAll(names);
+                yield cmd;
+            }
+            case "go" -> List.of("go", "test", "./...", "-run", alternation);
+            default -> null;
+        };
+    }
+
+    private void showFailures() {
+        java.util.List<String> snapshot = new ArrayList<>(failures);
+        javax.swing.JDialog dialog = new javax.swing.JDialog(
+                (java.awt.Frame) javax.swing.SwingUtilities.getWindowAncestor(this),
+                "VERITAS — failing tests", false);
+        javax.swing.JList<String> list = new javax.swing.JList<>(
+                snapshot.toArray(new String[0]));
+        list.setFont(new java.awt.Font(java.awt.Font.MONOSPACED, java.awt.Font.PLAIN, 12));
+        javax.swing.JPanel south = new javax.swing.JPanel(
+                new java.awt.FlowLayout(java.awt.FlowLayout.LEFT));
+        javax.swing.JButton rerun = new javax.swing.JButton(
+                "Re-run failed (" + snapshot.size() + ")");
+        rerun.setEnabled(rerunFailedCommand(effectiveFramework(), snapshot) != null);
+        rerun.addActionListener(ev -> {
+            List<String> cmd = rerunFailedCommand(effectiveFramework(), snapshot);
+            if (cmd != null) {
+                dialog.setVisible(false);
+                passed = 0;
+                failed = 0;
+                failures.clear();
+                launch(cmd);
+            }
+        });
+        south.add(rerun);
+        if (snapshot.isEmpty()) {
+            south.add(new javax.swing.JLabel("Nothing failing — run the suite first."));
+        }
+        dialog.add(new javax.swing.JScrollPane(list), java.awt.BorderLayout.CENTER);
+        dialog.add(south, java.awt.BorderLayout.SOUTH);
+        dialog.setSize(560, 360);
+        dialog.setLocationRelativeTo(this);
+        dialog.setVisible(true);
     }
 
     /** AUTO resolves to the project's "test" script, else its test framework dependency. */
@@ -181,12 +317,22 @@ public class TestDevice extends CommandDevice {
         if (m.find()) {
             failed = Integer.parseInt(m.group(1));
         }
+        String failure = failedTestName(line);
+        if (failure != null && failures.size() < 500) {
+            failures.add(failure);
+        }
+        double cov = coveragePercent(line);
+        if (cov >= 0) {
+            coverage = cov;
+        }
         if (passed + failed > 0) {
             final int p = passed, f = failed;
+            final double c = coverage;
             onEdt(() -> {
                 tallyLcd.setTextColor(f > 0 ? new Color(255, 90, 80)
                         : org.nmox.studio.rack.ui.controls.RackStyle.LCD_TEXT);
-                tallyLcd.setText("P:" + p + " F:" + f);
+                tallyLcd.setText("P:" + p + " F:" + f
+                        + (c >= 0 ? " C:" + Math.round(c) + "%" : ""));
             });
         }
     }

--- a/rack/src/test/java/org/nmox/studio/rack/devices/TestingRigorTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/TestingRigorTest.java
@@ -1,0 +1,90 @@
+package org.nmox.studio.rack.devices;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The testing-rigor contract: VERITAS names its failures and re-runs
+ * exactly those; coverage and throughput become gates that close the
+ * OK jack, never silently pass.
+ */
+class TestingRigorTest {
+
+    @Test
+    @DisplayName("Failure lines are recognized across runner families")
+    void failureNamesParse() {
+        assertThat(TestDevice.failedTestName("  ✕ renders the header (23 ms)"))
+                .isEqualTo("renders the header");
+        assertThat(TestDevice.failedTestName("FAILED tests/test_api.py::test_login"))
+                .isEqualTo("tests/test_api.py::test_login");
+        assertThat(TestDevice.failedTestName("test parser::handles_empty ... FAILED"))
+                .isEqualTo("parser::handles_empty");
+        assertThat(TestDevice.failedTestName("--- FAIL: TestCheckout (0.03s)"))
+                .isEqualTo("TestCheckout");
+        assertThat(TestDevice.failedTestName("  ✓ renders the footer")).isNull();
+        assertThat(TestDevice.failedTestName("ordinary output")).isNull();
+    }
+
+    @Test
+    @DisplayName("Coverage summaries are read from istanbul, pytest-cov, and go")
+    void coverageParses() {
+        assertThat(TestDevice.coveragePercent("Lines        : 85.71% ( 42/49 )"))
+                .isEqualTo(85.71);
+        assertThat(TestDevice.coveragePercent("TOTAL     120     18    85%"))
+                .isEqualTo(85.0);
+        assertThat(TestDevice.coveragePercent("ok  \tapp/api\t0.5s\tcoverage: 91.2% of statements"))
+                .isEqualTo(91.2);
+        assertThat(TestDevice.coveragePercent("no coverage here")).isEqualTo(-1);
+    }
+
+    @Test
+    @DisplayName("Re-run failed builds the right filter per runner")
+    void rerunCommands() {
+        assertThat(TestDevice.rerunFailedCommand("jest", List.of("a", "b")))
+                .containsExactly("npx", "jest", "-t", "a|b");
+        assertThat(TestDevice.rerunFailedCommand("vitest", List.of("x")))
+                .containsExactly("npx", "vitest", "run", "-t", "x");
+        assertThat(TestDevice.rerunFailedCommand("pytest",
+                List.of("tests/test_api.py::test_login")))
+                .containsExactly("python3", "-m", "pytest", "tests/test_api.py::test_login");
+        assertThat(TestDevice.rerunFailedCommand("cargo", List.of("parser::handles_empty")))
+                .containsExactly("cargo", "test", "parser::handles_empty");
+        assertThat(TestDevice.rerunFailedCommand("go", List.of("TestA", "TestB")))
+                .containsExactly("go", "test", "./...", "-run", "TestA|TestB");
+        assertThat(TestDevice.rerunFailedCommand("mvn", List.of("t"))).isNull();
+        assertThat(TestDevice.rerunFailedCommand("jest", List.of())).isNull();
+    }
+
+    @Test
+    @DisplayName("VERITAS coverage floor gates a clean exit; unmeasured never gates")
+    void coverageFloorGates() {
+        TestDevice veritas = new TestDevice();
+        veritas.applyState(Map.of("covMin", "4")); // "80"
+        assertThat(veritas.coverageMinimum()).isEqualTo(80);
+
+        assertThat(veritas.overallSuccess(0))
+                .as("floor set but nothing measured: pass").isTrue();
+        veritas.onLine("Lines : 62.0% ( 62/100 )");
+        assertThat(veritas.overallSuccess(0)).as("62 < 80: gate closed").isFalse();
+        veritas.onLine("Lines : 91.0% ( 91/100 )");
+        assertThat(veritas.overallSuccess(0)).as("91 >= 80: pass").isTrue();
+        assertThat(veritas.overallSuccess(1)).as("exit 1 always fails").isFalse();
+    }
+
+    @Test
+    @DisplayName("GAUNTLET throughput floor gates a clean exit")
+    void benchFloorGates() {
+        BenchDevice gauntlet = new BenchDevice();
+        assertThat(gauntlet.overallSuccess(0)).as("floor off").isTrue();
+
+        gauntlet.applyState(Map.of("min", "3")); // "1k"
+        gauntlet.onLine("2k requests in 10.0s, 4 MB read");   // 200 r/s
+        assertThat(gauntlet.overallSuccess(0)).as("200 < 1000").isFalse();
+        gauntlet.onLine("120k requests in 10.0s, 24 MB read"); // 12000 r/s
+        assertThat(gauntlet.overallSuccess(0)).as("12000 >= 1000").isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- **VERITAS**: failing tests captured by name (jest/vitest/pytest/cargo/go), FAILURES viewer, and **Re-run failed** with per-runner filters. Coverage % on the tally LCD + a MIN COV floor that fails green-but-thin suites (unmeasured coverage never gates).
- **GAUNTLET**: MIN R/S throughput floor — a bench below the bar fires FAIL and can gate a deploy.
- Both ride `CommandDevice.overallSuccess`; LEDs and jacks agree.

## Verification

Full `mvn verify` green. TestingRigorTest 5/5; DeviceContractTest 217/217 (it rejected the first faceplate layout during development — fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)