### PR TITLE
Infra truth: drift detection + one-click stack teardown with cost framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.14.0] — 2026-07-02
+
+Infra truth and teardown: the designer stops being create-only — the
+canvas can now ask the cloud what is really there, and take a whole
+stack down in one decision with the bill in view.
+
+### Added
+- **Refresh — drift detection.** Every deployed node is re-checked
+  against the provider API: a droplet deleted in the cloud console
+  stops claiming "live" and reports **drifted: deleted in cloud**
+  (its stale id is released so re-deploy works). Kinds without a
+  per-resource read endpoint say "unverifiable" honestly instead of
+  guessing.
+- **Destroy stack — one-click teardown with the bill in view.** The
+  confirmation names every deployed resource and what destroying them
+  saves ("Destroy 6 cloud resources, saving ~$48.00/month?"), then
+  tears down in reverse dependency order — attachments and dependents
+  before the resources they lean on. Individual failures don't strand
+  the rest; the design stays on the canvas, ready to deploy again.
+
 ## [1.13.0] — 2026-07-02
 
 Testing rigor: failures get names and one-click re-runs, and coverage

--- a/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
+++ b/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
@@ -162,6 +162,17 @@ public final class InfraDesignerTopComponent extends TopComponent {
         sync.addActionListener(e -> syncFromCloud());
         bar.add(sync);
 
+        JButton refresh = new JButton("Refresh");
+        refresh.setToolTipText("Ask the cloud whether every deployed node still exists — deletions show as drifted");
+        refresh.addActionListener(e -> refreshDrift());
+        bar.add(refresh);
+
+        JButton destroyStack = new JButton("Destroy stack…");
+        destroyStack.setForeground(new Color(0xC6, 0x2B, 0x2B));
+        destroyStack.setToolTipText("Tear down every deployed resource in reverse dependency order");
+        destroyStack.addActionListener(e -> destroyStack());
+        bar.add(destroyStack);
+
         JButton fit = new JButton("Fit");
         fit.addActionListener(e -> canvas.fit());
         bar.add(fit);
@@ -278,6 +289,64 @@ public final class InfraDesignerTopComponent extends TopComponent {
                         "Sync failed: " + ex.getMessage(), "Infra Designer", JOptionPane.ERROR_MESSAGE));
             }
         }, "nmox-infra-sync");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /** The drift check: designed vs actual, node by node. */
+    private void refreshDrift() {
+        Thread worker = new Thread(() -> {
+            try {
+                client.refreshDrift(graph, (node, status) ->
+                        SwingUtilities.invokeLater(() -> graph.setStatus(node, status)));
+                SwingUtilities.invokeLater(this::save);
+            } catch (Exception ex) {
+                SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this,
+                        "Refresh failed: " + ex.getMessage(), "Refresh", JOptionPane.ERROR_MESSAGE));
+            }
+        }, "nmox-infra-refresh");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /**
+     * One decision, whole stack: name every deployed resource and the
+     * monthly bill it carries, then tear down in reverse dependency
+     * order. The design stays on the canvas, ready to deploy again.
+     */
+    private void destroyStack() {
+        java.util.List<InfraNode> order = DeployPlanner.teardownOrder(graph);
+        if (order.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Nothing deployed to destroy.");
+            return;
+        }
+        double monthly = 0;
+        StringBuilder names = new StringBuilder();
+        for (InfraNode node : order) {
+            monthly += node.monthlyUsd();
+            names.append("  • ").append(node.kind.getDisplayName())
+                    .append("  ").append(node.label).append('\n');
+        }
+        int answer = JOptionPane.showConfirmDialog(this,
+                "Destroy " + order.size() + " cloud resource" + (order.size() == 1 ? "" : "s")
+                + ", saving ~$" + String.format("%.2f", monthly) + "/month?\n\n" + names
+                + "\nReverse dependency order. The design stays on the canvas.",
+                "Destroy stack", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+        if (answer != JOptionPane.YES_OPTION) {
+            return;
+        }
+        Thread worker = new Thread(() -> {
+            int failures = client.destroyAll(order, (node, status) ->
+                    SwingUtilities.invokeLater(() -> graph.setStatus(node, status)));
+            SwingUtilities.invokeLater(() -> {
+                save();
+                if (failures > 0) {
+                    JOptionPane.showMessageDialog(this,
+                            failures + " resource(s) could not be destroyed — check their status lines.",
+                            "Destroy stack", JOptionPane.WARNING_MESSAGE);
+                }
+            });
+        }, "nmox-infra-destroy-stack");
         worker.setDaemon(true);
         worker.start();
     }

--- a/infra/src/main/java/org/nmox/studio/infra/api/DeployPlanner.java
+++ b/infra/src/main/java/org/nmox/studio/infra/api/DeployPlanner.java
@@ -47,6 +47,18 @@ public final class DeployPlanner {
     }
 
     /** Kahn's algorithm over creation-dependency edges (stable order). */
+    /**
+     * The teardown order for everything deployed: creation order
+     * reversed, so dependents (attachments, LBs, records) fall before
+     * the resources they lean on. Design-only nodes are not included.
+     */
+    public static List<InfraNode> teardownOrder(InfraGraph graph) {
+        List<InfraNode> order = new java.util.ArrayList<>(topologicalOrder(graph));
+        java.util.Collections.reverse(order);
+        order.removeIf(node -> node.doId == null);
+        return order;
+    }
+
     private static List<InfraNode> topologicalOrder(InfraGraph graph) {
         List<InfraNode> nodes = graph.getNodes();
         Map<String, Integer> indegree = new LinkedHashMap<>();

--- a/infra/src/main/java/org/nmox/studio/infra/api/DigitalOceanClient.java
+++ b/infra/src/main/java/org/nmox/studio/infra/api/DigitalOceanClient.java
@@ -301,32 +301,101 @@ public final class DigitalOceanClient {
         return imported;
     }
 
+    /**
+     * The REST path addressing a node's live resource - shared by
+     * destroy and drift checks; null when the provider offers no
+     * per-resource endpoint (Cloudflare records, Hetzner kinds).
+     */
+    static String resourcePath(org.nmox.studio.infra.model.NodeKind kind, String id) {
+        return switch (kind) {
+            case DROPLET, GPU_DROPLET -> "/v2/droplets/" + id;
+            case VPC -> "/v2/vpcs/" + id;
+            case LOAD_BALANCER -> "/v2/load_balancers/" + id;
+            case FIREWALL -> "/v2/firewalls/" + id;
+            case VOLUME -> "/v2/volumes/" + id;
+            case RESERVED_IP -> "/v2/reserved_ips/" + id;
+            case DOMAIN -> "/v2/domains/" + id;
+            case CDN -> "/v2/cdn/endpoints/" + id;
+            case KUBERNETES -> "/v2/kubernetes/clusters/" + id;
+            case APP_PLATFORM -> "/v2/apps/" + id;
+            case FUNCTIONS -> "/v2/functions/namespaces/" + id;
+            case CONTAINER_REGISTRY -> "/v2/registry";
+            case SSH_KEY -> "/v2/account/keys/" + id;
+            case CERTIFICATE -> "/v2/certificates/" + id;
+            case MONITOR_ALERT -> "/v2/monitoring/alerts/" + id;
+            case GRADIENT_AI -> "/v2/gen-ai/agents/" + id;
+            case DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY, DB_KAFKA, DB_OPENSEARCH ->
+                "/v2/databases/" + id;
+            default -> null;
+        };
+    }
+
+    /**
+     * Drift check: asks the cloud whether each deployed node still
+     * exists. A resource deleted behind the designer's back stops
+     * claiming "live" - it reports drifted instead. Kinds without a
+     * read endpoint are labeled honestly, never guessed.
+     */
+    public void refreshDrift(InfraGraph graph,
+            java.util.function.BiConsumer<InfraNode, String> onStatus)
+            throws IOException, InterruptedException {
+        for (InfraNode node : graph.getNodes()) {
+            if (node.doId == null) {
+                continue;
+            }
+            String path = resourcePath(node.kind, node.doId);
+            if (path == null) {
+                onStatus.accept(node, "unverifiable (no read API)");
+                continue;
+            }
+            try {
+                send("GET", path, "");
+                onStatus.accept(node, "live");
+            } catch (IOException ex) {
+                String msg = ex.getMessage() == null ? "" : ex.getMessage();
+                if (msg.contains("404")) {
+                    node.doId = null; // the cloud is the truth: it is gone
+                    onStatus.accept(node, "drifted: deleted in cloud");
+                } else {
+                    onStatus.accept(node, "check failed: " + (msg.length() > 60 ? msg.substring(0, 60) : msg));
+                }
+            }
+        }
+    }
+
+    /**
+     * Tears down the given nodes in the order handed in (callers pass
+     * DeployPlanner.teardownOrder - reverse dependency order). Keeps
+     * going past individual failures so one stuck resource does not
+     * strand the rest of the bill; returns the failure count.
+     */
+    public int destroyAll(java.util.List<InfraNode> nodes,
+            java.util.function.BiConsumer<InfraNode, String> onStep) {
+        int failures = 0;
+        for (InfraNode node : nodes) {
+            try {
+                onStep.accept(node, "destroying…");
+                destroy(node);
+                if (node.doId == null) {
+                    onStep.accept(node, "destroyed");
+                } else {
+                    failures++;
+                    onStep.accept(node, "no delete API — remove manually");
+                }
+            } catch (Exception ex) {
+                failures++;
+                onStep.accept(node, "destroy failed: " + ex.getMessage());
+            }
+        }
+        return failures;
+    }
+
     /** Destroys the cloud resource behind a node (the node stays designed). */
     public void destroy(InfraNode node) throws IOException, InterruptedException {
         if (node.doId == null) {
             return;
         }
-        String path = switch (node.kind) {
-            case DROPLET, GPU_DROPLET -> "/v2/droplets/" + node.doId;
-            case VPC -> "/v2/vpcs/" + node.doId;
-            case LOAD_BALANCER -> "/v2/load_balancers/" + node.doId;
-            case FIREWALL -> "/v2/firewalls/" + node.doId;
-            case VOLUME -> "/v2/volumes/" + node.doId;
-            case RESERVED_IP -> "/v2/reserved_ips/" + node.doId;
-            case DOMAIN -> "/v2/domains/" + node.doId;
-            case CDN -> "/v2/cdn/endpoints/" + node.doId;
-            case KUBERNETES -> "/v2/kubernetes/clusters/" + node.doId;
-            case APP_PLATFORM -> "/v2/apps/" + node.doId;
-            case FUNCTIONS -> "/v2/functions/namespaces/" + node.doId;
-            case CONTAINER_REGISTRY -> "/v2/registry";
-            case SSH_KEY -> "/v2/account/keys/" + node.doId;
-            case CERTIFICATE -> "/v2/certificates/" + node.doId;
-            case MONITOR_ALERT -> "/v2/monitoring/alerts/" + node.doId;
-            case GRADIENT_AI -> "/v2/gen-ai/agents/" + node.doId;
-            case DB_POSTGRES, DB_MYSQL, DB_MONGODB, DB_VALKEY, DB_KAFKA, DB_OPENSEARCH ->
-                "/v2/databases/" + node.doId;
-            default -> null;
-        };
+        String path = resourcePath(node.kind, node.doId);
         if (path != null) {
             send("DELETE", path, "");
             node.doId = null;

--- a/infra/src/test/java/org/nmox/studio/infra/api/InfraTruthTest.java
+++ b/infra/src/test/java/org/nmox/studio/infra/api/InfraTruthTest.java
@@ -1,0 +1,71 @@
+package org.nmox.studio.infra.api;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.NodeKind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Infra truth and teardown: the stack comes down in reverse dependency
+ * order, only deployed nodes are touched, and every destroyable or
+ * checkable kind resolves to a real per-resource API path.
+ */
+class InfraTruthTest {
+
+    @Test
+    @DisplayName("Teardown reverses creation order: domain -> LB -> droplet -> VPC")
+    void teardownReversesDependencies() {
+        InfraGraph graph = new InfraGraph();
+        var vpc = graph.addNode(NodeKind.VPC, 0, 0);
+        var droplet = graph.addNode(NodeKind.DROPLET, 200, 0);
+        var lb = graph.addNode(NodeKind.LOAD_BALANCER, 400, 0);
+        var domain = graph.addNode(NodeKind.DOMAIN, 600, 0);
+        graph.connect(vpc, droplet);
+        graph.connect(droplet, lb);
+        graph.connect(lb, domain);
+        for (var node : List.of(vpc, droplet, lb, domain)) {
+            node.doId = "id-" + node.id;
+        }
+
+        var order = DeployPlanner.teardownOrder(graph);
+
+        assertThat(order.indexOf(domain)).isLessThan(order.indexOf(lb));
+        assertThat(order.indexOf(lb)).isLessThan(order.indexOf(droplet));
+        assertThat(order.indexOf(droplet)).isLessThan(order.indexOf(vpc));
+    }
+
+    @Test
+    @DisplayName("Teardown touches only deployed nodes; design-only stays designed")
+    void teardownSkipsDesignOnly() {
+        InfraGraph graph = new InfraGraph();
+        var deployed = graph.addNode(NodeKind.DROPLET, 0, 0);
+        var designed = graph.addNode(NodeKind.VOLUME, 200, 0);
+        deployed.doId = "42";
+
+        var order = DeployPlanner.teardownOrder(graph);
+
+        assertThat(order).containsExactly(deployed);
+    }
+
+    @Test
+    @DisplayName("Every DigitalOcean kind resolves a per-resource path; CF/HZ honestly do not")
+    void resourcePathsAreReal() {
+        assertThat(DigitalOceanClient.resourcePath(NodeKind.DROPLET, "7"))
+                .isEqualTo("/v2/droplets/7");
+        assertThat(DigitalOceanClient.resourcePath(NodeKind.DB_POSTGRES, "abc"))
+                .isEqualTo("/v2/databases/abc");
+        assertThat(DigitalOceanClient.resourcePath(NodeKind.SSH_KEY, "9"))
+                .isEqualTo("/v2/account/keys/9");
+        // no per-record read endpoint: drift check must say so, not guess
+        assertThat(DigitalOceanClient.resourcePath(NodeKind.CF_DNS_RECORD, "x")).isNull();
+    }
+
+    @Test
+    @DisplayName("Empty designs tear down to an empty plan, never an error")
+    void emptyDesignIsEmptyTeardown() {
+        assertThat(DeployPlanner.teardownOrder(new InfraGraph())).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

The infra designer stops being create-only:

- **Refresh**: designed-vs-actual per node — deleted cloud resources flag as `drifted: deleted in cloud` (stale id released); kinds without a read API say `unverifiable` honestly.
- **Destroy stack…**: reverse-dependency teardown of everything deployed, confirmed with the resource list and the monthly savings. Individual failures don't strand the rest.

## Verification

Full `mvn verify` green. InfraTruthTest 4/4 (ordering, design-only skip, per-kind paths, empty design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)