### PR TITLE
Bun and Deno as first-class toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.15.0] — 2026-07-02
+
+Bun and Deno, first-class. The 2026 runtimes stop being "Node with
+extra steps": their manifests are detected with precedence, every AUTO
+device speaks the right binary, and CI export sets them up properly.
+
+### Added
+- **Bun toolchain.** `bun.lock`/`bunfig.toml` beside a package.json
+  means Bun, not Node: CRATE runs `bun install/update/outdated`,
+  VERITAS `bun test` (re-run failed via `-t`), FORGE `bun run build`,
+  IGNITION `bun run start`, and the CI exporter emits
+  `oven-sh/setup-bun`.
+- **Deno toolchain.** `deno.json`/`deno.jsonc` detection: CRATE
+  `deno install/outdated`, VERITAS `deno test` (re-run failed via
+  `--filter`), FORGE `deno task build`, IGNITION `deno task start`,
+  CI export via `denoland/setup-deno`. Both register as real platform
+  projects (Open Project works on a bare Deno repo).
+
 ## [1.14.0] — 2026-07-02
 
 Infra truth and teardown: the designer stops being create-only — the

--- a/rack/src/main/java/org/nmox/studio/rack/devices/BuildDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BuildDevice.java
@@ -115,6 +115,8 @@ public class BuildDevice extends CommandDevice {
     /** The build command for non-Node toolchains. */
     private List<String> kindCommand(ProjectInspector.ProjectKind kind, boolean prod) {
         return switch (kind) {
+            case BUN -> List.of("bun", "run", "build");
+            case DENO -> List.of("deno", "task", "build");
             case RUST -> prod ? List.of("cargo", "build", "--release") : List.of("cargo", "build");
             case GO -> List.of("go", "build", "./...");
             case ELIXIR -> List.of("mix", "compile");

--- a/rack/src/main/java/org/nmox/studio/rack/devices/PackageManagerDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/PackageManagerDevice.java
@@ -64,6 +64,15 @@ public class PackageManagerDevice extends CommandDevice {
 
     private List<String> cmdFor(ProjectInspector.ProjectKind kind, String verb) {
         return switch (kind) {
+            case BUN -> switch (verb) {
+                case "update" -> List.of("bun", "update");
+                case "outdated" -> List.of("bun", "outdated");
+                default -> List.of("bun", "install");
+            };
+            case DENO -> switch (verb) {
+                case "outdated" -> List.of("deno", "outdated");
+                default -> List.of("deno", "install");
+            };
             case RUST -> switch (verb) {
                 case "update" -> List.of("cargo", "update");
                 case "outdated" -> List.of("cargo", "update", "--dry-run");

--- a/rack/src/main/java/org/nmox/studio/rack/devices/ProjectInspector.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/ProjectInspector.java
@@ -17,6 +17,8 @@ public final class ProjectInspector {
 
     /** The toolchain a project belongs to, detected from its manifest. */
     public enum ProjectKind {
+        BUN("bun.lock", "bun.lockb", "bunfig.toml"),
+        DENO("deno.json", "deno.jsonc"),
         NODE("package.json"),
         RUST("Cargo.toml"),
         GO("go.mod"),

--- a/rack/src/main/java/org/nmox/studio/rack/devices/RunDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/RunDevice.java
@@ -22,7 +22,7 @@ import org.nmox.studio.rack.ui.controls.RackStyle;
  */
 public class RunDevice extends CommandDevice {
 
-    private static final String[] TARGETS = {"auto", "node", "python", "go", "rust", "elixir", "erlang", "clojure", "swift", "dotnet", "dart", "scala", "haskell", "zig", "ocaml", "crystal", "maven", "gradle", "ruby", "php", "make"};
+    private static final String[] TARGETS = {"auto", "node", "python", "go", "rust", "elixir", "erlang", "clojure", "swift", "dotnet", "dart", "scala", "haskell", "zig", "ocaml", "crystal", "maven", "gradle", "ruby", "php", "make", "bun", "deno"};
 
     private final Knob targetKnob;
     private final LcdDisplay argsLcd;
@@ -83,6 +83,8 @@ public class RunDevice extends CommandDevice {
         }
         return switch (effectiveKind()) {
             case NODE -> "node";
+            case BUN -> "bun";
+            case DENO -> "deno";
             case RUST -> "rust";
             case ELIXIR -> "elixir";
             case ERLANG -> "erlang";
@@ -121,6 +123,8 @@ public class RunDevice extends CommandDevice {
             case "zig" -> ProjectInspector.ProjectKind.ZIG;
             case "ocaml" -> ProjectInspector.ProjectKind.OCAML;
             case "crystal" -> ProjectInspector.ProjectKind.CRYSTAL;
+            case "bun" -> ProjectInspector.ProjectKind.BUN;
+            case "deno" -> ProjectInspector.ProjectKind.DENO;
             case "go" -> ProjectInspector.ProjectKind.GO;
             case "maven" -> ProjectInspector.ProjectKind.MAVEN;
             case "gradle" -> ProjectInspector.ProjectKind.GRADLE;
@@ -152,6 +156,8 @@ public class RunDevice extends CommandDevice {
     protected List<String> buildCommand() {
         List<String> cmd = new ArrayList<>(switch (effectiveTarget()) {
             case "python" -> List.of("python3", entryPoint("main.py", "app.py", "src/main.py"));
+            case "bun" -> List.of("bun", "run", "start");
+            case "deno" -> List.of("deno", "task", "start");
             case "go" -> List.of("go", "run", ".");
             case "rust" -> List.of("cargo", "run");
             case "elixir" -> List.of("mix", "run", "--no-halt");

--- a/rack/src/main/java/org/nmox/studio/rack/devices/TestDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/TestDevice.java
@@ -17,7 +17,7 @@ import org.nmox.studio.rack.ui.controls.ToggleSwitch;
  */
 public class TestDevice extends CommandDevice {
 
-    private static final String[] FRAMEWORKS = {"auto", "jest", "vitest", "mocha", "playwright", "cypress", "pytest", "cargo", "go", "mvn", "rspec", "phpunit", "mix", "rebar3", "clojure", "swift", "dotnet", "dart", "sbt", "stack", "zig", "dune", "crystal"};
+    private static final String[] FRAMEWORKS = {"auto", "jest", "vitest", "mocha", "playwright", "cypress", "pytest", "cargo", "go", "mvn", "rspec", "phpunit", "mix", "rebar3", "clojure", "swift", "dotnet", "dart", "sbt", "stack", "zig", "dune", "crystal", "bun", "deno"};
     private static final Pattern PASSED = Pattern.compile("(\\d+)\\s+(?:passed|passing)");
     private static final Pattern FAILED = Pattern.compile("(\\d+)\\s+(?:failed|failing)");
     private static final String[] COVERAGE_MINIMUMS = {"off", "50", "60", "70", "80", "90"};
@@ -142,6 +142,8 @@ public class TestDevice extends CommandDevice {
         String alternation = String.join("|", names);
         return switch (framework) {
             case "jest" -> List.of("npx", "jest", "-t", alternation);
+            case "bun" -> List.of("bun", "test", "-t", alternation);
+            case "deno" -> List.of("deno", "test", "--filter", alternation);
             case "vitest" -> List.of("npx", "vitest", "run", "-t", alternation);
             case "pytest" -> {
                 List<String> cmd = new ArrayList<>(List.of("python3", "-m", "pytest"));
@@ -200,6 +202,8 @@ public class TestDevice extends CommandDevice {
         }
         ProjectInspector.ProjectKind kind = effectiveKind();
         switch (kind) {
+            case BUN: return "bun";
+            case DENO: return "deno";
             case RUST: return "cargo";
             case ELIXIR: return "mix";
             case ERLANG: return "rebar3";
@@ -235,6 +239,8 @@ public class TestDevice extends CommandDevice {
     @Override
     protected java.io.File commandDir() {
         ProjectInspector.ProjectKind kind = switch (effectiveFramework()) {
+            case "bun" -> ProjectInspector.ProjectKind.BUN;
+            case "deno" -> ProjectInspector.ProjectKind.DENO;
             case "cargo" -> ProjectInspector.ProjectKind.RUST;
             case "mix" -> ProjectInspector.ProjectKind.ELIXIR;
             case "rebar3" -> ProjectInspector.ProjectKind.ERLANG;
@@ -268,6 +274,8 @@ public class TestDevice extends CommandDevice {
             case "playwright" -> cmd.addAll(List.of("npx", "playwright", "test"));
             case "cypress" -> cmd.addAll(List.of("npx", "cypress", "run"));
             case "pytest" -> cmd.addAll(List.of("python3", "-m", "pytest"));
+            case "bun" -> cmd.addAll(List.of("bun", "test"));
+            case "deno" -> cmd.addAll(List.of("deno", "test"));
             case "cargo" -> cmd.addAll(List.of("cargo", "test"));
             case "mix" -> cmd.addAll(List.of("mix", "test"));
             case "rebar3" -> cmd.addAll(List.of("rebar3", "eunit"));

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/CiExporter.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/CiExporter.java
@@ -126,6 +126,11 @@ public final class CiExporter {
                           - uses: actions/setup-node@v4
                             with: { node-version: 22 }
                     """.stripTrailing() + "\n");
+                case BUN -> steps.add("      - uses: oven-sh/setup-bun@v2\n");
+                case DENO -> steps.add("""
+                          - uses: denoland/setup-deno@v2
+                            with: { deno-version: v2.x }
+                    """.stripTrailing() + "\n");
                 case RUST -> steps.add("      - uses: dtolnay/rust-toolchain@stable\n");
                 case GO -> steps.add("""
                           - uses: actions/setup-go@v5

--- a/rack/src/test/java/org/nmox/studio/rack/devices/BunDenoTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/BunDenoTest.java
@@ -1,0 +1,56 @@
+package org.nmox.studio.rack.devices;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nmox.studio.rack.model.Rack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Bun and Deno as first-class toolchains: detection outranks plain
+ * Node when their manifests are present, and every AUTO device speaks
+ * the right binary.
+ */
+class BunDenoTest {
+
+    @Test
+    @DisplayName("bun.lock beside package.json means Bun, not Node")
+    void bunOutranksNode(@TempDir Path dir) throws Exception {
+        Files.writeString(dir.resolve("package.json"), "{}");
+        Files.writeString(dir.resolve("bun.lock"), "");
+        assertThat(ProjectInspector.detectKind(dir.toFile()))
+                .isEqualTo(ProjectInspector.ProjectKind.BUN);
+    }
+
+    @Test
+    @DisplayName("deno.json means Deno; devices run deno test / deno install / deno task")
+    void denoDevicesSpeakDeno(@TempDir Path dir) throws Exception {
+        Files.writeString(dir.resolve("deno.json"), "{}");
+        Rack rack = new Rack();
+        rack.setProjectDir(dir.toFile());
+        TestDevice tests = new TestDevice();
+        rack.addDevice(tests);
+        assertThat(tests.buildCommand()).startsWith("deno", "test");
+        rack.shutdown();
+    }
+
+    @Test
+    @DisplayName("Bun project: VERITAS runs bun test; re-run failed uses -t")
+    void bunVeritas(@TempDir Path dir) throws Exception {
+        Files.writeString(dir.resolve("package.json"), "{}");
+        Files.writeString(dir.resolve("bun.lock"), "");
+        Rack rack = new Rack();
+        rack.setProjectDir(dir.toFile());
+        TestDevice tests = new TestDevice();
+        rack.addDevice(tests);
+        assertThat(tests.buildCommand()).startsWith("bun", "test");
+        assertThat(TestDevice.rerunFailedCommand("bun", java.util.List.of("a", "b")))
+                .containsExactly("bun", "test", "-t", "a|b");
+        assertThat(TestDevice.rerunFailedCommand("deno", java.util.List.of("x")))
+                .containsExactly("deno", "test", "--filter", "x");
+        rack.shutdown();
+    }
+}

--- a/tools/src/main/java/org/nmox/studio/tools/npm/WebProjectFactory.java
+++ b/tools/src/main/java/org/nmox/studio/tools/npm/WebProjectFactory.java
@@ -19,7 +19,7 @@ public class WebProjectFactory implements ProjectFactory {
         "package.json", "Cargo.toml", "go.mod", "mix.exs", "rebar.config",
         "deps.edn", "project.clj", "Package.swift", "pom.xml", "build.gradle",
         "build.gradle.kts", "pyproject.toml", "requirements.txt", "Gemfile",
-        "composer.json", "angular.json"};
+        "composer.json", "angular.json", "bun.lock", "bunfig.toml", "deno.json", "deno.jsonc"};
 
     @Override
     public boolean isProject(FileObject projectDirectory) {


### PR DESCRIPTION
## Summary

Tranche A of the second-cut sprint: `bun.lock`/`bunfig.toml` and `deno.json[c]` are detected with precedence over plain Node, and every AUTO device speaks the right binary — CRATE, VERITAS (incl. re-run-failed filters), FORGE, IGNITION — plus real setup actions in the CI export and platform-project recognition.

## Verification

Full `mvn verify` green. BunDenoTest 3/3; DeviceContractTest 217/217 and PolyglotDevicesTest 9/9 unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)