### PR TITLE
HELM, BEACON, PRISM: servers, certificates, and bundle budgets on the patch bay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.16.0] — 2026-07-02
+
+Three second-cut devices: the rack reaches your servers, watches your
+certificates, and weighs your bundles.
+
+### Added
+- **HELM — the rack reaches your servers.** Dial user@host and a
+  command; it runs over ssh (BatchMode: key auth only, no hanging
+  prompts) with output on the bus and OK/FAIL/DONE jacks. Patch
+  LAUNCHPAD OK → RUN and a deploy finishes with a remote migration or
+  service restart; the HOST jack takes a cable.
+- **BEACON — cert & uptime sentinel.** One CHECK answers what pages
+  people at 3am: is it up, and how many days on the TLS cert? Dial
+  MIN DAYS and a cert inside the window fires FAIL. Patch TEMPO BAR →
+  CHECK to watch production on a clock.
+- **PRISM — bundle-size gate.** Weighs the build output; MAX sets the
+  budget. Patch FORGE OK → MEASURE and bundles over budget fire FAIL
+  before they ship. Bundles grow one innocent import at a time —
+  PRISM holds the line.
+
 ## [1.15.0] — 2026-07-02
 
 Bun and Deno, first-class. The 2026 runtimes stop being "Node with

--- a/rack/src/main/java/org/nmox/studio/rack/devices/BeaconDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BeaconDevice.java
@@ -1,0 +1,146 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.ui.controls.Knob;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.Led;
+import org.nmox.studio.rack.ui.controls.RackButton;
+import org.nmox.studio.rack.ui.controls.RackStyle;
+
+/**
+ * BEACON: the certificate and uptime sentinel. One CHECK answers the
+ * two questions that page people at 3am: is the site up, and how many
+ * days does its TLS certificate have left? Dial MIN DAYS and a cert
+ * inside the window fires FAIL - patch TEMPO's BAR into CHECK and the
+ * rack watches your production domain on a clock.
+ */
+public class BeaconDevice extends RackDevice {
+
+    private static final String[] MINIMUMS = {"off", "7", "14", "30"};
+
+    private final LcdDisplay urlLcd;
+    private final LcdDisplay resultLcd;
+    private final Knob minKnob;
+    private final Led upLed;
+    private final Led warnLed;
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(8)).build();
+
+    public BeaconDevice() {
+        super("beacon", "BEACON", "CERT & UPTIME SENTINEL", new Color(240, 180, 60), 2);
+
+        RackButton check = place(new RackButton("CHECK", RackStyle.GO), RackStyle.TRANSPORT_X, 46);
+        urlLcd = place(new LcdDisplay(220, 1), 130, 46);
+        urlLcd.setText("https://example.com");
+        urlLcd.setEditable("URL to watch");
+        minKnob = place(new Knob("MIN DAYS", MINIMUMS, 0), 370, 40);
+        minKnob.setToolTipText("Certificate floor: fewer days left than this fires FAIL");
+        resultLcd = place(new LcdDisplay(240, 1), 444, 46);
+        resultLcd.setText("—");
+        upLed = place(new Led("UP", RackStyle.GO), 700, 52);
+        warnLed = place(new Led("WARN", RackStyle.STOP), 744, 52);
+
+        check.addActionListener(e -> check());
+
+        addInPort("run", "CHECK", SignalType.TRIGGER);
+        addOutPort("ok", "OK", SignalType.TRIGGER);
+        addOutPort("fail", "FAIL", SignalType.TRIGGER);
+
+        param("url", urlLcd);
+        param("min", minKnob);
+    }
+
+    int minimumDays() {
+        String sel = minKnob.getSelectedOption();
+        return "off".equals(sel) ? 0 : Integer.parseInt(sel);
+    }
+
+    /** The gate: up, and (with a floor dialed) enough runway on the cert. */
+    static boolean verdict(boolean reachable, long certDays, int floorDays) {
+        return reachable && (floorDays == 0 || certDays < 0 || certDays >= floorDays);
+    }
+
+    private void check() {
+        String url = urlLcd.getText().trim();
+        if (url.isEmpty()) {
+            return;
+        }
+        onEdt(() -> {
+            resultLcd.setTextColor(RackStyle.LCD_AMBER);
+            resultLcd.setText("CHECKING…");
+        });
+        Thread worker = new Thread(() -> {
+            boolean reachable = false;
+            long days = -1;
+            String detail = "";
+            try {
+                URI uri = URI.create(url);
+                if ("https".equals(uri.getScheme())) {
+                    days = certDaysRemaining(uri.getHost(),
+                            uri.getPort() > 0 ? uri.getPort() : 443);
+                }
+                HttpResponse<Void> response = client.send(
+                        HttpRequest.newBuilder(uri).method("HEAD",
+                                HttpRequest.BodyPublishers.noBody())
+                                .timeout(Duration.ofSeconds(10)).build(),
+                        HttpResponse.BodyHandlers.discarding());
+                reachable = response.statusCode() < 500;
+                detail = "HTTP " + response.statusCode();
+            } catch (Exception ex) {
+                detail = "DOWN: " + (ex.getMessage() == null ? ex.getClass().getSimpleName()
+                        : ex.getMessage());
+            }
+            boolean ok = verdict(reachable, days, minimumDays());
+            final boolean up = reachable;
+            final long d = days;
+            final String det = detail;
+            onEdt(() -> {
+                upLed.setOn(up);
+                warnLed.setOn(!ok);
+                resultLcd.setTextColor(ok ? RackStyle.LCD_TEXT : new Color(255, 90, 80));
+                resultLcd.setText((d >= 0 ? "TLS " + d + "d · " : "") + det
+                        + (!ok && up && d >= 0 && d < minimumDays() ? " — CERT INSIDE FLOOR" : ""));
+            });
+            emit(ok ? "ok" : "fail", Signal.trigger(ok));
+        }, "nmox-beacon");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private long certDaysRemaining(String host, int port) {
+        try (SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault()
+                .createSocket()) {
+            socket.connect(new java.net.InetSocketAddress(host, port), 8_000);
+            socket.startHandshake();
+            var certs = socket.getSession().getPeerCertificates();
+            if (certs.length > 0 && certs[0] instanceof X509Certificate x509) {
+                return ChronoUnit.DAYS.between(Instant.now(),
+                        x509.getNotAfter().toInstant());
+            }
+        } catch (Exception ex) {
+            // handshake failed: reachability check below will tell the story
+        }
+        return -1;
+    }
+
+    @Override
+    public void receive(Port in, Signal signal) {
+        if ("run".equals(in.getId())) {
+            check();
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/devices/BundleSizeDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/BundleSizeDevice.java
@@ -1,0 +1,117 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.io.File;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.RackDevice;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.ui.controls.Knob;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.RackButton;
+import org.nmox.studio.rack.ui.controls.RackStyle;
+import org.nmox.studio.rack.ui.controls.VuMeter;
+
+/**
+ * PRISM: the bundle-size gate. Bundles grow one innocent import at a
+ * time; PRISM weighs the build output and holds the line. Patch
+ * FORGE's OK into MEASURE and every build gets weighed - dial MAX and
+ * a bundle over budget fires FAIL before it ships.
+ */
+public class BundleSizeDevice extends RackDevice {
+
+    private static final String[] MAXIMUMS = {"off", "250 KB", "500 KB", "1 MB", "2 MB", "5 MB"};
+    private static final long[] MAXIMUM_BYTES = {0, 250_000, 500_000, 1_000_000, 2_000_000, 5_000_000};
+
+    private final LcdDisplay dirLcd;
+    private final LcdDisplay resultLcd;
+    private final Knob maxKnob;
+    private final VuMeter meter;
+
+    public BundleSizeDevice() {
+        super("bundle-size", "PRISM", "BUNDLE-SIZE GATE", new Color(150, 120, 220), 2);
+
+        RackButton measure = place(new RackButton("MEASURE", RackStyle.GO), RackStyle.TRANSPORT_X, 46);
+        dirLcd = place(new LcdDisplay(160, 1), 150, 46);
+        dirLcd.setText("dist");
+        dirLcd.setEditable("Build output dir (relative to project)");
+        maxKnob = place(new Knob("MAX", MAXIMUMS, 0), 330, 40);
+        maxKnob.setToolTipText("Size budget: a build output over this fires FAIL");
+        resultLcd = place(new LcdDisplay(200, 1), 404, 46);
+        resultLcd.setText("—");
+        meter = place(new VuMeter("WEIGHT", false), 620, 40);
+
+        measure.addActionListener(e -> measure());
+
+        addInPort("run", "MEASURE", SignalType.TRIGGER);
+        addOutPort("ok", "OK", SignalType.TRIGGER);
+        addOutPort("fail", "FAIL", SignalType.TRIGGER);
+
+        param("dir", dirLcd);
+        param("max", maxKnob);
+    }
+
+    long maximumBytes() {
+        return MAXIMUM_BYTES[maxKnob.getSelectedIndex()];
+    }
+
+    /** Recursive on-disk weight of the build output. */
+    static long totalBytes(File dir) {
+        if (dir == null || !dir.exists()) {
+            return -1;
+        }
+        if (dir.isFile()) {
+            return dir.length();
+        }
+        long total = 0;
+        File[] kids = dir.listFiles();
+        if (kids != null) {
+            for (File kid : kids) {
+                long size = totalBytes(kid);
+                if (size > 0) {
+                    total += size;
+                }
+            }
+        }
+        return total;
+    }
+
+    static String human(long bytes) {
+        if (bytes >= 1_000_000) {
+            return String.format("%.1f MB", bytes / 1_000_000.0);
+        }
+        return (bytes / 1_000) + " KB";
+    }
+
+    private void measure() {
+        File raw = new File(dirLcd.getText().trim());
+        File dir = raw.isAbsolute() ? raw : new File(projectDir(), raw.getPath());
+        long total = totalBytes(dir);
+        long budget = maximumBytes();
+        if (total < 0) {
+            onEdt(() -> {
+                resultLcd.setTextColor(RackStyle.LCD_AMBER);
+                resultLcd.setText("NO " + dirLcd.getText().trim() + " — BUILD FIRST");
+            });
+            emit("fail", Signal.trigger(false));
+            return;
+        }
+        boolean ok = budget == 0 || total <= budget;
+        final long t = total;
+        onEdt(() -> {
+            meter.setLevel(budget > 0 ? Math.min(1.0, (double) t / budget)
+                    : Math.min(1.0, t / 5_000_000.0));
+            resultLcd.setTextColor(ok ? RackStyle.LCD_TEXT : new Color(255, 90, 80));
+            resultLcd.setText(human(t) + (budget > 0
+                    ? (ok ? " / " + human(budget) : " > MAX " + human(budget)) : ""));
+        });
+        emit(ok ? "ok" : "fail", Signal.trigger(ok));
+    }
+
+    @Override
+    public void receive(Port in, Signal signal) {
+        if ("run".equals(in.getId())) {
+            measure();
+        }
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
@@ -45,7 +45,10 @@ public enum DeviceType {
     DATABASE("database", "NEPTUNE", "Database Console — ping databases & trigger schemas", new Color(51, 153, 255), DatabaseDevice::new),
     CMD("cmd", "SOLDER", "Custom Command — run anything as a pipeline step", new Color(176, 141, 87), CommandLineDevice::new),
     TAIL("tail", "TAIL", "Log Follower — tail -f any file onto the patch bay", new Color(140, 190, 120), TailDevice::new),
-    VITALS("vitals", "VITALS", "Web Quality Gate — Lighthouse scores with a shipping floor", new Color(255, 105, 97), VitalsDevice::new);
+    VITALS("vitals", "VITALS", "Web Quality Gate — Lighthouse scores with a shipping floor", new Color(255, 105, 97), VitalsDevice::new),
+    SSH("ssh", "HELM", "Remote Runner — run commands on your servers over ssh", new Color(95, 158, 199), SshDevice::new),
+    BEACON("beacon", "BEACON", "Cert & Uptime Sentinel — TLS runway and reachability, gated", new Color(240, 180, 60), BeaconDevice::new),
+    BUNDLE_SIZE("bundle-size", "PRISM", "Bundle-Size Gate — weigh the build, hold the line", new Color(150, 120, 220), BundleSizeDevice::new);
 
     private final String id;
     private final String title;
@@ -97,10 +100,11 @@ public enum DeviceType {
     public PaletteCategory getPaletteCategory() {
         return switch (this) {
             case MASTER, REFLEX, JOIN, TEMPO, RUN, NPM_SCRIPT, CMD -> PaletteCategory.AUTOMATE;
-            case PACKAGE_MANAGER, BUILD, TEST, LINT, FORMAT, TYPECHECK, VITALS -> PaletteCategory.VERIFY;
+            case SSH -> PaletteCategory.SHIP;
+            case PACKAGE_MANAGER, BUILD, TEST, LINT, FORMAT, TYPECHECK, VITALS, BUNDLE_SIZE -> PaletteCategory.VERIFY;
             case DEV_SERVER, TUNNEL, BROWSER, HTTP, DATABASE -> PaletteCategory.SERVE;
             case ANGULAR, PHOENIX, NEXTJS -> PaletteCategory.FRAMEWORKS;
-            case CONSOLE, TERMINAL, BENCH, DEBUG, BLACKBOX, SONAR, TAIL -> PaletteCategory.OBSERVE;
+            case CONSOLE, TERMINAL, BENCH, DEBUG, BLACKBOX, SONAR, TAIL, BEACON -> PaletteCategory.OBSERVE;
             case GIT, AUDIT, DEPLOY, DOCKER, PREFLIGHT -> PaletteCategory.SHIP;
             case ENV, ROSETTA -> PaletteCategory.UTILITY;
         };
@@ -144,6 +148,9 @@ public enum DeviceType {
             case DATABASE -> "Pings SQL databases (PostgreSQL/MySQL/SQLite/MariaDB).\nDial DB TYPE to select database URL or profile; ping fires OK on success.";
             case CMD -> "Runs exactly what you type - make seed-db, ./scripts/fixtures.sh - argv only, no shell.\nPatch VERITAS OK → RUN to chain custom steps; SOLDER exports to CI like any device.";
             case TAIL -> "tail -f as a device: dial a file (relative to the project), flip FOLLOW.\nPatch OUT → PHOSPHOR and your server's logs/app.log scrolls beside its stdout.";
+            case SSH -> "Runs the dialed command on user@host over ssh (BatchMode: key auth only).\nPatch LAUNCHPAD OK → RUN to finish deploys with a remote migrate or restart; HOST accepts a cable.";
+            case BEACON -> "CHECK answers: is it up, and how many days on the TLS cert?\nPatch TEMPO BAR → CHECK to watch production on a clock; MIN DAYS fires FAIL inside the window.";
+            case BUNDLE_SIZE -> "Weighs the build output dir; MAX sets the budget.\nPatch FORGE OK → MEASURE and OK → LAUNCHPAD: bundles over budget don't ship.";
             case VITALS -> "Lighthouse headless against the dialed URL - PERF/A11Y/BEST/SEO on the meters.\nPatch SURGE URL → URL and READY → RUN; dial MIN and slow pages close the gate (FAIL, not OK).";
         };
     }

--- a/rack/src/main/java/org/nmox/studio/rack/devices/SshDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/SshDevice.java
@@ -1,0 +1,78 @@
+package org.nmox.studio.rack.devices;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.Signal;
+import org.nmox.studio.rack.model.SignalType;
+import org.nmox.studio.rack.ui.controls.LcdDisplay;
+import org.nmox.studio.rack.ui.controls.RackButton;
+import org.nmox.studio.rack.ui.controls.RackStyle;
+
+/**
+ * HELM: the rack reaches your servers. Dial user@host and a command,
+ * and it runs over ssh with the standard treatment - output on the
+ * bus, OK/FAIL/DONE jacks, CI export. BatchMode only: key auth, no
+ * password prompts, no hanging pipelines. Patch LAUNCHPAD's OK in and
+ * a deploy can finish with a remote migration or service restart.
+ */
+public class SshDevice extends CommandDevice {
+
+    private final LcdDisplay hostLcd;
+    private final LcdDisplay commandLcd;
+
+    public SshDevice() {
+        super("ssh", "HELM", "REMOTE RUNNER", new Color(95, 158, 199), 2);
+
+        RackButton run = place(new RackButton("RUN", RackStyle.GO), RackStyle.TRANSPORT_X, 52);
+        run.setCommandPreview(this::commandPreview);
+        RackButton stop = place(new RackButton("STOP", RackStyle.STOP), RackStyle.TRANSPORT_STOP_X, 52);
+        hostLcd = place(new LcdDisplay(180, 1), 180, 46);
+        hostLcd.setText("");
+        hostLcd.setEditable("user@host");
+        commandLcd = place(new LcdDisplay(280, 1), 380, 46);
+        commandLcd.setText("");
+        commandLcd.setEditable("Remote command");
+
+        run.addActionListener(e -> primaryAction());
+        stop.addActionListener(e -> stopProcess());
+
+        // a droplet's address can arrive by cable (infra designer, TAIL of
+        // a provisioning log, anything that knows the host)
+        addInPort("host", "HOST", SignalType.DATA);
+
+        param("host", hostLcd);
+        param("command", commandLcd);
+    }
+
+    /** Remote work needs a host, not a local manifest. */
+    @Override
+    protected boolean requiresProjectManifest() {
+        return false;
+    }
+
+    @Override
+    protected List<String> buildCommand() {
+        String host = hostLcd.getText().trim();
+        List<String> remote = CommandLineDevice.splitArgs(commandLcd.getText());
+        if (host.isEmpty() || remote.isEmpty()) {
+            return null;
+        }
+        List<String> cmd = new ArrayList<>(List.of("ssh",
+                "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host));
+        cmd.addAll(remote);
+        return cmd;
+    }
+
+    @Override
+    public void receive(Port in, Signal signal) {
+        if ("host".equals(in.getId())) {
+            if (signal.payload() != null && !signal.payload().isBlank()) {
+                onEdt(() -> hostLcd.setText(signal.payload().trim()));
+            }
+            return;
+        }
+        super.receive(in, signal);
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/devices/SecondCutDevicesTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/SecondCutDevicesTest.java
@@ -1,0 +1,58 @@
+package org.nmox.studio.rack.devices;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * HELM, BEACON, PRISM: the second-cut devices honor their faceplates -
+ * ssh is BatchMode-only argv, the sentinel's verdict gates on runway,
+ * and the bundle gate weighs real bytes against a real budget.
+ */
+class SecondCutDevicesTest {
+
+    @Test
+    @DisplayName("HELM builds a BatchMode ssh argv; empty host or command builds nothing")
+    void helmBuildsSsh() {
+        SshDevice helm = new SshDevice();
+        assertThat(helm.buildCommand()).isNull();
+        helm.applyState(Map.of("host", "deploy@203.0.113.7",
+                "command", "systemctl restart app"));
+        assertThat(helm.buildCommand()).containsExactly("ssh",
+                "-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
+                "deploy@203.0.113.7", "systemctl", "restart", "app");
+    }
+
+    @Test
+    @DisplayName("BEACON verdict: down always fails; floor gates only measured runway")
+    void beaconVerdict() {
+        assertThat(BeaconDevice.verdict(false, 90, 0)).isFalse();
+        assertThat(BeaconDevice.verdict(true, 90, 30)).isTrue();
+        assertThat(BeaconDevice.verdict(true, 12, 30)).isFalse();
+        assertThat(BeaconDevice.verdict(true, -1, 30))
+                .as("plain http has no cert: floor doesn't apply").isTrue();
+        assertThat(BeaconDevice.verdict(true, 5, 0))
+                .as("floor off: reachability decides").isTrue();
+    }
+
+    @Test
+    @DisplayName("PRISM weighs a tree and formats budgets honestly")
+    void prismWeighs(@TempDir Path dir) throws Exception {
+        Files.createDirectories(dir.resolve("assets"));
+        Files.write(dir.resolve("app.js"), new byte[120_000]);
+        Files.write(dir.resolve("assets/style.css"), new byte[30_000]);
+        assertThat(BundleSizeDevice.totalBytes(dir.toFile())).isEqualTo(150_000);
+        assertThat(BundleSizeDevice.totalBytes(dir.resolve("missing").toFile())).isEqualTo(-1);
+        assertThat(BundleSizeDevice.human(150_000)).isEqualTo("150 KB");
+        assertThat(BundleSizeDevice.human(1_500_000)).isEqualTo("1.5 MB");
+
+        BundleSizeDevice prism = new BundleSizeDevice();
+        prism.applyState(Map.of("max", "1")); // 250 KB
+        assertThat(prism.maximumBytes()).isEqualTo(250_000);
+    }
+}


### PR DESCRIPTION
## Summary

Tranche B of the second-cut sprint — three devices:

- **HELM**: ssh remote runner (BatchMode-only argv, cable-fed HOST) — deploys can finish with remote migrations/restarts.
- **BEACON**: uptime + TLS runway sentinel with a MIN DAYS gate; TEMPO-clockable.
- **PRISM**: bundle-size gate — FORGE OK → MEASURE, over-budget fires FAIL.

## Verification

Full `mvn verify` green. SecondCutDevicesTest 3/3; DeviceContractTest auto-grew to 235 assertions over the 39-device catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)