### PR TITLE
Infra Designer: sane zoom + deeper DigitalOcean (cloud-init, SSH-from-node, deploy log)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
-## [1.16.1] — 2026-07-02
+## [1.17.0] — 2026-07-02
+
+The infrastructure designer, deepened: it opens fitted, provisions
+servers that configure themselves, and hands you the way in.
+
+### Added
+- **Cloud-init on droplets.** A droplet's new user_data field flows
+  into the create body, so a server configures itself on first boot
+  (install nginx, pull your app, whatever) — infrastructure as one
+  design, not a design plus a runbook.
+- **Copy SSH command from a node.** Once a droplet is deployed (or
+  imported by Sync), its public IP is remembered and persisted; the
+  node's right-click menu offers "Copy SSH command (root@…)". The
+  designer stops being a place you look at servers and becomes the way
+  in to them.
+- **Deploy log.** Every deploy appends a timestamped, per-resource
+  record to .nmox/deploy-log beside the project — a half-deployed
+  stack is legible after the fact, not a hunt.
 
 ### Fixed
 - **The Infra Designer opens at a sane zoom.** Fit ran before the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.16.1] — 2026-07-02
+
+### Fixed
+- **The Infra Designer opens at a sane zoom.** Fit ran before the
+  window had a size, so dividing by a zero-width viewport slammed the
+  zoom to its floor on every open — the canvas always started "way
+  out". Fit now waits for a real layout pass, contains the design
+  without ever magnifying it (small designs stay at natural size), and
+  centers the content. The toolbar gains − / Fit / + zoom buttons.
+
 ## [1.16.0] — 2026-07-02
 
 Three second-cut devices: the rack reaches your servers, watches your

--- a/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
+++ b/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
@@ -264,15 +264,20 @@ public final class InfraDesignerTopComponent extends TopComponent {
             return;
         }
         Thread worker = new Thread(() -> {
+            StringBuilder log = new StringBuilder("NMOX deploy " + java.time.LocalDateTime.now() + "\n");
             boolean ok = client.execute(plan, graph, (node, message) -> {
                 if (node != null) {
                     graph.setStatus(node, message);
+                    log.append("  ").append(node.kind.getDisplayName())
+                            .append(" ").append(node.label).append(": ").append(message).append('\n');
                 }
             });
+            writeDeployLog(log.toString());
             SwingUtilities.invokeLater(() -> {
                 save();
                 JOptionPane.showMessageDialog(this,
-                        ok ? "Deploy complete - nodes are live." : "Deploy stopped on a failure; see node status.",
+                        ok ? "Deploy complete - nodes are live. Log: .nmox/deploy-log"
+                           : "Deploy stopped on a failure; see node status and .nmox/deploy-log.",
                         "Infra Designer", ok ? JOptionPane.INFORMATION_MESSAGE : JOptionPane.ERROR_MESSAGE);
             });
         }, "nmox-infra-deploy");
@@ -362,6 +367,25 @@ public final class InfraDesignerTopComponent extends TopComponent {
         worker.start();
     }
 
+    /** Appends a deploy run to .nmox/deploy-log beside the aimed project. */
+    private void writeDeployLog(String entry) {
+        try {
+            java.io.File root = org.nmox.studio.rack.service.RackService.getDefault()
+                    .getRack().getProjectDir();
+            if (root == null) {
+                return;
+            }
+            java.io.File dir = new java.io.File(root, ".nmox");
+            java.nio.file.Files.createDirectories(dir.toPath());
+            java.nio.file.Files.writeString(new java.io.File(dir, "deploy-log").toPath(),
+                    entry + "\n", java.nio.charset.StandardCharsets.UTF_8,
+                    java.nio.file.StandardOpenOption.CREATE,
+                    java.nio.file.StandardOpenOption.APPEND);
+        } catch (Exception ex) {
+            // a log is a courtesy, never a blocker
+        }
+    }
+
     private void showNodeMenu(InfraNode node, Point screenPoint) {
         JPopupMenu menu = new JPopupMenu();
         if (node.doId != null) {
@@ -385,6 +409,18 @@ public final class InfraDesignerTopComponent extends TopComponent {
                 }
             });
             menu.add(destroy);
+            menu.addSeparator();
+        }
+        if (node.ip != null && !node.ip.isBlank()) {
+            JMenuItem ssh = new JMenuItem("Copy SSH command  (root@" + node.ip + ")");
+            ssh.addActionListener(e -> {
+                java.awt.datatransfer.StringSelection sel =
+                        new java.awt.datatransfer.StringSelection("ssh root@" + node.ip);
+                java.awt.Toolkit.getDefaultToolkit().getSystemClipboard().setContents(sel, null);
+                org.openide.awt.StatusDisplayer.getDefault()
+                        .setStatusText("Copied: ssh root@" + node.ip);
+            });
+            menu.add(ssh);
             menu.addSeparator();
         }
         JMenuItem remove = new JMenuItem("Remove from design");

--- a/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
+++ b/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
@@ -173,9 +173,20 @@ public final class InfraDesignerTopComponent extends TopComponent {
         destroyStack.addActionListener(e -> destroyStack());
         bar.add(destroyStack);
 
+        JButton zoomOut = new JButton("−");
+        zoomOut.setToolTipText("Zoom out");
+        zoomOut.addActionListener(e -> canvas.zoomOut());
+        bar.add(zoomOut);
+
         JButton fit = new JButton("Fit");
+        fit.setToolTipText("Fit the whole design in view");
         fit.addActionListener(e -> canvas.fit());
         bar.add(fit);
+
+        JButton zoomIn = new JButton("+");
+        zoomIn.setToolTipText("Zoom in");
+        zoomIn.addActionListener(e -> canvas.zoomIn());
+        bar.add(zoomIn);
 
         bar.add(javax.swing.Box.createHorizontalGlue());
 

--- a/infra/src/main/java/org/nmox/studio/infra/api/DeployPlanner.java
+++ b/infra/src/main/java/org/nmox/studio/infra/api/DeployPlanner.java
@@ -124,6 +124,10 @@ public final class DeployPlanner {
                     body.put("backups", Boolean.parseBoolean(p.getOrDefault("backups", "false")))
                             .put("monitoring", Boolean.parseBoolean(p.getOrDefault("monitoring", "true")));
                 }
+                String userData = p.getOrDefault("userData", "");
+                if (!userData.isBlank()) {
+                    body.put("user_data", userData); // cloud-init: the droplet configures itself
+                }
                 JSONArray keys = new JSONArray();
                 for (InfraNode prov : providers) {
                     if (prov.kind == NodeKind.VPC) {

--- a/infra/src/main/java/org/nmox/studio/infra/api/DigitalOceanClient.java
+++ b/infra/src/main/java/org/nmox/studio/infra/api/DigitalOceanClient.java
@@ -90,6 +90,9 @@ public final class DigitalOceanClient {
                     node.doId = doId;
                     ids.put(node.id, doId);
                 }
+                if (node != null && ips.containsKey(node.id) && ips.get(node.id) != null) {
+                    node.ip = ips.get(node.id); // remember it: the SSH command needs it later
+                }
                 // honesty over green lights: a created resource whose id we
                 // could not parse cannot be synced or destroyed later
                 onStep.accept(node, node != null && node.doId == null
@@ -285,6 +288,18 @@ public final class DigitalOceanClient {
                     node.label = item.optString(source.nameKey(), node.label);
                 }
                 node.doId = doId;
+                if (source.kind() == NodeKind.DROPLET || source.kind() == NodeKind.GPU_DROPLET) {
+                    JSONObject nets = item.optJSONObject("networks");
+                    JSONArray v4 = nets != null ? nets.optJSONArray("v4") : null;
+                    if (v4 != null) {
+                        for (int k = 0; k < v4.length(); k++) {
+                            JSONObject net = v4.getJSONObject(k);
+                            if ("public".equals(net.optString("type"))) {
+                                node.ip = net.optString("ip_address", null);
+                            }
+                        }
+                    }
+                }
                 graph.setStatus(node, "live");
                 imported++;
                 x += 190;

--- a/infra/src/main/java/org/nmox/studio/infra/model/GraphIO.java
+++ b/infra/src/main/java/org/nmox/studio/infra/model/GraphIO.java
@@ -33,6 +33,9 @@ public final class GraphIO {
             if (node.doId != null) {
                 nj.put("doId", node.doId);
             }
+            if (node.ip != null) {
+                nj.put("ip", node.ip);
+            }
             nodeArr.put(nj);
         }
         root.put("nodes", nodeArr);
@@ -62,6 +65,7 @@ public final class GraphIO {
                     nj.getString("id"), kind, nj.getInt("x"), nj.getInt("y"));
             node.label = nj.optString("label", node.label);
             node.doId = nj.has("doId") ? nj.getString("doId") : null;
+            node.ip = nj.has("ip") ? nj.getString("ip") : null;
             JSONObject props = nj.optJSONObject("props");
             if (props != null) {
                 for (String key : props.keySet()) {

--- a/infra/src/main/java/org/nmox/studio/infra/model/InfraGraph.java
+++ b/infra/src/main/java/org/nmox/studio/infra/model/InfraGraph.java
@@ -26,6 +26,8 @@ public final class InfraGraph {
         public final Map<String, String> props = new LinkedHashMap<>();
         /** DigitalOcean resource id once deployed; null while design-only. */
         public String doId;
+        /** Public IPv4 once known (droplets); null otherwise. */
+        public String ip;
         public String status = "";
 
         InfraNode(String id, NodeKind kind, int x, int y) {

--- a/infra/src/main/java/org/nmox/studio/infra/model/NodeKind.java
+++ b/infra/src/main/java/org/nmox/studio/infra/model/NodeKind.java
@@ -23,7 +23,8 @@ public enum NodeKind {
                     "ubuntu-24-04-x64", "ubuntu-22-04-x64", "debian-12-x64", "fedora-40-x64",
                     "rockylinux-9-x64", "docker-20-04"),
                 Prop.bool("backups", "Backups", false),
-                Prop.bool("monitoring", "Monitoring agent", true)),
+                Prop.bool("monitoring", "Monitoring agent", true),
+                Prop.text("userData", "Cloud-init (user_data)", "")),
             6.0),
     GPU_DROPLET("GPU Droplet", Category.COMPUTE,
             List.of(

--- a/infra/src/main/java/org/nmox/studio/infra/ui/FlowCanvas.java
+++ b/infra/src/main/java/org/nmox/studio/infra/ui/FlowCanvas.java
@@ -135,6 +135,13 @@ public class FlowCanvas extends JPanel {
 
     /** Centers the view on the design. */
     public void fit() {
+        // called on load before the window system has sized this canvas:
+        // dividing by width 0 slammed zoom to the floor ("way out").
+        // Defer one layout pass and fit against the real viewport.
+        if (getWidth() <= 0 || getHeight() <= 0) {
+            javax.swing.SwingUtilities.invokeLater(this::fit);
+            return;
+        }
         var nodes = graph.getNodes();
         if (nodes.isEmpty()) {
             zoom = 1.0;
@@ -148,12 +155,39 @@ public class FlowCanvas extends JPanel {
                 maxX = Math.max(maxX, n.x + NODE_W);
                 maxY = Math.max(maxY, n.y + NODE_H + 18);
             }
-            double zx = getWidth() / (double) Math.max(200, maxX - minX + 120);
-            double zy = getHeight() / (double) Math.max(160, maxY - minY + 120);
-            zoom = Math.max(0.4, Math.min(1.5, Math.min(zx, zy)));
-            panX = -minX * zoom + 60;
-            panY = -minY * zoom + 60;
+            double contentW = maxX - minX + 120;
+            double contentH = maxY - minY + 120;
+            double zx = getWidth() / Math.max(200.0, contentW);
+            double zy = getHeight() / Math.max(160.0, contentH);
+            // contain, never magnify: small designs stay at natural size
+            zoom = Math.max(0.3, Math.min(1.0, Math.min(zx, zy)));
+            // center the content in the viewport, both axes
+            panX = (getWidth() - (maxX - minX) * zoom) / 2 - minX * zoom;
+            panY = (getHeight() - (maxY - minY) * zoom) / 2 - minY * zoom;
         }
+        repaint();
+    }
+
+    /** Current zoom factor (1.0 = natural size). */
+    public double getZoom() {
+        return zoom;
+    }
+
+    /** Step zoom around the viewport center - the toolbar +/- buttons. */
+    public void zoomIn() {
+        zoomAroundCenter(1.25);
+    }
+
+    public void zoomOut() {
+        zoomAroundCenter(1 / 1.25);
+    }
+
+    private void zoomAroundCenter(double factor) {
+        double newZoom = Math.max(0.3, Math.min(2.5, zoom * factor));
+        double cx = getWidth() / 2.0, cy = getHeight() / 2.0;
+        panX = cx - (cx - panX) * (newZoom / zoom);
+        panY = cy - (cy - panY) * (newZoom / zoom);
+        zoom = newZoom;
         repaint();
     }
 

--- a/infra/src/test/java/org/nmox/studio/infra/api/DigitalOceanDeepTest.java
+++ b/infra/src/test/java/org/nmox/studio/infra/api/DigitalOceanDeepTest.java
@@ -1,0 +1,61 @@
+package org.nmox.studio.infra.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.infra.model.GraphIO;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.InfraGraph.InfraNode;
+import org.nmox.studio.infra.model.NodeKind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Deeper DigitalOcean: cloud-init reaches the create body, and a
+ * droplet's public IP survives save/reload so the designer can hand
+ * you an ssh command in a later session.
+ */
+class DigitalOceanDeepTest {
+
+    @Test
+    @DisplayName("Cloud-init user_data reaches the droplet create body — only when set")
+    void userDataFlowsWhenSet() {
+        InfraGraph graph = new InfraGraph();
+        InfraNode droplet = graph.addNode(NodeKind.DROPLET, 0, 0);
+
+        String bare = plannedBody(graph, droplet);
+        assertThat(bare).doesNotContain("user_data");
+
+        droplet.props.put("userData", "#cloud-config\npackages: [nginx]\n");
+        String configured = plannedBody(graph, droplet);
+        assertThat(configured).contains("user_data").contains("cloud-config");
+    }
+
+    @Test
+    @DisplayName("A droplet's public IP round-trips through save/reload")
+    void ipPersists() {
+        InfraGraph graph = new InfraGraph();
+        InfraNode droplet = graph.addNode(NodeKind.DROPLET, 40, 40);
+        droplet.doId = "123456";
+        droplet.ip = "203.0.113.7";
+
+        InfraGraph reloaded = new InfraGraph();
+        GraphIO.fromJson(reloaded, GraphIO.toJson(graph));
+
+        InfraNode back = reloaded.getNodes().get(0);
+        assertThat(back.doId).isEqualTo("123456");
+        assertThat(back.ip).isEqualTo("203.0.113.7");
+    }
+
+    @Test
+    @DisplayName("Cloud-init is a real droplet property in the catalog")
+    void userDataIsACatalogProp() {
+        assertThat(NodeKind.DROPLET.getProps())
+                .anyMatch(p -> p.key().equals("userData"));
+    }
+
+    private static String plannedBody(InfraGraph graph, InfraNode droplet) {
+        return DeployPlanner.plan(graph).stream()
+                .filter(r -> r.nodeId().equals(droplet.id))
+                .findFirst().orElseThrow().body().toString();
+    }
+}

--- a/infra/src/test/java/org/nmox/studio/infra/ui/FlowCanvasFitTest.java
+++ b/infra/src/test/java/org/nmox/studio/infra/ui/FlowCanvasFitTest.java
@@ -1,0 +1,90 @@
+package org.nmox.studio.infra.ui;
+
+import java.awt.Point;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.infra.model.InfraGraph;
+import org.nmox.studio.infra.model.InfraGraph.InfraNode;
+import org.nmox.studio.infra.model.NodeKind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The fit() contract: contain the design, never magnify it, and never
+ * run the math against an unsized canvas (the bug: dividing by width 0
+ * slammed zoom to the floor on every open).
+ */
+class FlowCanvasFitTest {
+
+    private static final FlowCanvas.Callbacks NOOP = new FlowCanvas.Callbacks() {
+        @Override
+        public void nodeDoubleClicked(InfraNode node) {
+        }
+
+        @Override
+        public void nodeContextMenu(InfraNode node, Point screenPoint) {
+        }
+
+        @Override
+        public void selectionChanged(InfraNode node) {
+        }
+    };
+
+    @Test
+    @DisplayName("A small design fits at natural size — contain, never magnify")
+    void smallDesignStaysAtNaturalSize() {
+        InfraGraph graph = new InfraGraph();
+        graph.addNode(NodeKind.DROPLET, 100, 100);
+        graph.addNode(NodeKind.VPC, 300, 100);
+        FlowCanvas canvas = new FlowCanvas(graph, NOOP);
+        canvas.setSize(1200, 800);
+
+        canvas.fit();
+
+        assertThat(canvas.getZoom()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("A sprawling design zooms out to contain, bounded by the floor")
+    void sprawlingDesignContained() {
+        InfraGraph graph = new InfraGraph();
+        for (int i = 0; i < 6; i++) {
+            graph.addNode(NodeKind.DROPLET, i * 700, i * 400);
+        }
+        FlowCanvas canvas = new FlowCanvas(graph, NOOP);
+        canvas.setSize(1000, 700);
+
+        canvas.fit();
+
+        assertThat(canvas.getZoom()).isLessThan(1.0).isGreaterThanOrEqualTo(0.3);
+    }
+
+    @Test
+    @DisplayName("Fit on an unsized canvas defers instead of computing garbage")
+    void unsizedCanvasDefers() {
+        InfraGraph graph = new InfraGraph();
+        graph.addNode(NodeKind.DROPLET, 0, 0);
+        FlowCanvas canvas = new FlowCanvas(graph, NOOP);
+        // no setSize: width/height are 0, as at window-open time
+
+        canvas.fit();
+
+        assertThat(canvas.getZoom())
+                .as("zoom untouched until a real layout pass").isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("Zoom buttons step within bounds")
+    void zoomButtonsClamp() {
+        FlowCanvas canvas = new FlowCanvas(new InfraGraph(), NOOP);
+        canvas.setSize(800, 600);
+        for (int i = 0; i < 20; i++) {
+            canvas.zoomIn();
+        }
+        assertThat(canvas.getZoom()).isEqualTo(2.5);
+        for (int i = 0; i < 40; i++) {
+            canvas.zoomOut();
+        }
+        assertThat(canvas.getZoom()).isEqualTo(0.3);
+    }
+}


### PR DESCRIPTION
## Summary

Two infra-designer improvements shipping together (the zoom fix's background pipeline landed its commit on this branch, so they release as one v1.17.0):

- **Sane zoom on open** — `fit()` deferred until layout; contain-without-magnify; − / Fit / + toolbar buttons. (User-reported: designer always opened "way out".)
- **Cloud-init** — droplet `user_data` flows into the create body.
- **Copy SSH command** — droplet public IP captured on deploy/sync, persisted, offered in the node menu as `ssh root@ip`.
- **Deploy log** — timestamped per-resource record to `.nmox/deploy-log`.

## Verification

Full `mvn verify` green. FlowCanvasFitTest 4/4 + DigitalOceanDeepTest 3/3; InfraModelTest 36/36 (new `userData` prop passes the catalog contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)