### PR TITLE
Docs truth pass: generated device reference (CI-gated), README/CLAUDE.md brought to v1.17 reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 NMOX Studio is a NetBeans Platform-based IDE for modern web development, with first-class polyglot support (JS/TS, Java, C/C++, Python, Ruby, Rust, Go, PHP, shell + configs), NPM integration, project templates, and build tools. It's built as a multi-module Maven project with the NetBeans Rich Client Platform (RCP).
 
-**Status**: shipping (v1.3.0 released, v1.4.0 in flight). Polyglot editing (32 TextMate grammars incl. HTML/CSS/SCSS/Less activated through CSL, LSP providers for 35 MIMEs), the Reason-style task rack (34 devices, stderr monitor bus, cross-lane coordination — QUORUM join + readiness ENABLE gates + per-lane REFLEX routing, presets, CI export, session resurrection, PREFLIGHT ship gate), the Workbench home base (open/recent files, projects, tooling shelf), the Docker control panel, the multi-cloud infra designer (DigitalOcean/Hetzner/Cloudflare), settings UI, installers for all three OSes, and a tag-triggered release workflow.
+**Status**: shipping (v1.17.0). Polyglot editing (45+ TextMate grammars incl. the config layer, LSP providers, Bun/Deno/Rust/Go/BEAM+ toolchains with per-lane monorepo dirs), the Reason-style task rack (39 devices — see docs/devices.md, generated + CI-gated; cross-lane QUORUM join, readiness ENABLE gates, per-lane REFLEX GLOB routing; quality gates: VITALS Lighthouse floor, VERITAS coverage floor + named-failure re-runs, GAUNTLET throughput floor, PRISM bundle budget, BEACON cert/uptime sentinel; SOLDER any-command, TAIL log follow, HELM ssh runner; presets, CI export, session resurrection, PREFLIGHT ship gate), safe project switching + .env everywhere + Experiments (~/.nmox/experiments lifecycle), Quick Search/status line/keymap surfaces, the Workbench home base, the Docker control panel, the multi-cloud infra designer (DigitalOcean/Hetzner/Cloudflare — drift Refresh, Destroy-stack with cost framing, cloud-init user_data, copy-ssh-from-node, deploy log), one Options category, installers for all three OSes with bundled runtimes, Homebrew cask, and a tag-triggered release workflow with SBOM.
 
 ## Build and Run Commands
 
@@ -267,6 +267,11 @@ See `docs/hack/technical-debt.md` for comprehensive list. Key items:
 - **v0.1**: Basic JavaScript/TypeScript support, NPM integration, project templates
 - **v1.0.x**: task rack, polyglot editor (TextMate+CSL), LSP everywhere, infra designer, Workbench, packaging + release pipeline (and the real branded splash)
 - **v1.1.0-v1.3.0**: Docker control panel + HARBOR, BLACKBOX/SONAR awareness devices, session resurrection, PREFLIGHT ship gate
+- **v1.4.x-v1.10.x**: bundled JRE installers, config-layer grammars, Navigator outline, WebProject SPI, LSP health + installer, self-policing build (SpotBugs/find-sec-bugs/JaCoCo floors), Java 21 + CI matrix + SBOM + Dependabot, CI release gates (boot smoke, test audit, rendering probe)
+- **v1.11.0**: daily driver — safe switching guard, .env everywhere, Experiments, Quick Search/status line/keymap, crisp chrome (VCS-museum eviction, honest About, menu-bar name)
+- **v1.12.0-v1.13.0**: SOLDER/TAIL/VITALS + overallSuccess verdict hook; testing rigor (named failures, re-run failed, coverage + throughput floors)
+- **v1.14.0**: infra truth — drift Refresh + Destroy stack with cost framing
+- **v1.15.0-v1.17.0**: Bun + Deno first-class; HELM/BEACON/PRISM; DO deep (cloud-init, ssh-from-node, deploy log) + designer fit/zoom
 - See CHANGELOG.md for the full record; tagging vX.Y.Z triggers the release workflow (5 artifacts)
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -45,11 +45,22 @@ Update later with `brew update && brew upgrade --cask nmox-studio`; remove clean
 ### 🎛️ The Task Rack
 Every web-dev task is a hardware device — knobs, LEDs, LCDs, patch cables.
 Wire OK jacks together (Tab flips the rack) and one keypress runs install →
-build → test, with output scrolling on a phosphor monitor. 33 devices:
+build → test, with output scrolling on a phosphor monitor. 39 devices:
 package managers, bundlers, test runners, dev servers, databases, linters,
 formatters, git, deploy, HTTP, tunnels, load bench, file watcher, the
-QUORUM lane-join barrier, and more. Patches persist per project, ship as
-presets, and export to GitHub Actions.
+QUORUM lane-join barrier, SOLDER (any command as a unit), TAIL (follow log
+files), HELM (run commands on your servers over ssh), and more. Patches
+persist per project, ship as presets, and export to GitHub Actions.
+**[The full device reference](docs/devices.md)** is generated from the
+catalog itself — CI fails if it drifts.
+
+### 🚦 Quality is a shipping gate
+Four floors, each a knob on a faceplate, each able to close the OK jack:
+**VITALS** (Lighthouse performance/a11y/best-practices/SEO), **VERITAS
+MIN COV** (test coverage), **GAUNTLET MIN R/S** (load-bench throughput),
+and **PRISM** (bundle-size budget). **BEACON** watches production —
+uptime plus TLS days-remaining on a clock. Wire any subset through
+QUORUM into LAUNCHPAD: nothing slow, thin, heavy, or expiring ships.
 
 ### ⚡ Built to live in all day
 - **Switch Project (⌘⇧P)** re-aims the whole IDE through a guard that
@@ -80,7 +91,10 @@ networks — and **Dockerize**, which generates production multi-stage
 Dockerfiles from your project's detected toolchain.
 
 ### ⌨️ Polyglot editing
-45+ languages with syntax highlighting (TextMate grammars through NetBeans
+Bun and Deno are first-class toolchains (detected with precedence over
+plain Node — every AUTO device speaks the right binary, CI export
+included), alongside Rust, Go, Python, Ruby, PHP, the BEAM family, and
+more. 45+ languages with syntax highlighting (TextMate grammars through NetBeans
 CSL) — code plus the whole config layer: `.editorconfig`, dotenv, ignore
 files, GraphQL, Vue, Svelte, Astro, Pug, Handlebars, Liquid, nginx,
 Makefile, Protocol Buffers, Prisma, YAML, TOML, Dockerfile. First-class
@@ -97,7 +111,12 @@ and jumps to a symbol on click; and the NMOX Phosphor dark theme.
 The Workbench home base (toolchain chips, open/recent files, tooling
 shelf), Project Studio templates that scaffold versioned, rack-wired
 projects, and a Node-RED-style Infra Designer for DigitalOcean, Hetzner,
-and Cloudflare with cost estimates and dry-run planning.
+and Cloudflare with cost estimates and dry-run planning — plus the
+truth-and-teardown loop: **Refresh** flags cloud-deleted resources as
+drifted, **Destroy stack** tears everything down in reverse dependency
+order with the monthly bill in view, droplets take **cloud-init**
+user_data, and a deployed node hands you its **ssh command** from the
+context menu.
 
 ### ✅ Proven, not promised
 CI runs real `npm install`/build/test/serve through the actual rack devices

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -1,0 +1,327 @@
+# The Device Reference
+
+Every unit in the rack, straight from the catalog — this file is
+generated from `DeviceType` by `DeviceDocsTest` and CI fails if it
+drifts. Do not edit by hand; regenerate with:
+
+```
+mvn -pl rack test -Dtest=DeviceDocsTest -Dnmox.docs.write=true
+```
+
+## AUTOMATE
+
+### MAESTRO — Master Control — fire whole pipelines
+
+> Press RUN SEQUENCE to fire all four TRIG outs at once.
+> Patch TRIG 1 → CRATE RUN, then chain OK jacks: install → build → test.
+
+- **Out:** `TRIG 1` (trigger), `TRIG 2` (trigger), `TRIG 3` (trigger), `TRIG 4` (trigger)
+
+### REFLEX — File Watcher — fire pipelines on save
+
+> Flip WATCH on and every file save fires CHANGED.
+> Patch CHANGED → VERITAS RUN for test-on-save; FILTER narrows to code/styles/docs, or GLOB to one lane (*.rs).
+
+- **Out:** `CHANGED` (trigger), `PATH` (data)
+
+### QUORUM — Lane Join — barrier: fire OK when all lanes pass
+
+> The barrier where lanes converge: ALL fires OK once every wired IN has arrived and all passed.
+> Patch each lane's DONE → IN, OK → LAUNCHPAD. MODE=ANY relays the first instead.
+
+- **In:** `IN 1` (trigger), `IN 2` (trigger), `IN 3` (trigger), `IN 4` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger)
+
+### IGNITION — Polyglot Runtime — run anything: node/go/rust/py/rb/php
+
+> Runs your project's main: cargo run, go run, mix run, python…
+> TARGET=auto follows the detected toolchain; ARGS feed the command line.
+
+- **In:** `RUN` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `RUNNING` (gate)
+
+### NPM-9000 — Script Sequencer — run package.json scripts
+
+> One package.json script per press. SCRIPT knob lists your scripts.
+> Patch OK into the next device to chain scripts into pipelines.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### TEMPO — Step Sequencer — fire pipelines on a clock
+
+> A clock: TICK fires at the dialed rate, BAR every 4th tick.
+> Gate it with ENABLE (patch SURGE RUNNING in) for health checks only while serving.
+
+- **In:** `START` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `TICK` (trigger), `BAR` (trigger), `RUNNING` (gate)
+
+### SOLDER — Custom Command — run anything as a pipeline step
+
+> Runs exactly what you type - make seed-db, ./scripts/fixtures.sh - argv only, no shell.
+> Patch VERITAS OK → RUN to chain custom steps; SOLDER exports to CI like any device.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+## VERIFY
+
+### CRATE — Package Manager — install & update deps
+
+> INSTALL readies dependencies - in mixed repos it sequences every toolchain.
+> UPDATE upgrades, CHECK reports outdated. OK fires when done.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### FORGE — Build Engine — vite/webpack/rollup & co
+
+> BUILD compiles with the detected tool (vite/cargo/mix/swift…).
+> WATCH mode fires OK on every rebuild - patch OK → VERITAS for build-then-test.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### VERITAS — Test Harness — jest/vitest/mocha...
+
+> Runs the suite; the tally LCD shows live pass/fail.
+> RUNNER=auto picks jest/pytest/cargo/mix… Patch OUT → MONITOR to read output.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### PURITY — Lint Filter — eslint/stylelint
+
+> Static analysis; E/W counts land on the LCD, CLEAN lights when spotless.
+> FIX rewrites violations in place (amber = it mutates your files).
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### GLOSS — Code Formatter — prettier
+
+> Prettier over the project. WRITE rewrites; CHECK only verifies.
+> Patch REFLEX CHANGED → RUN for format-on-save.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### TYPEGUARD — Type Checker — tsc, watch-aware
+
+> tsc --noEmit. WATCH keeps the compiler resident and fires OK/FAIL per check.
+> STRICT adds --strict. E: count on the LCD.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### VITALS — Web Quality Gate — Lighthouse scores with a shipping floor
+
+> Lighthouse headless against the dialed URL - PERF/A11Y/BEST/SEO on the meters.
+> Patch SURGE URL → URL and READY → RUN; dial MIN and slow pages close the gate (FAIL, not OK).
+
+- **In:** `RUN` (trigger), `URL` (data)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### PRISM — Bundle-Size Gate — weigh the build, hold the line
+
+> Weighs the build output dir; MAX sets the budget.
+> Patch FORGE OK → MEASURE and OK → LAUNCHPAD: bundles over budget don't ship.
+
+- **In:** `MEASURE` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger)
+
+## SERVE
+
+### SURGE — Dev Server — start/stop local serving
+
+> START serves your project; URL and READY outs feed SCOPE so the
+> browser opens itself at the real address. RUNNING gates TEMPO nicely.
+
+- **In:** `RUN` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `RUNNING` (gate), `READY` (trigger), `URL` (data)
+
+### PING — Request Probe — HTTP smoke tests
+
+> Fires one HTTP request; status + latency on the LCDs, OK/FAIL triggers out.
+> Patch TEMPO TICK → SEND for a heartbeat monitor.
+
+- **In:** `SEND` (trigger), `URL` (data)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `BODY` (data)
+
+### SCOPE — Browser Link — open URLs on trigger
+
+> Opens the system browser at the dialed URL on OPEN or any trigger in.
+> Patch a URL data jack in and SCOPE follows wherever the server actually is.
+
+- **In:** `OPEN` (trigger), `URL` (data)
+- **Out:** `OPENED` (trigger)
+
+### WORMHOLE — Public Tunnel — cloudflared/ngrok/localtunnel
+
+> OPEN exposes a local port to the internet via cloudflared/ngrok.
+> The public URL lands on the LCD and the URL jack - patch into SCOPE to pop it.
+
+- **In:** `RUN` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `URL` (data), `RUNNING` (gate)
+
+### NEPTUNE — Database Console — ping databases & trigger schemas
+
+> Pings SQL databases (PostgreSQL/MySQL/SQLite/MariaDB).
+> Dial DB TYPE to select database URL or profile; ping fires OK on success.
+
+- **In:** `RUN` (trigger), `PING` (trigger), `MIGRATE` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `RUNNING` (gate)
+
+## FRAMEWORKS
+
+### HALO — Angular Console — serve/generate/update, stays current
+
+> SERVE/BUILD/TEST drive ng; GEN scaffolds with the SCHEMATIC knob.
+> The version cluster nags when Angular moves - UPDATE runs ng update.
+
+- **In:** `RUN` (trigger), `SERVE` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `URL` (data), `READY` (trigger), `SERVING` (gate)
+
+### PHOENIX — Phoenix Console — phx.server/gen/ecto, Hex currency
+
+> SERVER runs mix phx.server; GEN row drives phx.gen.*; MIGRATE runs ecto.
+> Version cluster tracks :phoenix against Hex.
+
+- **In:** `RUN` (trigger), `SERVE` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `URL` (data), `READY` (trigger), `SERVING` (gate)
+
+### NEXUS — Next.js Console — dev/build/start, registry currency
+
+> DEV serves with the URL out feeding SCOPE; BUILD then START runs production.
+> Version cluster tracks next against the registry.
+
+- **In:** `RUN` (trigger), `DEV` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `URL` (data), `READY` (trigger), `SERVING` (gate)
+
+## OBSERVE
+
+### INSPECTOR — Debug Launcher — debug servers with attach endpoints
+
+> LAUNCH starts your runtime in debug-server mode; the attach
+> endpoint (chrome://inspect, debugpy, dlv…) lands on the LCD.
+
+- **In:** `RUN` (trigger), `STOP` (trigger), `ENABLE` (gate)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data), `ENDPOINT` (data), `RUNNING` (gate)
+
+### MONITOR — Output Console — watch any OUT jack
+
+> A glanceable 8-line screen. Patch any OUT (data) jack into IN,
+> or dial TAP to stderr/all to hear every device unpatched — errors glow red.
+
+- **In:** `IN` (data)
+
+### PHOSPHOR — Scrollback Terminal — 5k lines, selectable
+
+> 5,000 lines of selectable scrollback. FOLLOW tails the output.
+> Patch the OUT of anything chatty in here.
+
+- **In:** `IN` (data)
+
+### GAUNTLET — Load Bench — autocannon throughput
+
+> FIRE hammers the URL with autocannon; req/s on the meter.
+> Patch SURGE URL → URL and READY → RUN to bench the second it serves.
+
+- **In:** `RUN` (trigger), `URL` (data)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### BLACKBOX — Flight Recorder — session timeline, slow-creep alarm
+
+> The rack's session memory: every launch, exit, duration, and error, timestamped.
+> VIEW scrolls the timeline; the health line warns when a build quietly slows past its average.
+
+- **Out:** `OUT` (data)
+
+### SONAR — Port Radar — who owns every port, one-click kill
+
+> SWEEP maps every listening port to its owning process — docker containers labeled.
+> VIEW opens the field: BROWSE any port, KILL any squatter. EADDRINUSE, solved.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OUT` (data)
+
+### TAIL — Log Follower — tail -f any file onto the patch bay
+
+> tail -f as a device: dial a file (relative to the project), flip FOLLOW.
+> Patch OUT → PHOSPHOR and your server's logs/app.log scrolls beside its stdout.
+
+- **Out:** `OUT` (data)
+
+### BEACON — Cert & Uptime Sentinel — TLS runway and reachability, gated
+
+> CHECK answers: is it up, and how many days on the TLS cert?
+> Patch TEMPO BAR → CHECK to watch production on a clock; MIN DAYS fires FAIL inside the window.
+
+- **In:** `CHECK` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger)
+
+## SHIP
+
+### TIMELINE — Git Sequencer — status/pull/commit/push
+
+> STATUS/PULL/COMMIT/PUSH with the branch on the LCD and a DIRTY light.
+> Amber buttons mutate - the law of the rack.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### SENTRY — Security Analyzer — npm audit meters
+
+> SCAN runs the security audit; severity ladders fill per class.
+> SECURE lights green when the tree is clean.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### LAUNCHPAD — Deploy Output — armed deploys only
+
+> Flip ARM, then LAUNCH deploys to the dialed target.
+> Unarmed pads ignore even patched triggers - by design.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### HARBOR — Docker Engine — panel, prune, status
+
+> The ENGINE LED tracks the daemon; LCDs show containers up, images held, disk reclaimable.
+> PANEL opens the full control room — containers, images, volumes, networks, and one-click Dockerize.
+
+- **In:** `RUN` (trigger)
+- **Out:** `RUNNING` (gate), `OUT` (data)
+
+### PREFLIGHT — Ship Check — git/tests/build/lint/audit, one verdict
+
+> CHECK runs the readiness list — git clean, tests, build, lint, audit — one LED per item.
+> Patch OK → LAUNCHPAD RUN and unverified code physically cannot deploy.
+
+- **In:** `RUN` (trigger)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+### HELM — Remote Runner — run commands on your servers over ssh
+
+> Runs the dialed command on user@host over ssh (BatchMode: key auth only).
+> Patch LAUNCHPAD OK → RUN to finish deploys with a remote migrate or restart; HOST accepts a cable.
+
+- **In:** `RUN` (trigger), `HOST` (data)
+- **Out:** `OK` (trigger), `FAIL` (trigger), `DONE` (trigger), `OUT` (data)
+
+## UTILITY
+
+### ROSETTA — Language Selector — steer AUTO knobs in mixed repos
+
+> Mixed repo? Pin every AUTO knob to one toolchain with the dial.
+> AUTO follows detection; KIND out reports the choice.
+
+- **Out:** `KIND` (data)
+
+### ATMOS — Env Mixer — NODE_ENV/CI/custom vars
+
+> Sets NODE_ENV/CI/custom vars for every command the rack runs.
+> What the knob says is what every device gets.
+
+- **Out:** `ENV` (data)

--- a/docs/engineering/actual-implementation.md
+++ b/docs/engineering/actual-implementation.md
@@ -1,3 +1,6 @@
+> **Historical document** (v0.x era). Kept for archaeology; see CLAUDE.md,
+> README.md and CHANGELOG.md for current reality.
+
 # Actual Implementation Architecture
 
 *Reality vs Vision: What we actually built*

--- a/docs/engineering/api-design.md
+++ b/docs/engineering/api-design.md
@@ -1,3 +1,6 @@
+> **Historical document** (v0.x era). Kept for archaeology; see CLAUDE.md,
+> README.md and CHANGELOG.md for current reality.
+
 # API Design Documentation
 
 ## 🎯 API Design Principles

--- a/docs/engineering/next-iteration.md
+++ b/docs/engineering/next-iteration.md
@@ -1,3 +1,6 @@
+> **Historical document** (v0.x era). Kept for archaeology; see CLAUDE.md,
+> README.md and CHANGELOG.md for current reality.
+
 # Next Iteration Plan: v0.2 "Polish & Performance"
 
 *From working prototype to polished developer tool*

--- a/docs/hack/implementation-complete.md
+++ b/docs/hack/implementation-complete.md
@@ -1,3 +1,6 @@
+> **Historical document** (v0.x era). Kept for archaeology; see CLAUDE.md,
+> README.md and CHANGELOG.md for current reality.
+
 # Implementation Complete: What We Actually Built
 
 *Reality check: From ambitious plans to working software*

--- a/docs/hack/technical-debt.md
+++ b/docs/hack/technical-debt.md
@@ -1,3 +1,6 @@
+> **Historical document** (v0.x era). Kept for archaeology; see CLAUDE.md,
+> README.md and CHANGELOG.md for current reality.
+
 # Technical Debt & Known Issues
 
 *Honest assessment of shortcuts taken and problems to solve*

--- a/rack/src/test/java/org/nmox/studio/rack/devices/DeviceDocsTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/DeviceDocsTest.java
@@ -1,0 +1,89 @@
+package org.nmox.studio.rack.devices;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nmox.studio.rack.model.Port;
+import org.nmox.studio.rack.model.RackDevice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Documentation that cannot lie: docs/devices.md is generated from the
+ * DeviceType catalog itself - titles, descriptions, usage recipes, and
+ * the real jacks on every back panel. This test fails when the
+ * committed file drifts from the catalog; regenerate with
+ *
+ *   mvn -pl rack test -Dtest=DeviceDocsTest -Dnmox.docs.write=true
+ */
+class DeviceDocsTest {
+
+    @Test
+    @DisplayName("docs/devices.md matches the device catalog exactly")
+    void deviceReferenceIsCurrent() throws Exception {
+        String generated = generate();
+        File doc = new File("../docs/devices.md");
+        if (Boolean.getBoolean("nmox.docs.write")) {
+            Files.writeString(doc.toPath(), generated);
+            return;
+        }
+        assertThat(doc).as("docs/devices.md missing — regenerate with -Dnmox.docs.write=true").exists();
+        assertThat(Files.readString(doc.toPath()))
+                .as("docs/devices.md is stale — regenerate with -Dnmox.docs.write=true")
+                .isEqualTo(generated);
+    }
+
+    static String generate() {
+        StringBuilder md = new StringBuilder();
+        md.append("# The Device Reference\n\n");
+        md.append("Every unit in the rack, straight from the catalog — this file is\n");
+        md.append("generated from `DeviceType` by `DeviceDocsTest` and CI fails if it\n");
+        md.append("drifts. Do not edit by hand; regenerate with:\n\n");
+        md.append("```\nmvn -pl rack test -Dtest=DeviceDocsTest -Dnmox.docs.write=true\n```\n");
+
+        Map<DeviceType.PaletteCategory, List<DeviceType>> byCategory = new LinkedHashMap<>();
+        for (DeviceType.PaletteCategory cat : DeviceType.PaletteCategory.values()) {
+            byCategory.put(cat, new java.util.ArrayList<>());
+        }
+        for (DeviceType type : DeviceType.values()) {
+            byCategory.get(type.getPaletteCategory()).add(type);
+        }
+        for (var entry : byCategory.entrySet()) {
+            if (entry.getValue().isEmpty()) {
+                continue;
+            }
+            md.append("\n## ").append(entry.getKey()).append("\n");
+            for (DeviceType type : entry.getValue()) {
+                RackDevice device = type.create();
+                md.append("\n### ").append(type.getTitle())
+                        .append(" — ").append(type.getDescription()).append("\n\n");
+                for (String line : type.getUsage().split("\n")) {
+                    md.append("> ").append(line).append("\n");
+                }
+                StringBuilder ins = new StringBuilder();
+                StringBuilder outs = new StringBuilder();
+                for (Port p : device.getPorts()) {
+                    StringBuilder side = p.getDirection() == Port.Direction.IN ? ins : outs;
+                    if (side.length() > 0) {
+                        side.append(", ");
+                    }
+                    side.append("`").append(p.getLabel()).append("` (")
+                            .append(p.getType().name().toLowerCase()).append(")");
+                }
+                md.append("\n");
+                if (ins.length() > 0) {
+                    md.append("- **In:** ").append(ins).append("\n");
+                }
+                if (outs.length() > 0) {
+                    md.append("- **Out:** ").append(outs).append("\n");
+                }
+                device.dispose();
+            }
+        }
+        return md.toString();
+    }
+}


### PR DESCRIPTION
## Summary

- **docs/devices.md** — the 39-device reference generated from `DeviceType` itself; `DeviceDocsTest` fails CI if it drifts. Same philosophy as the contract tests: documentation that cannot lie.
- **README** — device count corrected (33→39), new *Quality is a shipping gate* section, Bun/Deno, infra truth-and-teardown, reference link. `brew trust` verified as a real command before touching the install instructions.
- **CLAUDE.md** — status rewritten from "v1.3.0 released, v1.4.0 in flight" (14 releases stale) to v1.17.0 reality; version history completed.
- **Historical banners** on five v0.x-era docs.

## Verification

Full `mvn verify` green including the new docs gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)