### PR TITLE
REST console on PING + platform dialogs in the infra designer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.18.0] — 2026-07-02
+
+The second-cut sprint's final tranche: PING grows into a REST console,
+and the infra designer's dialogs join the platform.
+
+### Added
+- **PING is a REST console now.** HEADERS carries auth and content
+  types (session-only — tokens never persist into the committable
+  patch, the ATMOS rule); VIEW opens a console with the last 50
+  exchanges, pretty-printed JSON responses, and one-click **Replay**.
+  A dialed Content-Type wins over the JSON sniff.
+
+### Changed
+- **The infra designer speaks the platform.** All twelve raw
+  `JOptionPane` dialogs — deploy confirmation, destroy-stack, token
+  entry, sync/refresh results — are now `DialogDisplayer`
+  notifications and dialogs: correctly parented, keyboard-correct, and
+  consistent with the rest of the IDE. These are the highest-stakes
+  confirmations in the app (they spend money); they deserved it.
+
 ## [1.17.0] — 2026-07-02
 
 The infrastructure designer, deepened: it opens fitted, provisions

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -142,8 +142,8 @@ mvn -pl rack test -Dtest=DeviceDocsTest -Dnmox.docs.write=true
 
 ### PING — Request Probe — HTTP smoke tests
 
-> Fires one HTTP request; status + latency on the LCDs, OK/FAIL triggers out.
-> Patch TEMPO TICK → SEND for a heartbeat monitor.
+> Fires HTTP requests; status + latency on the LCDs, OK/FAIL triggers out.
+> VIEW opens the console (pretty-printed responses, last 50 exchanges, replay); HEADERS is session-only.
 
 - **In:** `SEND` (trigger), `URL` (data)
 - **Out:** `OK` (trigger), `FAIL` (trigger), `BODY` (data)

--- a/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
+++ b/infra/src/main/java/org/nmox/studio/infra/InfraDesignerTopComponent.java
@@ -10,7 +10,9 @@ import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import javax.swing.JPasswordField;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -140,10 +142,9 @@ public final class InfraDesignerTopComponent extends TopComponent {
                 panel.add(new JLabel(providers[i].displayName() + current));
                 panel.add(fields[i]);
             }
-            int ok = JOptionPane.showConfirmDialog(this, panel,
-                    "Cloud API tokens (stored in IDE settings; blank = keep current)",
-                    JOptionPane.OK_CANCEL_OPTION);
-            if (ok == JOptionPane.OK_OPTION) {
+            DialogDescriptor dd = new DialogDescriptor(panel,
+                    "Cloud API tokens (stored in IDE settings; blank = keep current)");
+            if (DialogDisplayer.getDefault().notify(dd) == DialogDescriptor.OK_OPTION) {
                 for (int i = 0; i < providers.length; i++) {
                     String value = new String(fields[i].getPassword()).trim();
                     if (!value.isEmpty()) {
@@ -213,8 +214,7 @@ public final class InfraDesignerTopComponent extends TopComponent {
     private void deploy() {
         List<DoRequest> plan = DeployPlanner.plan(graph);
         if (plan.isEmpty()) {
-            JOptionPane.showMessageDialog(this, "Nothing to deploy - the design is empty or all live.",
-                    "Infra Designer", JOptionPane.INFORMATION_MESSAGE);
+            info("Nothing to deploy - the design is empty or all live.");
             return;
         }
         StringBuilder text = new StringBuilder();
@@ -256,11 +256,17 @@ public final class InfraDesignerTopComponent extends TopComponent {
         String title = live ? "Deploy?"
                 : missing.isEmpty() ? "Dry run (no API token set)"
                         : "Dry run (missing API tokens)";
-        Object[] options = live ? new Object[]{"Deploy", "Cancel"} : new Object[]{"Close"};
-        int choice = JOptionPane.showOptionDialog(this, new JScrollPane(area), title,
-                JOptionPane.DEFAULT_OPTION, live ? JOptionPane.WARNING_MESSAGE : JOptionPane.INFORMATION_MESSAGE,
-                null, options, options[0]);
-        if (!live || choice != 0) {
+        DialogDescriptor dd = new DialogDescriptor(new JScrollPane(area), title);
+        if (live) {
+            Object deploy = "Deploy";
+            dd.setOptions(new Object[]{deploy, "Cancel"});
+            dd.setValue("Cancel");
+            if (DialogDisplayer.getDefault().notify(dd) != deploy) {
+                return;
+            }
+        } else {
+            dd.setOptions(new Object[]{"Close"});
+            DialogDisplayer.getDefault().notify(dd);
             return;
         }
         Thread worker = new Thread(() -> {
@@ -275,10 +281,11 @@ public final class InfraDesignerTopComponent extends TopComponent {
             writeDeployLog(log.toString());
             SwingUtilities.invokeLater(() -> {
                 save();
-                JOptionPane.showMessageDialog(this,
-                        ok ? "Deploy complete - nodes are live. Log: .nmox/deploy-log"
-                           : "Deploy stopped on a failure; see node status and .nmox/deploy-log.",
-                        "Infra Designer", ok ? JOptionPane.INFORMATION_MESSAGE : JOptionPane.ERROR_MESSAGE);
+                if (ok) {
+                    info("Deploy complete - nodes are live. Log: .nmox/deploy-log");
+                } else {
+                    error("Deploy stopped on a failure; see node status and .nmox/deploy-log.");
+                }
             });
         }, "nmox-infra-deploy");
         worker.setDaemon(true);
@@ -287,8 +294,7 @@ public final class InfraDesignerTopComponent extends TopComponent {
 
     private void syncFromCloud() {
         if (!DigitalOceanClient.hasToken()) {
-            JOptionPane.showMessageDialog(this, "Set an API token first.", "Infra Designer",
-                    JOptionPane.INFORMATION_MESSAGE);
+            info("Set an API token first.");
             return;
         }
         Thread worker = new Thread(() -> {
@@ -297,12 +303,10 @@ public final class InfraDesignerTopComponent extends TopComponent {
                 SwingUtilities.invokeLater(() -> {
                     canvas.fit();
                     save();
-                    JOptionPane.showMessageDialog(this, "Imported " + imported + " live resources.",
-                            "Infra Designer", JOptionPane.INFORMATION_MESSAGE);
+                    info("Imported " + imported + " live resources.");
                 });
             } catch (Exception ex) {
-                SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this,
-                        "Sync failed: " + ex.getMessage(), "Infra Designer", JOptionPane.ERROR_MESSAGE));
+                SwingUtilities.invokeLater(() -> error("Sync failed: " + ex.getMessage()));
             }
         }, "nmox-infra-sync");
         worker.setDaemon(true);
@@ -317,8 +321,7 @@ public final class InfraDesignerTopComponent extends TopComponent {
                         SwingUtilities.invokeLater(() -> graph.setStatus(node, status)));
                 SwingUtilities.invokeLater(this::save);
             } catch (Exception ex) {
-                SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this,
-                        "Refresh failed: " + ex.getMessage(), "Refresh", JOptionPane.ERROR_MESSAGE));
+                SwingUtilities.invokeLater(() -> error("Refresh failed: " + ex.getMessage()));
             }
         }, "nmox-infra-refresh");
         worker.setDaemon(true);
@@ -333,7 +336,7 @@ public final class InfraDesignerTopComponent extends TopComponent {
     private void destroyStack() {
         java.util.List<InfraNode> order = DeployPlanner.teardownOrder(graph);
         if (order.isEmpty()) {
-            JOptionPane.showMessageDialog(this, "Nothing deployed to destroy.");
+            info("Nothing deployed to destroy.");
             return;
         }
         double monthly = 0;
@@ -343,12 +346,12 @@ public final class InfraDesignerTopComponent extends TopComponent {
             names.append("  • ").append(node.kind.getDisplayName())
                     .append("  ").append(node.label).append('\n');
         }
-        int answer = JOptionPane.showConfirmDialog(this,
-                "Destroy " + order.size() + " cloud resource" + (order.size() == 1 ? "" : "s")
+        boolean go = confirm("Destroy " + order.size() + " cloud resource"
+                + (order.size() == 1 ? "" : "s")
                 + ", saving ~$" + String.format("%.2f", monthly) + "/month?\n\n" + names
                 + "\nReverse dependency order. The design stays on the canvas.",
-                "Destroy stack", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-        if (answer != JOptionPane.YES_OPTION) {
+                "Destroy stack");
+        if (!go) {
             return;
         }
         Thread worker = new Thread(() -> {
@@ -357,14 +360,30 @@ public final class InfraDesignerTopComponent extends TopComponent {
             SwingUtilities.invokeLater(() -> {
                 save();
                 if (failures > 0) {
-                    JOptionPane.showMessageDialog(this,
-                            failures + " resource(s) could not be destroyed — check their status lines.",
-                            "Destroy stack", JOptionPane.WARNING_MESSAGE);
+                    error(failures + " resource(s) could not be destroyed — check their status lines.");
                 }
             });
         }, "nmox-infra-destroy-stack");
         worker.setDaemon(true);
         worker.start();
+    }
+
+    // ---- platform dialogs (parented, keyboard-correct, consistent chrome) ----
+
+    private void info(String message) {
+        DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
+                message, NotifyDescriptor.INFORMATION_MESSAGE));
+    }
+
+    private void error(String message) {
+        DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
+                message, NotifyDescriptor.ERROR_MESSAGE));
+    }
+
+    private boolean confirm(String message, String title) {
+        NotifyDescriptor d = new NotifyDescriptor.Confirmation(message, title,
+                NotifyDescriptor.YES_NO_OPTION, NotifyDescriptor.WARNING_MESSAGE);
+        return DialogDisplayer.getDefault().notify(d) == NotifyDescriptor.YES_OPTION;
     }
 
     /** Appends a deploy run to .nmox/deploy-log beside the aimed project. */
@@ -391,10 +410,8 @@ public final class InfraDesignerTopComponent extends TopComponent {
         if (node.doId != null) {
             JMenuItem destroy = new JMenuItem("Destroy in cloud (" + node.doId + ")");
             destroy.addActionListener(e -> {
-                if (JOptionPane.showConfirmDialog(this,
-                        "Really destroy " + node.kind.getDisplayName() + " " + node.label + " on DigitalOcean?",
-                        "Destroy resource", JOptionPane.YES_NO_OPTION,
-                        JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+                if (confirm("Really destroy " + node.kind.getDisplayName() + " "
+                        + node.label + " on DigitalOcean?", "Destroy resource")) {
                     Thread worker = new Thread(() -> {
                         try {
                             client.destroy(node);

--- a/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/DeviceType.java
@@ -128,7 +128,7 @@ public enum DeviceType {
             case DEV_SERVER -> "START serves your project; URL and READY outs feed SCOPE so the\nbrowser opens itself at the real address. RUNNING gates TEMPO nicely.";
             case TUNNEL -> "OPEN exposes a local port to the internet via cloudflared/ngrok.\nThe public URL lands on the LCD and the URL jack - patch into SCOPE to pop it.";
             case BROWSER -> "Opens the system browser at the dialed URL on OPEN or any trigger in.\nPatch a URL data jack in and SCOPE follows wherever the server actually is.";
-            case HTTP -> "Fires one HTTP request; status + latency on the LCDs, OK/FAIL triggers out.\nPatch TEMPO TICK → SEND for a heartbeat monitor.";
+            case HTTP -> "Fires HTTP requests; status + latency on the LCDs, OK/FAIL triggers out.\nVIEW opens the console (pretty-printed responses, last 50 exchanges, replay); HEADERS is session-only.";
             case ANGULAR -> "SERVE/BUILD/TEST drive ng; GEN scaffolds with the SCHEMATIC knob.\nThe version cluster nags when Angular moves - UPDATE runs ng update.";
             case PHOENIX -> "SERVER runs mix phx.server; GEN row drives phx.gen.*; MIGRATE runs ecto.\nVersion cluster tracks :phoenix against Hex.";
             case NEXTJS -> "DEV serves with the URL out feeding SCOPE; BUILD then START runs production.\nVersion cluster tracks next against the registry.";

--- a/rack/src/main/java/org/nmox/studio/rack/devices/HttpDevice.java
+++ b/rack/src/main/java/org/nmox/studio/rack/devices/HttpDevice.java
@@ -1,11 +1,18 @@
 package org.nmox.studio.rack.devices;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.nmox.studio.rack.model.Port;
 import org.nmox.studio.rack.model.RackDevice;
 import org.nmox.studio.rack.model.Signal;
@@ -18,42 +25,60 @@ import org.nmox.studio.rack.ui.controls.RackStyle;
 import org.nmox.studio.rack.ui.controls.VuMeter;
 
 /**
- * PING Request Probe: fires HTTP requests at an endpoint and reports
- * status and latency - a smoke tester for APIs and dev servers.
+ * PING Request Probe: a REST console on a faceplate. Fires HTTP
+ * requests, reports status and latency, and VIEW opens the console -
+ * pretty-printed responses and the last 50 exchanges with one-click
+ * replay. HEADERS carries auth and content types but is session-only:
+ * tokens must never ride the committable patch file (the ATMOS rule).
  */
 public class HttpDevice extends RackDevice {
 
     private static final String[] METHODS = {"GET", "HEAD", "POST", "PUT", "DELETE"};
+    private static final int HISTORY_MAX = 50;
 
     private final Knob methodKnob;
     private final LcdDisplay urlLcd;
     private final LcdDisplay bodyLcd;
+    private final LcdDisplay headersLcd;
     private final LcdDisplay statusLcd;
     private final VuMeter latencyMeter;
     private final Led okLed;
     private final Led failLed;
+    private final Deque<Exchange> history = new ArrayDeque<>();
     private final HttpClient client = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
             .build();
+
+    /** One request/response round trip, for the console history. */
+    record Exchange(String method, String url, int status, long ms,
+            String responseHeaders, String responseBody) {
+    }
 
     public HttpDevice() {
         super("http", "PING", "REQUEST PROBE", new Color(96, 180, 100), 2);
 
         methodKnob = place(new Knob("METHOD", METHODS, 0), 112, 40);
-        urlLcd = place(new LcdDisplay(260, 1), 184, 46);
+        urlLcd = place(new LcdDisplay(260, 1), 184, 40);
         urlLcd.setText("http://localhost:3000");
         urlLcd.setEditable("Request URL");
-        bodyLcd = place(new LcdDisplay(260, 1), 184, 78);
+        headersLcd = place(new LcdDisplay(260, 1), 184, 66);
+        headersLcd.setText("");
+        headersLcd.setEditable("Headers (Name: value; Name: value) — session-only");
+        headersLcd.setToolTipText("Auth and content headers. Session-only — tokens never persist into the patch file.");
+        bodyLcd = place(new LcdDisplay(260, 1), 184, 92);
         bodyLcd.setText("");
         bodyLcd.setEditable("Request body (sent on POST/PUT)");
-        RackButton send = place(new RackButton("SEND", RackStyle.GO), RackStyle.TRANSPORT_X, 46);
-        statusLcd = place(new LcdDisplay(120, 1), 460, 46);
+        RackButton send = place(new RackButton("SEND", RackStyle.GO), RackStyle.TRANSPORT_X, 40);
+        RackButton view = place(new RackButton("VIEW", RackStyle.QUERY), RackStyle.TRANSPORT_X, 78);
+        view.setToolTipText("Open the console: pretty-printed responses and the last 50 exchanges");
+        statusLcd = place(new LcdDisplay(120, 1), 460, 40);
         statusLcd.setText("—");
-        latencyMeter = place(new VuMeter("LATENCY", false), 460, 80);
-        okLed = place(new Led("2XX", RackStyle.GO), 600, 52);
-        failLed = place(new Led("ERR", RackStyle.STOP), 640, 52);
+        latencyMeter = place(new VuMeter("LATENCY", false), 460, 78);
+        okLed = place(new Led("2XX", RackStyle.GO), 600, 46);
+        failLed = place(new Led("ERR", RackStyle.STOP), 640, 46);
 
         send.addActionListener(e -> fire());
+        view.addActionListener(e -> showConsole());
 
         addInPort("send", "SEND", SignalType.TRIGGER);
         addInPort("url", "URL", SignalType.DATA);
@@ -64,6 +89,8 @@ public class HttpDevice extends RackDevice {
         param("method", methodKnob);
         param("url", urlLcd);
         param("body", bodyLcd);
+        // headers are NOT a param: auth tokens must not persist into the
+        // committable .nmoxrack.json (same rule as ATMOS's EXTRA line)
     }
 
     private void fire() {
@@ -77,10 +104,11 @@ public class HttpDevice extends RackDevice {
             statusLcd.setTextColor(RackStyle.LCD_AMBER);
             statusLcd.setText("…");
         });
+        String method = METHODS[methodKnob.getSelectedIndex()];
         long start = System.nanoTime();
         HttpRequest request;
         try {
-            request = buildRequest(METHODS[methodKnob.getSelectedIndex()], url, bodyLcd.getText());
+            request = buildRequest(method, url, bodyLcd.getText(), parseHeaders(headersLcd.getText()));
         } catch (RuntimeException ex) {
             onEdt(() -> {
                 failLed.setOn(true);
@@ -93,6 +121,8 @@ public class HttpDevice extends RackDevice {
                 .whenComplete((response, error) -> {
                     long ms = (System.nanoTime() - start) / 1_000_000;
                     if (error != null) {
+                        record(new Exchange(method, url, -1, ms, "",
+                                error.getMessage() == null ? "no route" : error.getMessage()));
                         onEdt(() -> {
                             failLed.setOn(true);
                             statusLcd.setTextColor(new Color(255, 90, 80));
@@ -102,6 +132,9 @@ public class HttpDevice extends RackDevice {
                         return;
                     }
                     boolean ok = response.statusCode() < 400;
+                    String body = response.body() == null ? "" : response.body();
+                    record(new Exchange(method, url, response.statusCode(), ms,
+                            formatHeaders(response), body));
                     latencyMeter.setLevel(Math.min(1.0, ms / 2000.0));
                     onEdt(() -> {
                         okLed.setOn(ok);
@@ -110,40 +143,161 @@ public class HttpDevice extends RackDevice {
                         statusLcd.setText(response.statusCode() + "  " + ms + "ms");
                     });
                     emit(ok ? "ok" : "fail", Signal.trigger(ok));
-                    String body = response.body();
-                    if (body != null && !body.isEmpty()) {
-                        // full payload down the cable (PHOSPHOR holds 5k lines);
-                        // only truly pathological bodies get clipped
+                    if (!body.isEmpty()) {
+                        // full payload down the cable (PHOSPHOR holds 5k lines)
                         emit("body", Signal.data(body.length() > 65_536
                                 ? body.substring(0, 65_536) + "…" : body));
                     }
                 });
     }
 
+    private synchronized void record(Exchange exchange) {
+        history.addFirst(exchange);
+        while (history.size() > HISTORY_MAX) {
+            history.removeLast();
+        }
+    }
+
     /**
-     * Builds the request: POST/PUT carry the body field (JSON gets a
-     * Content-Type so APIs accept it); everything else is body-less.
+     * Builds the request: POST/PUT carry the body field, dialed headers
+     * apply on top (an explicit Content-Type wins over the JSON sniff).
      * Static and side-effect-free so the wiring is unit-testable.
      */
-    static HttpRequest buildRequest(String method, String url, String body) {
+    static HttpRequest buildRequest(String method, String url, String body, Map<String, String> headers) {
         HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url))
                 .timeout(Duration.ofSeconds(15));
         boolean sendsBody = ("POST".equals(method) || "PUT".equals(method))
                 && body != null && !body.isBlank();
         if (sendsBody) {
             b.method(method, HttpRequest.BodyPublishers.ofString(body));
-            if (looksJson(body)) {
+            if (looksJson(body) && !headers.containsKey("Content-Type")) {
                 b.header("Content-Type", "application/json");
             }
         } else {
             b.method(method, HttpRequest.BodyPublishers.noBody());
         }
+        headers.forEach(b::header); // dialed headers win: auth, overrides
         return b.build();
     }
 
     static boolean looksJson(String body) {
         String t = body.strip();
         return t.startsWith("{") || t.startsWith("[");
+    }
+
+    /** Parses "Name: value; Other: value" into an ordered header map. */
+    static Map<String, String> parseHeaders(String line) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        if (line == null || line.isBlank()) {
+            return headers;
+        }
+        for (String segment : line.split(";")) {
+            int colon = segment.indexOf(':');
+            if (colon <= 0) {
+                continue;
+            }
+            String name = segment.substring(0, colon).trim();
+            String value = segment.substring(colon + 1).trim();
+            if (!name.isEmpty() && !value.isEmpty()) {
+                headers.put(name, value);
+            }
+        }
+        return headers;
+    }
+
+    /** Indents a JSON body for the console; anything else passes through. */
+    static String prettyJson(String body) {
+        if (body == null) {
+            return "";
+        }
+        String t = body.strip();
+        try {
+            if (t.startsWith("{")) {
+                return new JSONObject(t).toString(2);
+            }
+            if (t.startsWith("[")) {
+                return new JSONArray(t).toString(2);
+            }
+        } catch (RuntimeException notJson) {
+            // not valid JSON; show it raw
+        }
+        return body;
+    }
+
+    private static String formatHeaders(HttpResponse<?> response) {
+        StringBuilder sb = new StringBuilder();
+        response.headers().map().forEach((k, v) ->
+                sb.append(k).append(": ").append(String.join(", ", v)).append('\n'));
+        return sb.toString();
+    }
+
+    // ---- the console ----
+
+    private void showConsole() {
+        java.util.List<Exchange> snapshot;
+        synchronized (this) {
+            snapshot = new java.util.ArrayList<>(history);
+        }
+        javax.swing.JDialog dialog = new javax.swing.JDialog(
+                (java.awt.Frame) javax.swing.SwingUtilities.getWindowAncestor(this),
+                "PING — REST console", false);
+        javax.swing.DefaultListModel<Exchange> model = new javax.swing.DefaultListModel<>();
+        snapshot.forEach(model::addElement);
+        javax.swing.JList<Exchange> list = new javax.swing.JList<>(model);
+        list.setCellRenderer(new javax.swing.DefaultListCellRenderer() {
+            @Override
+            public java.awt.Component getListCellRendererComponent(javax.swing.JList<?> l,
+                    Object v, int i, boolean s, boolean f) {
+                Exchange x = (Exchange) v;
+                String label = x.method() + " " + x.url() + "  →  "
+                        + (x.status() < 0 ? "no route" : x.status()) + " · " + x.ms() + "ms";
+                return super.getListCellRendererComponent(l, label, i, s, f);
+            }
+        });
+        javax.swing.JTextArea detail = new javax.swing.JTextArea();
+        detail.setEditable(false);
+        detail.setFont(new java.awt.Font(java.awt.Font.MONOSPACED, java.awt.Font.PLAIN, 12));
+        list.addListSelectionListener(e -> {
+            Exchange x = list.getSelectedValue();
+            if (x != null) {
+                detail.setText((x.status() < 0 ? "NO ROUTE" : "HTTP " + x.status())
+                        + "  ·  " + x.ms() + "ms\n\n"
+                        + x.responseHeaders() + "\n" + prettyJson(x.responseBody()));
+                detail.setCaretPosition(0);
+            }
+        });
+        if (!model.isEmpty()) {
+            list.setSelectedIndex(0);
+        }
+
+        javax.swing.JButton replay = new javax.swing.JButton("Replay");
+        replay.addActionListener(e -> {
+            Exchange x = list.getSelectedValue();
+            if (x != null) {
+                onEdt(() -> {
+                    methodKnob.selectOption(x.method());
+                    urlLcd.setText(x.url());
+                });
+                fire();
+            }
+        });
+        javax.swing.JPanel south = new javax.swing.JPanel(
+                new java.awt.FlowLayout(java.awt.FlowLayout.LEFT));
+        south.add(replay);
+        if (model.isEmpty()) {
+            south.add(new javax.swing.JLabel("No exchanges yet — SEND a request."));
+        }
+
+        javax.swing.JSplitPane split = new javax.swing.JSplitPane(
+                javax.swing.JSplitPane.HORIZONTAL_SPLIT,
+                new javax.swing.JScrollPane(list),
+                new javax.swing.JScrollPane(detail));
+        split.setDividerLocation(320);
+        dialog.add(split, BorderLayout.CENTER);
+        dialog.add(south, BorderLayout.SOUTH);
+        dialog.setSize(860, 500);
+        dialog.setLocationRelativeTo(this);
+        dialog.setVisible(true);
     }
 
     @Override

--- a/rack/src/test/java/org/nmox/studio/rack/devices/DeviceWiringTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/DeviceWiringTest.java
@@ -83,7 +83,7 @@ class DeviceWiringTest {
     @Test
     @DisplayName("POST with a JSON body sends it with a JSON Content-Type")
     void postCarriesJsonBody() {
-        HttpRequest r = HttpDevice.buildRequest("POST", "http://localhost:3000/api", "{\"a\":1}");
+        HttpRequest r = HttpDevice.buildRequest("POST", "http://localhost:3000/api", "{\"a\":1}", java.util.Map.of());
         assertThat(r.method()).isEqualTo("POST");
         assertThat(r.bodyPublisher()).isPresent();
         assertThat(r.bodyPublisher().get().contentLength()).isGreaterThan(0);
@@ -93,7 +93,7 @@ class DeviceWiringTest {
     @Test
     @DisplayName("POST with a non-JSON body sends it without forcing a JSON Content-Type")
     void postPlainBodyHasNoJsonHeader() {
-        HttpRequest r = HttpDevice.buildRequest("PUT", "http://localhost:3000/api", "hello=world");
+        HttpRequest r = HttpDevice.buildRequest("PUT", "http://localhost:3000/api", "hello=world", java.util.Map.of());
         assertThat(r.bodyPublisher().get().contentLength()).isGreaterThan(0);
         assertThat(r.headers().firstValue("Content-Type")).isEmpty();
     }
@@ -101,10 +101,10 @@ class DeviceWiringTest {
     @Test
     @DisplayName("GET ignores any body; POST with a blank body sends none")
     void readMethodsAndBlankBodiesAreBodyLess() {
-        HttpRequest get = HttpDevice.buildRequest("GET", "http://localhost:3000", "{\"a\":1}");
+        HttpRequest get = HttpDevice.buildRequest("GET", "http://localhost:3000", "{\"a\":1}", java.util.Map.of());
         assertThat(get.bodyPublisher().get().contentLength()).isZero();
 
-        HttpRequest blank = HttpDevice.buildRequest("POST", "http://localhost:3000", "   ");
+        HttpRequest blank = HttpDevice.buildRequest("POST", "http://localhost:3000", "   ", java.util.Map.of());
         assertThat(blank.bodyPublisher().get().contentLength()).isZero();
     }
 

--- a/rack/src/test/java/org/nmox/studio/rack/devices/HttpConsoleTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/devices/HttpConsoleTest.java
@@ -1,0 +1,46 @@
+package org.nmox.studio.rack.devices;
+
+import java.net.http.HttpRequest;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The REST-console upgrade: header parsing, JSON pretty-printing, and
+ * the precedence rule that a dialed Content-Type wins over the sniff.
+ */
+class HttpConsoleTest {
+
+    @Test
+    @DisplayName("Headers parse from 'Name: value; Name: value', malformed skipped")
+    void headersParse() {
+        Map<String, String> h = HttpDevice.parseHeaders(
+                "Authorization: Bearer abc123; Accept: application/json; junk; X-Empty:");
+        assertThat(h).containsEntry("Authorization", "Bearer abc123")
+                .containsEntry("Accept", "application/json")
+                .hasSize(2);
+        assertThat(HttpDevice.parseHeaders("")).isEmpty();
+        assertThat(HttpDevice.parseHeaders(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A dialed header is applied; an explicit Content-Type beats the JSON sniff")
+    void dialedHeadersWin() {
+        HttpRequest r = HttpDevice.buildRequest("POST", "http://x/api", "{\"a\":1}",
+                Map.of("Authorization", "Bearer t", "Content-Type", "application/vnd.api+json"));
+        assertThat(r.headers().firstValue("Authorization")).hasValue("Bearer t");
+        assertThat(r.headers().firstValue("Content-Type")).hasValue("application/vnd.api+json");
+    }
+
+    @Test
+    @DisplayName("JSON bodies pretty-print; non-JSON passes through unchanged")
+    void prettyPrint() {
+        assertThat(HttpDevice.prettyJson("{\"a\":1,\"b\":2}")).contains("\n").contains("\"a\": 1");
+        assertThat(HttpDevice.prettyJson("[1,2,3]")).contains("\n");
+        assertThat(HttpDevice.prettyJson("plain text")).isEqualTo("plain text");
+        assertThat(HttpDevice.prettyJson("{not json")).isEqualTo("{not json");
+        assertThat(HttpDevice.prettyJson(null)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Tranche D — the second-cut sprint's finale:

- **PING → REST console**: session-only HEADERS (tokens never persist to the patch), VIEW console with 50-exchange history, pretty-printed JSON, one-click Replay. Explicit Content-Type beats the sniff.
- **InfraDesigner dialogs**: all 12 `JOptionPane` sites → `DialogDisplayer`/`NotifyDescriptor`/`DialogDescriptor`. The app's highest-stakes (money-spending) confirmations now use the platform idiom.

## Verification

Full `mvn verify` green. HttpConsoleTest 3/3; the devices.md gate caught the PING usage-text change (regenerated). Zero JOptionPane left in the infra flagship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)