### PR TITLE
API Studio: a Postman-style API management and testing suite in a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.19.0] — 2026-07-02
+
+API Studio — a Postman-style suite in its own tab, beside the rack and
+the infra designer.
+
+### Added
+- **API Studio (Window → API Studio).** A new module and tab for
+  managing and testing HTTP APIs:
+  - **Collections** of saved requests in a tree, with add/delete.
+  - A **request builder**: method, URL, query params and headers
+    (toggleable rows), request body, and auth (bearer or basic).
+  - **Environments** with `{{variable}}` substitution, so one saved
+    request travels from localhost to staging to prod by switching the
+    environment instead of editing URLs.
+  - **Tests**: per-request assertions — status is, time under N ms,
+    body contains, JSON has path (`data.user.id`, `items.0.sku`),
+    header present — evaluated on every send, green/red per line. A
+    probe becomes a check.
+  - A **response viewer**: status, time, size, pretty-printed JSON
+    body, and response headers.
+  - The workspace **persists as `.nmoxapi.json`** beside the project,
+    exactly like the rack patch and the infra design. Secrets belong
+    in environment variables kept out of source control (the file is
+    committable).
+
 ## [1.18.0] — 2026-07-02
 
 The second-cut sprint's final tranche: PING grows into a REST console,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ NMOX-Studio/
 ├── tools/                   # NPM integration, build tools
 ├── rack/                    # Reason-style task rack: drag-drop device wiring, control surfaces
 ├── infra/                   # Node-RED-style DigitalOcean infrastructure designer
+├── apiclient/               # API Studio — Postman-style request/collection/test suite
 ├── project/                 # Project templates, scaffolding, project explorer UI
 ├── ui/                      # Main windows, actions, welcome screen, startup logic
 ├── branding/               # Application theming, splash screen, icons
@@ -110,6 +111,7 @@ NMOX-Studio/
 | **editor** | File editing and language support | `JavaScriptLexer` (regex-aware), `JavaScriptDataObject`, `TypeScriptDataObject`, `WebFileSupport` (HTML), 45+ TextMate grammars incl. HTML/CSS/SCSS/Less + the config layer, JS/HTML/CSS completion providers, LSP providers, `OutlineModel`/`StructureNavigatorPanel` (Navigator outline for 32 mimes), `ConfigFileResolver` (dotfile MIME) |
 | **tools** | Development tools and integrations | `NpmService`, `WebProjectFactory`, `BuildToolService` |
 | **rack** | Reason-style virtual task rack + project lifecycle | `RackTopComponent`, `Rack`/`RackDevice` model, 34 task devices (incl. ROSETTA mixed-repo selector, QUORUM lane-join barrier, IGNITION polyglot runtime, INSPECTOR debug launcher, HARBOR docker, BLACKBOX flight recorder, SONAR port scanner, PREFLIGHT ship check, PHOSPHOR terminal), cross-lane coordination (QUORUM join, `RackDevice.enableGate` readiness gates on long-runners, REFLEX per-lane GLOB routing), patch-cable wiring, `FileWatcher`, `RackIO` persistence, `RackService`, `ProjectStudioTopComponent` (templates, file CRUD, package.json editor, presets) |
+| **apiclient** | API Studio (Postman-style) | `ApiClientTopComponent` tab, collections/requests tree, request builder (params/headers/body/auth/tests), response viewer, `{{var}}` environments, `.nmoxapi.json` per-project persistence; `ApiClient`/`TestRunner`/`WorkspaceIO` engine |
 | **infra** | DigitalOcean infra designer | `InfraDesignerTopComponent`, `NodeKind` catalog (22 DO offerings), `FlowCanvas`, `DeployPlanner`, `DigitalOceanClient`, cost estimation, `.nmoxinfra.json` persistence |
 | **project** | Project management | `ProjectExplorerTopComponent`, `WebProject`, wizards |
 | **ui** | Core UI components | `MainWindow`, `WelcomeScreen`, `StartupInitializer`, actions |

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ are never flagged as typos); a **Structure navigator** (⌘7) that outlines
 any file — classes, functions, tests, selectors, headings, config keys —
 and jumps to a symbol on click; and the NMOX Phosphor dark theme.
 
+### 🧪 API Studio
+A Postman-style tab (Window → API Studio) for building, saving, sending,
+and **testing** HTTP requests: collections of requests, a builder with
+params/headers/body/auth, `{{variable}}` environments so one request
+travels from localhost to prod, and per-request assertions (status,
+response time, body contains, JSON path, header present) that turn a
+probe into a check. The workspace persists as `.nmoxapi.json` beside the
+project.
+
 ### 🏗️ Projects and infrastructure
 The Workbench home base (toolchain chips, open/recent files, tooling
 shelf), Project Studio templates that scaffold versioned, rack-wired

--- a/apiclient/pom.xml
+++ b/apiclient/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.nmox</groupId>
+        <artifactId>NMOX-Studio-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>NMOX-Studio-apiclient</artifactId>
+    <packaging>nbm</packaging>
+    <name>NMOX Studio API</name>
+    <description>Postman-style API management and testing suite</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>NMOX-Studio-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>NMOX-Studio-rack</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-api-annotations-common</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util-lookup</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util-ui</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-awt</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-windows</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-dialogs</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-settings</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20260522</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.netbeans.utilities</groupId>
+                <artifactId>nbm-maven-plugin</artifactId>
+                <configuration>
+                    <publicPackages>
+                        <publicPackage>org.nmox.studio.apiclient.model</publicPackage>
+                        <publicPackage>org.nmox.studio.apiclient.api</publicPackage>
+                    </publicPackages>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+                    <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>coverage-floor</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.30</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/api/ApiClient.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/api/ApiClient.java
@@ -1,0 +1,115 @@
+package org.nmox.studio.apiclient.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.nmox.studio.apiclient.model.ApiModel.AuthType;
+import org.nmox.studio.apiclient.model.ApiModel.Pair;
+import org.nmox.studio.apiclient.model.ApiModel.Request;
+
+/**
+ * Fires a saved {@link Request} over {@code java.net.http}, resolving
+ * variables first, appending enabled query params, applying enabled
+ * headers and auth. Pure enough to build the request in a unit test;
+ * the send itself is a blocking call meant for a worker thread.
+ */
+public final class ApiClient {
+
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    /** Builds the wire request from a saved request + resolved variables. */
+    public static HttpRequest build(Request request, Map<String, String> vars) {
+        String url = appendParams(Variables.resolve(request.url, vars), request.params, vars);
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url.trim()))
+                .timeout(Duration.ofSeconds(30));
+
+        boolean bodyMethod = request.method.equals("POST") || request.method.equals("PUT")
+                || request.method.equals("PATCH");
+        String body = Variables.resolve(request.body, vars);
+        if (bodyMethod && body != null && !body.isBlank()) {
+            b.method(request.method, HttpRequest.BodyPublishers.ofString(body));
+        } else {
+            b.method(request.method, HttpRequest.BodyPublishers.noBody());
+        }
+
+        boolean hasContentType = false;
+        for (Pair h : request.headers) {
+            if (h != null && h.enabled && h.name != null && !h.name.isBlank()) {
+                String name = Variables.resolve(h.name, vars);
+                b.header(name, Variables.resolve(h.value == null ? "" : h.value, vars));
+                hasContentType |= name.equalsIgnoreCase("Content-Type");
+            }
+        }
+        if (bodyMethod && !hasContentType && looksJson(body)) {
+            b.header("Content-Type", "application/json");
+        }
+        applyAuth(b, request, vars);
+        return b.build();
+    }
+
+    private static void applyAuth(HttpRequest.Builder b, Request request, Map<String, String> vars) {
+        if (request.authType == AuthType.BEARER && request.authToken != null && !request.authToken.isBlank()) {
+            b.header("Authorization", "Bearer " + Variables.resolve(request.authToken, vars).trim());
+        } else if (request.authType == AuthType.BASIC && request.authToken != null && request.authToken.contains(":")) {
+            String creds = Variables.resolve(request.authToken, vars);
+            b.header("Authorization", "Basic "
+                    + Base64.getEncoder().encodeToString(creds.getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+
+    static String appendParams(String url, java.util.List<Pair> params, Map<String, String> vars) {
+        StringBuilder query = new StringBuilder();
+        for (Pair p : params) {
+            if (p == null || !p.enabled || p.name == null || p.name.isBlank()) {
+                continue;
+            }
+            query.append(query.length() == 0 ? "" : "&")
+                    .append(enc(Variables.resolve(p.name, vars)))
+                    .append('=')
+                    .append(enc(Variables.resolve(p.value == null ? "" : p.value, vars)));
+        }
+        if (query.length() == 0) {
+            return url;
+        }
+        return url + (url.contains("?") ? "&" : "?") + query;
+    }
+
+    private static String enc(String s) {
+        return java.net.URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    static boolean looksJson(String body) {
+        if (body == null) {
+            return false;
+        }
+        String t = body.strip();
+        return t.startsWith("{") || t.startsWith("[");
+    }
+
+    /** Sends the request and captures timing, size, headers, and body. */
+    public ApiResponse send(Request request, Map<String, String> vars) {
+        long start = System.nanoTime();
+        try {
+            HttpResponse<String> response = client.send(build(request, vars),
+                    HttpResponse.BodyHandlers.ofString());
+            long ms = (System.nanoTime() - start) / 1_000_000;
+            String body = response.body() == null ? "" : response.body();
+            Map<String, java.util.List<String>> headers = new LinkedHashMap<>(response.headers().map());
+            return new ApiResponse(response.statusCode(), ms,
+                    body.getBytes(StandardCharsets.UTF_8).length, headers, body, null);
+        } catch (Exception ex) {
+            long ms = (System.nanoTime() - start) / 1_000_000;
+            return ApiResponse.failure(ms,
+                    ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/api/ApiResponse.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/api/ApiResponse.java
@@ -1,0 +1,37 @@
+package org.nmox.studio.apiclient.api;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The outcome of firing a request: the raw material for the response
+ * viewer and the test runner. {@code status < 0} means the request
+ * never reached a server (DNS, connection refused, timeout).
+ */
+public record ApiResponse(int status, long millis, long bytes,
+        Map<String, List<String>> headers, String body, String error) {
+
+    public boolean reached() {
+        return status >= 0;
+    }
+
+    public boolean ok() {
+        return status >= 200 && status < 400;
+    }
+
+    public boolean hasHeader(String name) {
+        if (headers == null) {
+            return false;
+        }
+        for (String key : headers.keySet()) {
+            if (key.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static ApiResponse failure(long millis, String error) {
+        return new ApiResponse(-1, millis, 0, Map.of(), "", error);
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/api/TestRunner.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/api/TestRunner.java
@@ -1,0 +1,98 @@
+package org.nmox.studio.apiclient.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.nmox.studio.apiclient.model.ApiModel.Assertion;
+import org.nmox.studio.apiclient.model.ApiModel.Request;
+
+/**
+ * Judges a response against a request's assertions - the "Tests" tab
+ * that turns a probe into a check. Every assertion yields one
+ * {@link Result} so the panel can show green and red per line.
+ */
+public final class TestRunner {
+
+    private TestRunner() {
+    }
+
+    public record Result(String description, boolean passed, String detail) {
+    }
+
+    public static List<Result> run(Request request, ApiResponse response) {
+        List<Result> results = new ArrayList<>();
+        for (Assertion a : request.tests) {
+            results.add(evaluate(a, response));
+        }
+        return results;
+    }
+
+    static Result evaluate(Assertion a, ApiResponse r) {
+        return switch (a.kind) {
+            case STATUS_IS -> {
+                boolean ok = String.valueOf(r.status()).equals(a.target.trim());
+                yield new Result("Status is " + a.target, ok, "was " + r.status());
+            }
+            case TIME_UNDER_MS -> {
+                long limit = parseLong(a.target, Long.MAX_VALUE);
+                boolean ok = r.millis() < limit;
+                yield new Result("Time under " + a.target + "ms", ok, r.millis() + "ms");
+            }
+            case BODY_CONTAINS -> {
+                boolean ok = r.body() != null && r.body().contains(a.target);
+                yield new Result("Body contains \"" + a.target + "\"", ok,
+                        ok ? "found" : "not found");
+            }
+            case JSON_HAS_PATH -> {
+                boolean ok = jsonHasPath(r.body(), a.target);
+                yield new Result("JSON has " + a.target, ok, ok ? "present" : "missing");
+            }
+            case HEADER_PRESENT -> {
+                boolean ok = r.hasHeader(a.target.trim());
+                yield new Result("Header " + a.target + " present", ok,
+                        ok ? "present" : "missing");
+            }
+        };
+    }
+
+    /**
+     * Dotted-path presence check: {@code data.user.id}, with
+     * {@code items.0} indexing arrays. Presence only - enough for the
+     * common "did the field come back" assertion without a query DSL.
+     */
+    static boolean jsonHasPath(String body, String path) {
+        if (body == null || path == null || path.isBlank()) {
+            return false;
+        }
+        try {
+            Object current = body.strip().startsWith("[")
+                    ? new JSONArray(body) : new JSONObject(body);
+            for (String segment : path.split("\\.")) {
+                if (current instanceof JSONObject obj && obj.has(segment)) {
+                    current = obj.get(segment);
+                } else if (current instanceof JSONArray arr && isInt(segment)
+                        && Integer.parseInt(segment) < arr.length()) {
+                    current = arr.get(Integer.parseInt(segment));
+                } else {
+                    return false;
+                }
+            }
+            return true;
+        } catch (RuntimeException notJson) {
+            return false;
+        }
+    }
+
+    private static boolean isInt(String s) {
+        return s.chars().allMatch(Character::isDigit) && !s.isEmpty();
+    }
+
+    private static long parseLong(String s, long fallback) {
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException ex) {
+            return fallback;
+        }
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/api/Variables.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/api/Variables.java
@@ -1,0 +1,53 @@
+package org.nmox.studio.apiclient.api;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * {@code {{variable}}} substitution against the active environment -
+ * the mechanism that lets one saved request hit localhost, staging,
+ * and prod by switching environments instead of editing URLs.
+ */
+public final class Variables {
+
+    private static final Pattern TOKEN = Pattern.compile("\\{\\{\\s*([^}\\s]+)\\s*}}");
+
+    private Variables() {
+    }
+
+    /**
+     * Replaces every {@code {{name}}} with its value from the map;
+     * unknown variables are left verbatim so a missing one is visible
+     * in the request rather than silently blanked.
+     */
+    public static String resolve(String text, Map<String, String> vars) {
+        if (text == null || text.indexOf("{{") < 0 || vars == null) {
+            return text == null ? "" : text;
+        }
+        Matcher m = TOKEN.matcher(text);
+        StringBuilder out = new StringBuilder();
+        while (m.find()) {
+            String value = vars.get(m.group(1));
+            m.appendReplacement(out, Matcher.quoteReplacement(
+                    value != null ? value : m.group(0)));
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+
+    /** The variable names referenced in a piece of text, in order seen. */
+    public static java.util.List<String> referenced(String text) {
+        java.util.List<String> names = new java.util.ArrayList<>();
+        if (text == null) {
+            return names;
+        }
+        Matcher m = TOKEN.matcher(text);
+        while (m.find()) {
+            if (!names.contains(m.group(1))) {
+                names.add(m.group(1));
+            }
+        }
+        return names;
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/api/WorkspaceIO.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/api/WorkspaceIO.java
@@ -1,0 +1,202 @@
+package org.nmox.studio.apiclient.api;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.nmox.studio.apiclient.model.ApiModel.Assertion;
+import org.nmox.studio.apiclient.model.ApiModel.AuthType;
+import org.nmox.studio.apiclient.model.ApiModel.Collection;
+import org.nmox.studio.apiclient.model.ApiModel.Environment;
+import org.nmox.studio.apiclient.model.ApiModel.Pair;
+import org.nmox.studio.apiclient.model.ApiModel.Request;
+import org.nmox.studio.apiclient.model.ApiModel.Workspace;
+
+/**
+ * Reads and writes the workspace as {@code .nmoxapi.json} beside the
+ * project - the file is meant to be committed and shared, so it never
+ * carries secrets by policy: environment values that look like tokens
+ * are the developer's to keep in a git-ignored env file, mirroring the
+ * rack's ATMOS rule. (Here we persist what the user typed; the UI warns
+ * that secrets belong in variables kept out of source control.)
+ */
+public final class WorkspaceIO {
+
+    public static final String FILENAME = ".nmoxapi.json";
+
+    private WorkspaceIO() {
+    }
+
+    public static String toJson(Workspace w) {
+        JSONObject root = new JSONObject();
+        root.put("version", 1);
+        root.put("activeEnvironment", w.activeEnvironment);
+
+        JSONArray cols = new JSONArray();
+        for (Collection c : w.collections) {
+            JSONObject cj = new JSONObject();
+            cj.put("name", c.name);
+            JSONArray reqs = new JSONArray();
+            for (Request r : c.requests) {
+                reqs.put(requestJson(r));
+            }
+            cj.put("requests", reqs);
+            cols.put(cj);
+        }
+        root.put("collections", cols);
+
+        JSONArray envs = new JSONArray();
+        for (Environment e : w.environments) {
+            JSONObject ej = new JSONObject();
+            ej.put("name", e.name);
+            ej.put("variables", new JSONObject(e.variables));
+            envs.put(ej);
+        }
+        root.put("environments", envs);
+        return root.toString(2);
+    }
+
+    private static JSONObject requestJson(Request r) {
+        JSONObject rj = new JSONObject();
+        rj.put("name", r.name);
+        rj.put("method", r.method);
+        rj.put("url", r.url);
+        rj.put("body", r.body);
+        rj.put("authType", r.authType.name());
+        rj.put("authToken", r.authToken);
+        rj.put("params", pairsJson(r.params));
+        rj.put("headers", pairsJson(r.headers));
+        JSONArray tests = new JSONArray();
+        for (Assertion a : r.tests) {
+            tests.put(new JSONObject().put("kind", a.kind.name()).put("target", a.target));
+        }
+        rj.put("tests", tests);
+        return rj;
+    }
+
+    private static JSONArray pairsJson(java.util.List<Pair> pairs) {
+        JSONArray arr = new JSONArray();
+        for (Pair p : pairs) {
+            arr.put(new JSONObject().put("name", p.name == null ? "" : p.name)
+                    .put("value", p.value == null ? "" : p.value)
+                    .put("enabled", p.enabled));
+        }
+        return arr;
+    }
+
+    public static Workspace fromJson(String json) {
+        Workspace w = new Workspace();
+        JSONObject root = new JSONObject(json);
+        w.activeEnvironment = root.optString("activeEnvironment", "");
+        JSONArray cols = root.optJSONArray("collections");
+        if (cols != null) {
+            for (int i = 0; i < cols.length(); i++) {
+                w.collections.add(collection(cols.getJSONObject(i)));
+            }
+        }
+        JSONArray envs = root.optJSONArray("environments");
+        if (envs != null) {
+            for (int i = 0; i < envs.length(); i++) {
+                JSONObject ej = envs.getJSONObject(i);
+                Environment e = new Environment();
+                e.name = ej.optString("name", "env");
+                JSONObject vars = ej.optJSONObject("variables");
+                if (vars != null) {
+                    for (String key : vars.keySet()) {
+                        e.variables.put(key, vars.getString(key));
+                    }
+                }
+                w.environments.add(e);
+            }
+        }
+        return w;
+    }
+
+    private static Collection collection(JSONObject cj) {
+        Collection c = new Collection();
+        c.name = cj.optString("name", "collection");
+        JSONArray reqs = cj.optJSONArray("requests");
+        if (reqs != null) {
+            for (int i = 0; i < reqs.length(); i++) {
+                c.requests.add(request(reqs.getJSONObject(i)));
+            }
+        }
+        return c;
+    }
+
+    private static Request request(JSONObject rj) {
+        Request r = new Request();
+        r.name = rj.optString("name", "request");
+        r.method = rj.optString("method", "GET");
+        r.url = rj.optString("url", "");
+        r.body = rj.optString("body", "");
+        try {
+            r.authType = AuthType.valueOf(rj.optString("authType", "NONE"));
+        } catch (IllegalArgumentException ignored) {
+            r.authType = AuthType.NONE;
+        }
+        r.authToken = rj.optString("authToken", "");
+        readPairs(rj.optJSONArray("params"), r.params);
+        readPairs(rj.optJSONArray("headers"), r.headers);
+        JSONArray tests = rj.optJSONArray("tests");
+        if (tests != null) {
+            for (int i = 0; i < tests.length(); i++) {
+                JSONObject tj = tests.getJSONObject(i);
+                try {
+                    r.tests.add(new Assertion(
+                            Assertion.Kind.valueOf(tj.optString("kind", "STATUS_IS")),
+                            tj.optString("target", "")));
+                } catch (IllegalArgumentException ignored) {
+                    // unknown assertion kind from a newer file: skip it
+                }
+            }
+        }
+        return r;
+    }
+
+    private static void readPairs(JSONArray arr, java.util.List<Pair> into) {
+        if (arr == null) {
+            return;
+        }
+        for (int i = 0; i < arr.length(); i++) {
+            JSONObject pj = arr.getJSONObject(i);
+            Pair p = new Pair(pj.optString("name", ""), pj.optString("value", ""));
+            p.enabled = pj.optBoolean("enabled", true);
+            into.add(p);
+        }
+    }
+
+    public static void save(File dir, Workspace w) throws IOException {
+        Files.writeString(new File(dir, FILENAME).toPath(), toJson(w),
+                StandardCharsets.UTF_8);
+    }
+
+    public static Workspace load(File dir) throws IOException {
+        File f = new File(dir, FILENAME);
+        if (!f.isFile()) {
+            return null;
+        }
+        return fromJson(Files.readString(f.toPath(), StandardCharsets.UTF_8));
+    }
+
+    /** Indents a JSON body for the response viewer; non-JSON passes through. */
+    public static String pretty(String body) {
+        if (body == null) {
+            return "";
+        }
+        String t = body.strip();
+        try {
+            if (t.startsWith("{")) {
+                return new JSONObject(t).toString(2);
+            }
+            if (t.startsWith("[")) {
+                return new JSONArray(t).toString(2);
+            }
+        } catch (RuntimeException notJson) {
+            // leave it raw
+        }
+        return body;
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/model/ApiModel.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/model/ApiModel.java
@@ -1,0 +1,122 @@
+package org.nmox.studio.apiclient.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The API Studio data model: a workspace holds collections of saved
+ * requests and named environments of variables. Everything here is a
+ * plain mutable bean - the UI edits it directly and {@code WorkspaceIO}
+ * serializes it to {@code .nmoxapi.json} beside the project.
+ */
+public final class ApiModel {
+
+    private ApiModel() {
+    }
+
+    /** One header or query parameter: a name, a value, and an on/off. */
+    public static final class Pair {
+
+        public String name;
+        public String value;
+        public boolean enabled = true;
+
+        public Pair() {
+        }
+
+        public Pair(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+    }
+
+    /** How a request authenticates. NONE, or a bearer token, or basic. */
+    public enum AuthType {
+        NONE, BEARER, BASIC
+    }
+
+    /** A single assertion run against the response after a request. */
+    public static final class Assertion {
+
+        public enum Kind {
+            STATUS_IS, TIME_UNDER_MS, BODY_CONTAINS, JSON_HAS_PATH, HEADER_PRESENT
+        }
+
+        public Kind kind = Kind.STATUS_IS;
+        public String target = "200";
+
+        public Assertion() {
+        }
+
+        public Assertion(Kind kind, String target) {
+            this.kind = kind;
+            this.target = target;
+        }
+    }
+
+    /** A saved request: everything needed to fire it and judge the result. */
+    public static final class Request {
+
+        public String name = "New request";
+        public String method = "GET";
+        public String url = "";
+        public final List<Pair> params = new ArrayList<>();
+        public final List<Pair> headers = new ArrayList<>();
+        public String body = "";
+        public AuthType authType = AuthType.NONE;
+        public String authToken = "";  // bearer token, or "user:password" for basic
+        public final List<Assertion> tests = new ArrayList<>();
+    }
+
+    /** A named group of requests - Postman's "collection". */
+    public static final class Collection {
+
+        public String name = "New collection";
+        public final List<Request> requests = new ArrayList<>();
+    }
+
+    /** A named set of variables; {@code {{var}}} resolves against the active one. */
+    public static final class Environment {
+
+        public String name = "New environment";
+        public final Map<String, String> variables = new LinkedHashMap<>();
+    }
+
+    /** The persisted root: collections, environments, and the active one. */
+    public static final class Workspace {
+
+        public final List<Collection> collections = new ArrayList<>();
+        public final List<Environment> environments = new ArrayList<>();
+        public String activeEnvironment = "";
+
+        public Environment active() {
+            for (Environment e : environments) {
+                if (e.name.equals(activeEnvironment)) {
+                    return e;
+                }
+            }
+            return null;
+        }
+
+        /** A first-run workspace: one collection, one empty environment. */
+        public static Workspace starter() {
+            Workspace w = new Workspace();
+            Collection c = new Collection();
+            c.name = "My API";
+            Request r = new Request();
+            r.name = "Health check";
+            r.url = "{{base_url}}/health";
+            r.tests.add(new Assertion(Assertion.Kind.STATUS_IS, "200"));
+            c.requests.add(r);
+            w.collections.add(c);
+            Environment local = new Environment();
+            local.name = "Local";
+            local.variables.put("base_url", "http://localhost:3000");
+            w.environments.add(local);
+            w.activeEnvironment = "Local";
+            return w;
+        }
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/ui/ApiClientTopComponent.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/ui/ApiClientTopComponent.java
@@ -1,0 +1,550 @@
+package org.nmox.studio.apiclient.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.JToolBar;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
+import javax.swing.tree.TreeSelectionModel;
+import org.nmox.studio.apiclient.api.ApiClient;
+import org.nmox.studio.apiclient.api.ApiResponse;
+import org.nmox.studio.apiclient.api.TestRunner;
+import org.nmox.studio.apiclient.api.WorkspaceIO;
+import org.nmox.studio.apiclient.model.ApiModel.AuthType;
+import org.nmox.studio.apiclient.model.ApiModel.Collection;
+import org.nmox.studio.apiclient.model.ApiModel.Environment;
+import org.nmox.studio.apiclient.model.ApiModel.Request;
+import org.nmox.studio.apiclient.model.ApiModel.Workspace;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.util.NbBundle.Messages;
+import org.openide.windows.TopComponent;
+
+/**
+ * API Studio: a Postman-style tab for building, saving, sending, and
+ * testing HTTP requests. Collections on the left, a request builder in
+ * the center (method, URL, params/headers/body/auth/tests), the
+ * response below, and an environment selector whose {@code {{vars}}}
+ * let one request travel from localhost to prod. The workspace persists
+ * as {@code .nmoxapi.json} beside the aimed project, exactly like the
+ * rack patch and the infra design.
+ */
+@TopComponent.Description(preferredID = "ApiClientTopComponent",
+        persistenceType = TopComponent.PERSISTENCE_ALWAYS)
+@TopComponent.Registration(mode = "editor", openAtStartup = false, position = 350)
+@ActionID(category = "Window", id = "org.nmox.studio.apiclient.ui.ApiClientTopComponent")
+@ActionReference(path = "Menu/Window", position = 265)
+@TopComponent.OpenActionRegistration(displayName = "#CTL_ApiClientAction",
+        preferredID = "ApiClientTopComponent")
+@Messages({
+    "CTL_ApiClientAction=API Studio",
+    "CTL_ApiClientTopComponent=API Studio",
+    "HINT_ApiClientTopComponent=Postman-style API management and testing"
+})
+public final class ApiClientTopComponent extends TopComponent {
+
+    private static final Color OK_GREEN = new Color(0x4E, 0xC9, 0x8B);
+    private static final Color FAIL_RED = new Color(0xE2, 0x4B, 0x4A);
+    private static final Font MONO = new Font(Font.MONOSPACED, Font.PLAIN, 12);
+
+    private Workspace workspace;
+    private Request current;
+    private final ApiClient client = new ApiClient();
+    private final Timer saveDebounce;
+    private boolean loading;
+
+    private final JTree tree = new JTree();
+    private final JComboBox<String> envCombo = new JComboBox<>();
+    private final JComboBox<String> methodCombo =
+            new JComboBox<>(new String[]{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"});
+    private final JTextField urlField = new JTextField();
+    private final JTextField nameField = new JTextField();
+    private final JButton sendButton = new JButton("Send");
+
+    private final JTable paramsTable = new JTable();
+    private final JTable headersTable = new JTable();
+    private final JTextArea bodyArea = new JTextArea();
+    private final JComboBox<AuthType> authCombo = new JComboBox<>(AuthType.values());
+    private final JTextField authField = new JTextField();
+    private final JTable testsTable = new JTable();
+
+    private final JLabel statusLabel = new JLabel(" ");
+    private final JTextArea responseBody = new JTextArea();
+    private final JTextArea responseHeaders = new JTextArea();
+    private final JPanel testResults = new JPanel();
+
+    public ApiClientTopComponent() {
+        setName(Bundle.CTL_ApiClientTopComponent());
+        setToolTipText(Bundle.HINT_ApiClientTopComponent());
+        setLayout(new BorderLayout());
+
+        saveDebounce = new Timer(800, e -> save());
+        saveDebounce.setRepeats(false);
+
+        add(buildToolbar(), BorderLayout.NORTH);
+        JSplitPane center = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+                buildTree(), buildEditorAndResponse());
+        center.setDividerLocation(240);
+        add(center, BorderLayout.CENTER);
+
+        loadWorkspace();
+    }
+
+    // ---- toolbar: environment + send ----
+
+    private JToolBar buildToolbar() {
+        JToolBar bar = new JToolBar();
+        bar.setFloatable(false);
+        bar.add(new JLabel(" Environment: "));
+        envCombo.addActionListener(e -> {
+            if (!loading && envCombo.getSelectedItem() != null) {
+                workspace.activeEnvironment = (String) envCombo.getSelectedItem();
+                touch();
+            }
+        });
+        bar.add(envCombo);
+        JButton editEnv = new JButton("Variables…");
+        editEnv.addActionListener(e -> editEnvironment());
+        bar.add(editEnv);
+        bar.addSeparator();
+        methodCombo.setMaximumSize(methodCombo.getPreferredSize());
+        methodCombo.addActionListener(e -> {
+            if (!loading && current != null) {
+                current.method = (String) methodCombo.getSelectedItem();
+                touch();
+            }
+        });
+        bar.add(methodCombo);
+        urlField.getDocument().addDocumentListener(new SimpleDoc(() -> {
+            if (!loading && current != null) {
+                current.url = urlField.getText();
+                touch();
+            }
+        }));
+        bar.add(urlField);
+        sendButton.setForeground(new Color(0x1D, 0x9E, 0x75));
+        sendButton.addActionListener(e -> send());
+        bar.add(sendButton);
+        return bar;
+    }
+
+    // ---- left: collections tree ----
+
+    private JPanel buildTree() {
+        JPanel panel = new JPanel(new BorderLayout());
+        tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
+        tree.setRootVisible(false);
+        tree.addTreeSelectionListener(e -> onTreeSelect());
+        panel.add(new JScrollPane(tree), BorderLayout.CENTER);
+
+        JToolBar tools = new JToolBar();
+        tools.setFloatable(false);
+        JButton addCol = new JButton("+ Collection");
+        addCol.addActionListener(e -> addCollection());
+        JButton addReq = new JButton("+ Request");
+        addReq.addActionListener(e -> addRequest());
+        JButton del = new JButton("Delete");
+        del.addActionListener(e -> deleteSelected());
+        tools.add(addCol);
+        tools.add(addReq);
+        tools.add(del);
+        panel.add(tools, BorderLayout.SOUTH);
+        return panel;
+    }
+
+    // ---- center: request editor over response viewer ----
+
+    private JSplitPane buildEditorAndResponse() {
+        JPanel editor = new JPanel(new BorderLayout());
+        JPanel top = new JPanel();
+        top.setLayout(new BoxLayout(top, BoxLayout.X_AXIS));
+        top.setBorder(BorderFactory.createEmptyBorder(4, 6, 4, 6));
+        top.add(new JLabel("Name: "));
+        nameField.getDocument().addDocumentListener(new SimpleDoc(() -> {
+            if (!loading && current != null) {
+                current.name = nameField.getText();
+                ((DefaultTreeModel) tree.getModel()).reload();
+                restoreSelection();
+                touch();
+            }
+        }));
+        top.add(nameField);
+        editor.add(top, BorderLayout.NORTH);
+
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.addTab("Params", new JScrollPane(paramsTable));
+        tabs.addTab("Headers", new JScrollPane(headersTable));
+        bodyArea.setFont(MONO);
+        bodyArea.getDocument().addDocumentListener(new SimpleDoc(() -> {
+            if (!loading && current != null) {
+                current.body = bodyArea.getText();
+                touch();
+            }
+        }));
+        tabs.addTab("Body", new JScrollPane(bodyArea));
+        tabs.addTab("Auth", buildAuthPanel());
+        tabs.addTab("Tests", new JScrollPane(testsTable));
+        editor.add(tabs, BorderLayout.CENTER);
+
+        JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT, editor, buildResponsePanel());
+        split.setDividerLocation(300);
+        return split;
+    }
+
+    private JPanel buildAuthPanel() {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        JPanel row = new JPanel();
+        row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
+        row.add(new JLabel("Type: "));
+        authCombo.addActionListener(e -> {
+            if (!loading && current != null) {
+                current.authType = (AuthType) authCombo.getSelectedItem();
+                touch();
+            }
+        });
+        row.add(authCombo);
+        panel.add(row);
+        panel.add(new JLabel(" "));
+        panel.add(new JLabel("Token (Bearer), or user:password (Basic) — {{vars}} allowed:"));
+        authField.getDocument().addDocumentListener(new SimpleDoc(() -> {
+            if (!loading && current != null) {
+                current.authToken = authField.getText();
+                touch();
+            }
+        }));
+        panel.add(authField);
+        panel.add(new JLabel("<html><small>Secrets belong in environment variables kept out of "
+                + "source control — .nmoxapi.json is committable.</small></html>"));
+        return panel;
+    }
+
+    private JPanel buildResponsePanel() {
+        JPanel panel = new JPanel(new BorderLayout());
+        statusLabel.setFont(statusLabel.getFont().deriveFont(Font.BOLD));
+        statusLabel.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
+        panel.add(statusLabel, BorderLayout.NORTH);
+        JTabbedPane tabs = new JTabbedPane();
+        responseBody.setEditable(false);
+        responseBody.setFont(MONO);
+        tabs.addTab("Body", new JScrollPane(responseBody));
+        responseHeaders.setEditable(false);
+        responseHeaders.setFont(MONO);
+        tabs.addTab("Headers", new JScrollPane(responseHeaders));
+        testResults.setLayout(new BoxLayout(testResults, BoxLayout.Y_AXIS));
+        tabs.addTab("Tests", new JScrollPane(testResults));
+        panel.add(tabs, BorderLayout.CENTER);
+        return panel;
+    }
+
+    // ---- sending ----
+
+    private void send() {
+        if (current == null) {
+            return;
+        }
+        sendButton.setEnabled(false);
+        statusLabel.setForeground(Color.GRAY);
+        statusLabel.setText("Sending…");
+        Environment env = workspace.active();
+        Map<String, String> vars = env != null ? env.variables : Map.of();
+        Request request = current;
+        Thread worker = new Thread(() -> {
+            ApiResponse response = client.send(request, vars);
+            List<TestRunner.Result> results = TestRunner.run(request, response);
+            SwingUtilities.invokeLater(() -> showResponse(response, results));
+        }, "nmox-api-send");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private void showResponse(ApiResponse r, List<TestRunner.Result> results) {
+        sendButton.setEnabled(true);
+        if (!r.reached()) {
+            statusLabel.setForeground(FAIL_RED);
+            statusLabel.setText("No route — " + r.error() + "  ·  " + r.millis() + "ms");
+            responseBody.setText(r.error());
+        } else {
+            statusLabel.setForeground(r.ok() ? OK_GREEN : FAIL_RED);
+            statusLabel.setText(r.status() + "  ·  " + r.millis() + "ms  ·  " + humanBytes(r.bytes()));
+            responseBody.setText(WorkspaceIO.pretty(r.body()));
+            responseBody.setCaretPosition(0);
+        }
+        StringBuilder h = new StringBuilder();
+        r.headers().forEach((k, v) -> h.append(k).append(": ").append(String.join(", ", v)).append('\n'));
+        responseHeaders.setText(h.toString());
+        responseHeaders.setCaretPosition(0);
+
+        testResults.removeAll();
+        if (results.isEmpty()) {
+            testResults.add(new JLabel("  No tests on this request."));
+        }
+        for (TestRunner.Result res : results) {
+            JLabel line = new JLabel((res.passed() ? "  ✓  " : "  ✗  ")
+                    + res.description() + "   (" + res.detail() + ")");
+            line.setForeground(res.passed() ? OK_GREEN : FAIL_RED);
+            testResults.add(line);
+        }
+        testResults.revalidate();
+        testResults.repaint();
+    }
+
+    // ---- tree model + selection ----
+
+    private void rebuildTree() {
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode("Workspace");
+        for (Collection c : workspace.collections) {
+            DefaultMutableTreeNode cn = new DefaultMutableTreeNode(c);
+            for (Request r : c.requests) {
+                cn.add(new DefaultMutableTreeNode(r));
+            }
+            root.add(cn);
+        }
+        tree.setModel(new DefaultTreeModel(root));
+        for (int i = 0; i < tree.getRowCount(); i++) {
+            tree.expandRow(i);
+        }
+        tree.setCellRenderer(new RequestTreeRenderer());
+    }
+
+    private void onTreeSelect() {
+        DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
+        if (node != null && node.getUserObject() instanceof Request r) {
+            bindRequest(r);
+        }
+    }
+
+    private void bindRequest(Request r) {
+        loading = true;
+        current = r;
+        nameField.setText(r.name);
+        methodCombo.setSelectedItem(r.method);
+        urlField.setText(r.url);
+        bodyArea.setText(r.body);
+        authCombo.setSelectedItem(r.authType);
+        authField.setText(r.authToken);
+        paramsTable.setModel(new PairTableModel(r.params, this::touch));
+        headersTable.setModel(new PairTableModel(r.headers, this::touch));
+        testsTable.setModel(new TestsTableModel(r.tests, this::touch));
+        TestsTableModel.install(testsTable);
+        loading = false;
+    }
+
+    private void restoreSelection() {
+        if (current == null) {
+            return;
+        }
+        DefaultMutableTreeNode root = (DefaultMutableTreeNode) tree.getModel().getRoot();
+        java.util.Enumeration<javax.swing.tree.TreeNode> en = root.depthFirstEnumeration();
+        while (en.hasMoreElements()) {
+            DefaultMutableTreeNode n = (DefaultMutableTreeNode) en.nextElement();
+            if (n.getUserObject() == current) {
+                tree.setSelectionPath(new TreePath(n.getPath()));
+                return;
+            }
+        }
+    }
+
+    // ---- CRUD ----
+
+    private Collection selectedCollection() {
+        DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
+        if (node == null) {
+            return workspace.collections.isEmpty() ? null : workspace.collections.get(0);
+        }
+        if (node.getUserObject() instanceof Collection c) {
+            return c;
+        }
+        if (node.getUserObject() instanceof Request r) {
+            for (Collection c : workspace.collections) {
+                if (c.requests.contains(r)) {
+                    return c;
+                }
+            }
+        }
+        return workspace.collections.isEmpty() ? null : workspace.collections.get(0);
+    }
+
+    private void addCollection() {
+        Collection c = new Collection();
+        c.name = "New collection";
+        workspace.collections.add(c);
+        rebuildTree();
+        touch();
+    }
+
+    private void addRequest() {
+        Collection c = selectedCollection();
+        if (c == null) {
+            addCollection();
+            c = workspace.collections.get(workspace.collections.size() - 1);
+        }
+        Request r = new Request();
+        c.requests.add(r);
+        rebuildTree();
+        current = r;
+        restoreSelection();
+        touch();
+    }
+
+    private void deleteSelected() {
+        DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
+        if (node == null) {
+            return;
+        }
+        Object obj = node.getUserObject();
+        if (obj instanceof Request r) {
+            workspace.collections.forEach(c -> c.requests.remove(r));
+        } else if (obj instanceof Collection c) {
+            workspace.collections.remove(c);
+        } else {
+            return;
+        }
+        rebuildTree();
+        touch();
+    }
+
+    private void editEnvironment() {
+        Environment env = workspace.active();
+        if (env == null) {
+            NotifyDescriptor.InputLine name = new NotifyDescriptor.InputLine(
+                    "Environment name:", "New environment");
+            if (DialogDisplayer.getDefault().notify(name) != NotifyDescriptor.OK_OPTION) {
+                return;
+            }
+            env = new Environment();
+            env.name = name.getInputText().isBlank() ? "env" : name.getInputText().trim();
+            workspace.environments.add(env);
+            workspace.activeEnvironment = env.name;
+        }
+        JTextArea area = new JTextArea(12, 40);
+        area.setFont(MONO);
+        StringBuilder sb = new StringBuilder();
+        env.variables.forEach((k, v) -> sb.append(k).append('=').append(v).append('\n'));
+        area.setText(sb.toString());
+        NotifyDescriptor d = new NotifyDescriptor(new JScrollPane(area),
+                "Variables for \"" + env.name + "\"  (KEY=value per line)",
+                NotifyDescriptor.OK_CANCEL_OPTION, NotifyDescriptor.PLAIN_MESSAGE, null, null);
+        if (DialogDisplayer.getDefault().notify(d) == NotifyDescriptor.OK_OPTION) {
+            env.variables.clear();
+            for (String line : area.getText().split("\n")) {
+                int eq = line.indexOf('=');
+                if (eq > 0) {
+                    env.variables.put(line.substring(0, eq).trim(), line.substring(eq + 1).trim());
+                }
+            }
+            touch();
+        }
+    }
+
+    // ---- persistence ----
+
+    private File projectDir() {
+        try {
+            File dir = org.nmox.studio.rack.service.RackService.getDefault()
+                    .getRack().getProjectDir();
+            if (dir != null && dir.isDirectory()) {
+                return dir;
+            }
+        } catch (RuntimeException | LinkageError ignored) {
+            // rack unavailable (tests, stripped platform)
+        }
+        return new File(System.getProperty("user.home"));
+    }
+
+    private void loadWorkspace() {
+        loading = true;
+        try {
+            Workspace loaded = WorkspaceIO.load(projectDir());
+            workspace = loaded != null ? loaded : Workspace.starter();
+        } catch (Exception ex) {
+            workspace = Workspace.starter();
+        }
+        DefaultComboBoxModel<String> envs = new DefaultComboBoxModel<>();
+        workspace.environments.forEach(e -> envs.addElement(e.name));
+        envCombo.setModel(envs);
+        if (!workspace.activeEnvironment.isEmpty()) {
+            envCombo.setSelectedItem(workspace.activeEnvironment);
+        }
+        rebuildTree();
+        loading = false;
+        // select the first request so the editor isn't blank
+        if (!workspace.collections.isEmpty() && !workspace.collections.get(0).requests.isEmpty()) {
+            current = workspace.collections.get(0).requests.get(0);
+            restoreSelection();
+        }
+    }
+
+    private void touch() {
+        if (!loading) {
+            saveDebounce.restart();
+        }
+    }
+
+    private void save() {
+        try {
+            WorkspaceIO.save(projectDir(), workspace);
+        } catch (Exception ex) {
+            // best effort; a failed autosave should never interrupt editing
+        }
+    }
+
+    @Override
+    public void componentClosed() {
+        saveDebounce.stop();
+        save();
+    }
+
+    private static String humanBytes(long b) {
+        return b >= 1_000_000 ? String.format("%.1f MB", b / 1_000_000.0)
+                : b >= 1_000 ? (b / 1_000) + " KB" : b + " B";
+    }
+
+    /** A one-liner document listener that runs a callback on any edit. */
+    private static final class SimpleDoc implements javax.swing.event.DocumentListener {
+        private final Runnable onChange;
+
+        SimpleDoc(Runnable onChange) {
+            this.onChange = onChange;
+        }
+
+        @Override
+        public void insertUpdate(javax.swing.event.DocumentEvent e) {
+            onChange.run();
+        }
+
+        @Override
+        public void removeUpdate(javax.swing.event.DocumentEvent e) {
+            onChange.run();
+        }
+
+        @Override
+        public void changedUpdate(javax.swing.event.DocumentEvent e) {
+            onChange.run();
+        }
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/ui/PairTableModel.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/ui/PairTableModel.java
@@ -1,0 +1,89 @@
+package org.nmox.studio.apiclient.ui;
+
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.nmox.studio.apiclient.model.ApiModel.Pair;
+
+/**
+ * The editable grid behind the Params and Headers tabs: an on/off
+ * checkbox, a name, and a value, with a blank trailing row that
+ * materializes a new Pair the moment you type in it.
+ */
+final class PairTableModel extends AbstractTableModel {
+
+    private final List<Pair> pairs;
+    private final Runnable onChange;
+
+    PairTableModel(List<Pair> pairs, Runnable onChange) {
+        this.pairs = pairs;
+        this.onChange = onChange;
+    }
+
+    @Override
+    public int getRowCount() {
+        return pairs.size() + 1; // trailing blank row for adding
+    }
+
+    @Override
+    public int getColumnCount() {
+        return 3;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return switch (col) {
+            case 0 -> "On";
+            case 1 -> "Name";
+            default -> "Value";
+        };
+    }
+
+    @Override
+    public Class<?> getColumnClass(int col) {
+        return col == 0 ? Boolean.class : String.class;
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        return true;
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        if (row >= pairs.size()) {
+            return col == 0 ? Boolean.TRUE : "";
+        }
+        Pair p = pairs.get(row);
+        return switch (col) {
+            case 0 -> p.enabled;
+            case 1 -> p.name == null ? "" : p.name;
+            default -> p.value == null ? "" : p.value;
+        };
+    }
+
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        Pair p;
+        if (row >= pairs.size()) {
+            if (col == 0 || value == null || value.toString().isEmpty()) {
+                return; // don't create a row from an empty edit
+            }
+            p = new Pair("", "");
+            pairs.add(p);
+        } else {
+            p = pairs.get(row);
+        }
+        switch (col) {
+            case 0 -> p.enabled = Boolean.TRUE.equals(value);
+            case 1 -> p.name = value.toString();
+            default -> p.value = value.toString();
+        }
+        // drop a row emptied of both name and value
+        if ((p.name == null || p.name.isEmpty()) && (p.value == null || p.value.isEmpty())
+                && row < pairs.size()) {
+            pairs.remove(row);
+        }
+        fireTableDataChanged();
+        onChange.run();
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/ui/RequestTreeRenderer.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/ui/RequestTreeRenderer.java
@@ -1,0 +1,28 @@
+package org.nmox.studio.apiclient.ui;
+
+import java.awt.Component;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import org.nmox.studio.apiclient.model.ApiModel.Collection;
+import org.nmox.studio.apiclient.model.ApiModel.Request;
+
+/**
+ * Renders the collections tree: a collection by name, a request as
+ * "METHOD name" so the verb is visible at a glance.
+ */
+final class RequestTreeRenderer extends DefaultTreeCellRenderer {
+
+    @Override
+    public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel,
+            boolean expanded, boolean leaf, int row, boolean focus) {
+        super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, focus);
+        Object obj = value instanceof DefaultMutableTreeNode n ? n.getUserObject() : null;
+        if (obj instanceof Collection c) {
+            setText(c.name);
+        } else if (obj instanceof Request r) {
+            setText(r.method + "  " + r.name);
+        }
+        return this;
+    }
+}

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/ui/TestsTableModel.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/ui/TestsTableModel.java
@@ -1,0 +1,80 @@
+package org.nmox.studio.apiclient.ui;
+
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.nmox.studio.apiclient.model.ApiModel.Assertion;
+
+/**
+ * The editable grid behind the Tests tab: an assertion kind and its
+ * target value per row, with a blank trailing row that adds a new
+ * assertion when filled.
+ */
+final class TestsTableModel extends AbstractTableModel {
+
+    private final List<Assertion> tests;
+    private final Runnable onChange;
+
+    TestsTableModel(List<Assertion> tests, Runnable onChange) {
+        this.tests = tests;
+        this.onChange = onChange;
+    }
+
+    @Override
+    public int getRowCount() {
+        return tests.size() + 1;
+    }
+
+    @Override
+    public int getColumnCount() {
+        return 2;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return col == 0 ? "Assertion" : "Target";
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        return true;
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        if (row >= tests.size()) {
+            return col == 0 ? Assertion.Kind.STATUS_IS : "";
+        }
+        Assertion a = tests.get(row);
+        return col == 0 ? a.kind : a.target;
+    }
+
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        Assertion a;
+        if (row >= tests.size()) {
+            if (value == null || value.toString().isEmpty()) {
+                return;
+            }
+            a = new Assertion();
+            tests.add(a);
+        } else {
+            a = tests.get(row);
+        }
+        if (col == 0) {
+            a.kind = value instanceof Assertion.Kind k ? k : Assertion.Kind.valueOf(value.toString());
+        } else {
+            a.target = value.toString();
+        }
+        fireTableDataChanged();
+        onChange.run();
+    }
+
+    /** The combo editor for the Assertion column. */
+    static javax.swing.table.TableColumn install(javax.swing.JTable table) {
+        javax.swing.JComboBox<Assertion.Kind> combo =
+                new javax.swing.JComboBox<>(Assertion.Kind.values());
+        javax.swing.table.TableColumn col = table.getColumnModel().getColumn(0);
+        col.setCellEditor(new javax.swing.DefaultCellEditor(combo));
+        return col;
+    }
+}

--- a/apiclient/src/test/java/org/nmox/studio/apiclient/api/ApiStudioTest.java
+++ b/apiclient/src/test/java/org/nmox/studio/apiclient/api/ApiStudioTest.java
@@ -1,0 +1,152 @@
+package org.nmox.studio.apiclient.api;
+
+import java.net.http.HttpRequest;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nmox.studio.apiclient.model.ApiModel.Assertion;
+import org.nmox.studio.apiclient.model.ApiModel.AuthType;
+import org.nmox.studio.apiclient.model.ApiModel.Pair;
+import org.nmox.studio.apiclient.model.ApiModel.Request;
+import org.nmox.studio.apiclient.model.ApiModel.Workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The API Studio engine: variable substitution, request building,
+ * assertions, and workspace persistence - the parts that must be
+ * correct for the tab to be trustworthy.
+ */
+class ApiStudioTest {
+
+    // ---- variables ----
+
+    @Test
+    @DisplayName("Variables resolve from the environment; unknowns stay visible")
+    void variablesResolve() {
+        Map<String, String> env = Map.of("base_url", "https://api.example.com", "id", "42");
+        assertThat(Variables.resolve("{{base_url}}/users/{{id}}", env))
+                .isEqualTo("https://api.example.com/users/42");
+        assertThat(Variables.resolve("{{missing}}/x", env)).isEqualTo("{{missing}}/x");
+        assertThat(Variables.referenced("{{a}}/{{b}}/{{a}}")).containsExactly("a", "b");
+    }
+
+    // ---- request building ----
+
+    @Test
+    @DisplayName("Build resolves url, appends enabled params, applies headers and bearer auth")
+    void buildAssemblesTheRequest() {
+        Request r = new Request();
+        r.method = "GET";
+        r.url = "{{base_url}}/search";
+        r.params.add(new Pair("q", "hello world"));
+        Pair off = new Pair("debug", "1");
+        off.enabled = false;
+        r.params.add(off);
+        r.headers.add(new Pair("Accept", "application/json"));
+        r.authType = AuthType.BEARER;
+        r.authToken = "{{token}}";
+
+        HttpRequest built = ApiClient.build(r,
+                Map.of("base_url", "https://x.dev", "token", "abc123"));
+
+        assertThat(built.uri().toString())
+                .startsWith("https://x.dev/search?q=hello")
+                .doesNotContain("debug");
+        assertThat(built.headers().firstValue("Accept")).hasValue("application/json");
+        assertThat(built.headers().firstValue("Authorization")).hasValue("Bearer abc123");
+    }
+
+    @Test
+    @DisplayName("POST with a JSON body gets a JSON Content-Type unless one is set")
+    void jsonBodyContentType() {
+        Request r = new Request();
+        r.method = "POST";
+        r.url = "https://x.dev/items";
+        r.body = "{\"name\":\"n\"}";
+        HttpRequest built = ApiClient.build(r, Map.of());
+        assertThat(built.headers().firstValue("Content-Type")).hasValue("application/json");
+        assertThat(built.bodyPublisher().get().contentLength()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("Basic auth encodes user:password")
+    void basicAuth() {
+        Request r = new Request();
+        r.url = "https://x.dev";
+        r.authType = AuthType.BASIC;
+        r.authToken = "user:pass";
+        HttpRequest built = ApiClient.build(r, Map.of());
+        // base64("user:pass") = dXNlcjpwYXNz
+        assertThat(built.headers().firstValue("Authorization")).hasValue("Basic dXNlcjpwYXNz");
+    }
+
+    // ---- assertions ----
+
+    @Test
+    @DisplayName("Assertions judge status, time, body, JSON path, and headers")
+    void assertionsEvaluate() {
+        ApiResponse resp = new ApiResponse(200, 40, 12,
+                Map.of("Content-Type", java.util.List.of("application/json")),
+                "{\"data\":{\"user\":{\"id\":7}},\"items\":[{\"sku\":\"a\"}]}", null);
+
+        assertThat(pass(Assertion.Kind.STATUS_IS, "200", resp)).isTrue();
+        assertThat(pass(Assertion.Kind.STATUS_IS, "404", resp)).isFalse();
+        assertThat(pass(Assertion.Kind.TIME_UNDER_MS, "100", resp)).isTrue();
+        assertThat(pass(Assertion.Kind.TIME_UNDER_MS, "10", resp)).isFalse();
+        assertThat(pass(Assertion.Kind.BODY_CONTAINS, "user", resp)).isTrue();
+        assertThat(pass(Assertion.Kind.JSON_HAS_PATH, "data.user.id", resp)).isTrue();
+        assertThat(pass(Assertion.Kind.JSON_HAS_PATH, "items.0.sku", resp)).isTrue();
+        assertThat(pass(Assertion.Kind.JSON_HAS_PATH, "data.user.email", resp)).isFalse();
+        assertThat(pass(Assertion.Kind.HEADER_PRESENT, "content-type", resp)).isTrue();
+        assertThat(pass(Assertion.Kind.HEADER_PRESENT, "x-nope", resp)).isFalse();
+    }
+
+    @Test
+    @DisplayName("A failed request reaches nothing; assertions on it fail cleanly")
+    void failedRequestJudged() {
+        ApiResponse resp = ApiResponse.failure(9000, "Connection refused");
+        assertThat(resp.reached()).isFalse();
+        assertThat(pass(Assertion.Kind.STATUS_IS, "200", resp)).isFalse();
+    }
+
+    private static boolean pass(Assertion.Kind kind, String target, ApiResponse resp) {
+        return TestRunner.evaluate(new Assertion(kind, target), resp).passed();
+    }
+
+    // ---- persistence ----
+
+    @Test
+    @DisplayName("A workspace round-trips through JSON with all its parts")
+    void workspaceRoundTrips(@TempDir Path dir) throws Exception {
+        Workspace w = Workspace.starter();
+        w.collections.get(0).requests.get(0).headers.add(new Pair("X-Api-Key", "k"));
+        w.collections.get(0).requests.get(0).method = "POST";
+
+        WorkspaceIO.save(dir.toFile(), w);
+        Workspace back = WorkspaceIO.load(dir.toFile());
+
+        assertThat(back).isNotNull();
+        assertThat(back.activeEnvironment).isEqualTo("Local");
+        assertThat(back.active().variables).containsEntry("base_url", "http://localhost:3000");
+        var req = back.collections.get(0).requests.get(0);
+        assertThat(req.method).isEqualTo("POST");
+        assertThat(req.headers).anyMatch(p -> "X-Api-Key".equals(p.name) && "k".equals(p.value));
+        assertThat(req.tests).anyMatch(a -> a.kind == Assertion.Kind.STATUS_IS);
+    }
+
+    @Test
+    @DisplayName("Loading from an empty directory returns null, not an error")
+    void loadMissingIsNull(@TempDir Path dir) throws Exception {
+        assertThat(WorkspaceIO.load(dir.toFile())).isNull();
+    }
+
+    @Test
+    @DisplayName("Pretty-print indents JSON, passes other bodies through")
+    void prettyPrints() {
+        assertThat(WorkspaceIO.pretty("{\"a\":1,\"b\":2}")).contains("\n").contains("\"a\": 1");
+        assertThat(WorkspaceIO.pretty("plain")).isEqualTo("plain");
+    }
+}

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -160,6 +160,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>NMOX-Studio-apiclient</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>NMOX-Studio-sample</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
         <module>tools</module>
         <module>rack</module>
         <module>infra</module>
+        <module>apiclient</module>
         <module>application</module>
         <module>NMOX-Studio-sample</module>
     </modules>


### PR DESCRIPTION
## Summary

A complete API suite as its own tab (Window → API Studio), built as a new `apiclient` module mirroring the infra designer's structure:

- **Collections** tree (add/delete), **request builder** (method, URL, toggleable params/headers, body, bearer/basic auth), **environments** with `{{variable}}` substitution, per-request **tests** (status / time / body-contains / JSON-path / header-present), and a **response viewer** (status·time·size, pretty JSON, headers, green-red test results).
- Persists as `.nmoxapi.json` beside the project. Secrets belong in environment variables (the file is committable).

## Verification

Full `mvn verify` green (new module carries a 0.30 coverage floor; `ApiStudioTest` 9/9). App assembles with the module in the cluster; **boot smoke clean** — the tab registers without install/enable failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)