### PR TITLE
fix(ui): follow-up dialogs no longer stack behind the main window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.20.1] — 2026-07-03
+
+Patch: a defect found by driving the released IDE with computer
+automation — clicks, keystrokes, and on-disk assertions against the
+running app.
+
+### Fixed
+- **Follow-up dialogs no longer stack behind the main window.** A
+  dialog opened in the same event dispatch that was still disposing its
+  predecessor (the Standards Kit outcome report after the wizard, the
+  New Experiment error report, API Studio's variables editor after
+  naming a new environment) could open *behind* the main window —
+  modal, invisible, every menu action greyed: a soft-locked app with no
+  visible reason. Confirmed live via window enumeration; each follow-up
+  dialog is now deferred one dispatch so its predecessor is fully gone
+  before it shows.
+
+### Verified live (no code change)
+- The automation run also battle-tested the paths CI could only
+  logic-verify: a real HTTPS send through API Studio (200, timed,
+  sized, headers graded on the Standards tab), .editorconfig
+  save-enforcement in the running editor (trailing whitespace trimmed,
+  final newline added, on disk), experiment lifecycle (scaffold →
+  no-git marker → external-delete resilience), Standards Kit files
+  spec-checked on disk, and the Infra Designer's fit/zoom controls.
+
 ## [1.20.0] — 2026-07-03
 
 The standards sprint: the web's specs, supported with gusto — text

--- a/apiclient/src/main/java/org/nmox/studio/apiclient/ui/ApiClientTopComponent.java
+++ b/apiclient/src/main/java/org/nmox/studio/apiclient/ui/ApiClientTopComponent.java
@@ -469,11 +469,19 @@ public final class ApiClientTopComponent extends TopComponent {
             if (DialogDisplayer.getDefault().notify(name) != NotifyDescriptor.OK_OPTION) {
                 return;
             }
-            env = new Environment();
-            env.name = name.getInputText().isBlank() ? "env" : name.getInputText().trim();
-            workspace.environments.add(env);
-            workspace.activeEnvironment = env.name;
+            Environment fresh = new Environment();
+            fresh.name = name.getInputText().isBlank() ? "env" : name.getInputText().trim();
+            workspace.environments.add(fresh);
+            workspace.activeEnvironment = fresh.name;
+            // deferred a dispatch: a dialog opened while the previous one is
+            // still disposing can stack behind the main window
+            SwingUtilities.invokeLater(() -> editVariables(fresh));
+            return;
         }
+        editVariables(env);
+    }
+
+    private void editVariables(Environment env) {
         JTextArea area = new JTextArea(12, 40);
         area.setFont(MONO);
         StringBuilder sb = new StringBuilder();

--- a/ui/src/main/java/org/nmox/studio/ui/actions/NewExperimentAction.java
+++ b/ui/src/main/java/org/nmox/studio/ui/actions/NewExperimentAction.java
@@ -8,6 +8,7 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import org.nmox.studio.rack.projectstudio.Experiments;
 import org.nmox.studio.rack.projectstudio.ProjectTemplates;
 import org.nmox.studio.rack.service.RackService;
@@ -75,9 +76,11 @@ public final class NewExperimentAction implements ActionListener {
                 workbench.requestActive();
             }
         } catch (Exception ex) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
-                    "Could not create the experiment: " + ex.getMessage(),
-                    NotifyDescriptor.ERROR_MESSAGE));
+            String message = "Could not create the experiment: " + ex.getMessage();
+            // deferred a dispatch: shown while the wizard is still disposing,
+            // the error can stack behind the main window and soft-lock the app
+            SwingUtilities.invokeLater(() -> DialogDisplayer.getDefault().notify(
+                    new NotifyDescriptor.Message(message, NotifyDescriptor.ERROR_MESSAGE)));
         }
     }
 }

--- a/ui/src/main/java/org/nmox/studio/ui/actions/StandardsKitAction.java
+++ b/ui/src/main/java/org/nmox/studio/ui/actions/StandardsKitAction.java
@@ -9,6 +9,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import org.nmox.studio.rack.projectstudio.StandardsKit;
 import org.nmox.studio.rack.service.RackService;
 import org.openide.DialogDescriptor;
@@ -80,11 +81,15 @@ public final class StandardsKitAction implements ActionListener {
                 report.append(o.written() ? "  ✓ " : "  – ").append(o.path())
                         .append(o.written() ? "" : "  (already exists, untouched)").append('\n');
             }
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
-                    "Standards Kit:\n\n" + report, NotifyDescriptor.INFORMATION_MESSAGE));
+            // deferred a dispatch: a dialog opened while the wizard is still
+            // disposing can stack behind the main window and soft-lock the app
+            SwingUtilities.invokeLater(() -> DialogDisplayer.getDefault().notify(
+                    new NotifyDescriptor.Message("Standards Kit:\n\n" + report,
+                            NotifyDescriptor.INFORMATION_MESSAGE)));
         } catch (Exception ex) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
-                    "Could not write: " + ex.getMessage(), NotifyDescriptor.ERROR_MESSAGE));
+            String message = "Could not write: " + ex.getMessage();
+            SwingUtilities.invokeLater(() -> DialogDisplayer.getDefault().notify(
+                    new NotifyDescriptor.Message(message, NotifyDescriptor.ERROR_MESSAGE)));
         }
     }
 }


### PR DESCRIPTION
## Summary
Driving the released v1.20.0 IDE with computer automation surfaced a soft-lock: a dialog opened in the same EDT dispatch that was still disposing its predecessor (Standards Kit outcome report after the wizard) opened **behind** the main window - modal, invisible, every menu action greyed. Confirmed live via window enumeration.

## Fix
Defer the follow-up dialog one dispatch (`SwingUtilities.invokeLater`) so its predecessor is fully disposed before it shows. Applied at all three dialog-after-dialog sites:
- `StandardsKitAction` - outcome report + error message
- `NewExperimentAction` - error message
- `ApiClientTopComponent.editEnvironment` - variables editor after the name prompt (extracted `editVariables`)

Worker-thread chains (infra deploy/sync/destroy) already re-entered the EDT fresh and were never affected.

## Testing
- Full `mvn clean verify` gate (SpotBugs, find-sec-bugs, JaCoCo floors, all suites)
- **Live regression test**: rebuilt, relaunched, re-ran the exact automated reproduction - the report dialog now appears in front

🤖 Generated with [Claude Code](https://claude.com/claude-code)