### PR TITLE
feat: the daily-driver polish (v1.25.0) — Welcome launchpad, Environment Doctor, update awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to NMOX Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.25.0] — 2026-07-03
+
+The daily-driver polish: after twenty-four releases of capability, the
+weakest surfaces were the first ones a user meets. This release makes
+the front door, the environment, and the upgrade story honest.
+
+### Added
+- **The Welcome screen is a launchpad again.** It was frozen at v1.0 —
+  three buttons, unaware of everything since. Now: a Start column
+  (New Project / New Experiment / New Learning Space / Open Folder,
+  shortcuts shown), a live Recent column (your actual projects, click
+  to aim the studio — refreshed every time the tab shows), a Tooling
+  column with every window and its keystroke, and an honest footer:
+  the stamped version plus "What's new ↗" to the release notes.
+- **Environment Doctor (Tools menu).** The studio leans on ~40
+  external tools — the core four, a toolchain per language lane, and
+  an interpreter per learning space — and each device already speaks
+  up alone. The Doctor sweeps them all at once: one table, every tool
+  probed live with `--version` through the same hardened launcher the
+  devices use — ✓ with its version line, or ✗ with the install
+  command that fixes it. The checklist extends itself from the
+  learning catalog, so new spaces are covered automatically.
+- **Update awareness.** Once a day, fifteen seconds after startup and
+  entirely off the EDT, the studio asks GitHub for the latest release
+  tag and — only when it outranks the version this build was stamped
+  with — shows one quiet notification linking to the releases page.
+  Dev builds never check, offline never nags, and the `updateCheck`
+  preference turns it off. Version arithmetic is numeric (1.9 < 1.24),
+  tested in core.
+
 ## [1.24.0] — 2026-07-03
 
 Learning Spaces: projects that exist to be learned from. Pick a

--- a/core/src/main/java/org/nmox/studio/core/util/Versions.java
+++ b/core/src/main/java/org/nmox/studio/core/util/Versions.java
@@ -1,0 +1,47 @@
+package org.nmox.studio.core.util;
+
+/**
+ * Honest version arithmetic for the update check: parse the version out
+ * of the branded product name and compare dotted versions numerically —
+ * 1.9.0 is older than 1.24.0, which string comparison gets wrong.
+ */
+public final class Versions {
+
+    private Versions() {
+    }
+
+    /**
+     * Extracts "1.24.0" from strings like "NMOX Studio 1.24.0" or
+     * "v1.24.0"; null when there is no x.y[.z] version to find (the
+     * dev-build "NMOX Studio 1.0" yields "1.0", which callers treat as
+     * unstamped).
+     */
+    public static String extract(String text) {
+        if (text == null) {
+            return null;
+        }
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("(\\d+(?:\\.\\d+)+)").matcher(text);
+        return m.find() ? m.group(1) : null;
+    }
+
+    /** Numeric dotted-version compare: negative if a &lt; b, 0 if equal. */
+    public static int compare(String a, String b) {
+        String[] as = a.split("\\.");
+        String[] bs = b.split("\\.");
+        int n = Math.max(as.length, bs.length);
+        for (int i = 0; i < n; i++) {
+            int ai = i < as.length ? Integer.parseInt(as[i]) : 0;
+            int bi = i < bs.length ? Integer.parseInt(bs[i]) : 0;
+            if (ai != bi) {
+                return Integer.compare(ai, bi);
+            }
+        }
+        return 0;
+    }
+
+    /** True when the running version is stamped (a release build, not "1.0"). */
+    public static boolean isStamped(String version) {
+        return version != null && !version.equals("1.0");
+    }
+}

--- a/core/src/test/java/org/nmox/studio/core/util/VersionsTest.java
+++ b/core/src/test/java/org/nmox/studio/core/util/VersionsTest.java
@@ -1,0 +1,41 @@
+package org.nmox.studio.core.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Version arithmetic for the update check: extraction from branded
+ * strings and numeric (not lexicographic) comparison.
+ */
+class VersionsTest {
+
+    @Test
+    @DisplayName("extract finds the version inside branded and tagged strings")
+    void extraction() {
+        assertThat(Versions.extract("NMOX Studio 1.24.0")).isEqualTo("1.24.0");
+        assertThat(Versions.extract("v1.25.0")).isEqualTo("1.25.0");
+        assertThat(Versions.extract("NMOX Studio 1.0")).isEqualTo("1.0");
+        assertThat(Versions.extract("no version here")).isNull();
+        assertThat(Versions.extract(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("compare is numeric: 1.9 is older than 1.24, missing parts are zero")
+    void comparison() {
+        assertThat(Versions.compare("1.9.0", "1.24.0")).isNegative();
+        assertThat(Versions.compare("1.24.0", "1.24.0")).isZero();
+        assertThat(Versions.compare("1.24.1", "1.24.0")).isPositive();
+        assertThat(Versions.compare("1.24", "1.24.0")).isZero();
+        assertThat(Versions.compare("2.0", "1.99.99")).isPositive();
+    }
+
+    @Test
+    @DisplayName("only release builds are stamped; the dev '1.0' is not")
+    void stamped() {
+        assertThat(Versions.isStamped("1.24.0")).isTrue();
+        assertThat(Versions.isStamped("1.0")).isFalse();
+        assertThat(Versions.isStamped(null)).isFalse();
+    }
+}

--- a/rack/src/main/java/org/nmox/studio/rack/projectstudio/EnvironmentDoctor.java
+++ b/rack/src/main/java/org/nmox/studio/rack/projectstudio/EnvironmentDoctor.java
@@ -1,0 +1,103 @@
+package org.nmox.studio.rack.projectstudio;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.nmox.studio.core.process.ProcessSupport;
+
+/**
+ * The environment doctor: one honest answer to "what does this machine
+ * actually have?" The IDE leans on dozens of external tools — the core
+ * four every project touches, a toolchain per language lane, and an
+ * interpreter per learning space — and each device already speaks up
+ * when its own tool is missing. This sweeps them all at once: each
+ * tool is probed with {@code --version} through the same hardened
+ * launcher the devices use, so the verdict here is the verdict there.
+ */
+public final class EnvironmentDoctor {
+
+    /** One probed tool: found (with its version line) or missing (with the fix). */
+    public record Finding(String tool, String purpose, boolean found,
+            String detail, String installHint) {
+    }
+
+    private EnvironmentDoctor() {
+    }
+
+    /** The full checkup list: core tools, toolchains, then REPL interpreters. */
+    public static List<String[]> checklist() {
+        // {binary, purpose, install hint} — hints favor Homebrew on the
+        // assumption the doctor's OS hint column stays honest per-entry
+        List<String[]> checks = new ArrayList<>(List.of(
+                new String[]{"git", "version control — TIMELINE, project init", "brew install git"},
+                new String[]{"node", "JavaScript runtime — most web tooling", "brew install node"},
+                new String[]{"npm", "package manager — CRATE, NPM-9000", "ships with node"},
+                new String[]{"docker", "containers — HARBOR, Docker panel", "Docker Desktop"},
+                new String[]{"java", "JVM — Maven lanes, jshell space", "brew install openjdk"},
+                new String[]{"mvn", "Maven builds", "brew install maven"},
+                new String[]{"cargo", "Rust toolchain", "brew install rustup && rustup default stable"},
+                new String[]{"go", "Go toolchain", "brew install go"},
+                new String[]{"python3", "Python — tooling and spaces", "brew install python"},
+                new String[]{"ruby", "Ruby toolchain", "brew install ruby"},
+                new String[]{"php", "PHP toolchain", "brew install php"},
+                new String[]{"bun", "Bun runtime", "brew install oven-sh/bun/bun"},
+                new String[]{"deno", "Deno runtime", "brew install deno"},
+                new String[]{"mix", "Elixir/BEAM toolchain", "brew install elixir"}));
+        // every distinct REPL interpreter the learning catalog can launch
+        Map<String, String[]> repls = new LinkedHashMap<>();
+        for (LearningCatalog.Space space : LearningCatalog.all()) {
+            if (space.driver().kind() != LearningCatalog.DriverKind.REPL
+                    || space.driver().command().isEmpty()) {
+                continue;
+            }
+            String binary = space.driver().command().get(0);
+            String hint = space.install().getOrDefault(LearningSpace.osKey(), "");
+            repls.putIfAbsent(binary, new String[]{binary,
+                "learning space: " + space.name(), hint});
+        }
+        for (String[] check : checks) {
+            repls.remove(check[0]); // already covered above
+        }
+        checks.addAll(repls.values());
+        return checks;
+    }
+
+    /**
+     * Probes one tool by running {@code tool --version} through the
+     * hardened launcher with a short leash. Missing binary → not found;
+     * a tool that launches but dislikes --version still counts as found.
+     */
+    public static Finding probe(String tool, String purpose, String installHint) {
+        try {
+            Process p = ProcessSupport.builder(List.of(tool, "--version"))
+                    .redirectErrorStream(true)
+                    .start();
+            String firstLine = "";
+            try (BufferedReader r = new BufferedReader(
+                    new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                String line = r.readLine();
+                if (line != null) {
+                    firstLine = line.strip();
+                }
+                r.transferTo(java.io.Writer.nullWriter()); // drain so the tool can exit
+            }
+            if (!p.waitFor(4, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+            }
+            String detail = firstLine.isBlank() ? "found (version unknown)"
+                    : (firstLine.length() > 72 ? firstLine.substring(0, 72) + "…" : firstLine);
+            return new Finding(tool, purpose, true, detail, installHint);
+        } catch (IOException notFound) {
+            return new Finding(tool, purpose, false, "not found", installHint);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return new Finding(tool, purpose, false, "interrupted", installHint);
+        }
+    }
+}

--- a/rack/src/test/java/org/nmox/studio/rack/projectstudio/EnvironmentDoctorTest.java
+++ b/rack/src/test/java/org/nmox/studio/rack/projectstudio/EnvironmentDoctorTest.java
@@ -1,0 +1,51 @@
+package org.nmox.studio.rack.projectstudio;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The environment doctor's contract: the checklist covers the core
+ * tools plus every learning-space interpreter exactly once, and a probe
+ * tells the truth for both a tool that exists and one that doesn't.
+ */
+class EnvironmentDoctorTest {
+
+    @Test
+    @DisplayName("The checklist covers core tools and every REPL interpreter, no duplicates")
+    void checklistCoverage() {
+        List<String[]> checks = EnvironmentDoctor.checklist();
+        List<String> tools = checks.stream().map(c -> c[0]).toList();
+        assertThat(tools).contains("git", "node", "npm", "docker", "mvn");
+        assertThat(tools).as("learning-space interpreters are swept")
+                .contains("clisp", "sqlite3");
+        assertThat(tools).doesNotHaveDuplicates();
+        assertThat(checks).allSatisfy(c -> {
+            assertThat(c[1]).as("%s has a purpose", c[0]).isNotBlank();
+        });
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    @DisplayName("Probing a real tool reports found with a version line")
+    void probeFindsRealTool() {
+        // git exists on every dev/CI box this project supports
+        EnvironmentDoctor.Finding f = EnvironmentDoctor.probe("git", "vcs", "");
+        assertThat(f.found()).isTrue();
+        assertThat(f.detail()).containsIgnoringCase("git");
+    }
+
+    @Test
+    @DisplayName("Probing a missing tool reports not found, never throws")
+    void probeMissesHonestly() {
+        EnvironmentDoctor.Finding f = EnvironmentDoctor.probe(
+                "nmox-no-such-tool-xyz", "nothing", "install hint");
+        assertThat(f.found()).isFalse();
+        assertThat(f.detail()).isEqualTo("not found");
+        assertThat(f.installHint()).isEqualTo("install hint");
+    }
+}

--- a/ui/src/main/java/org/nmox/studio/ui/MainWindow.java
+++ b/ui/src/main/java/org/nmox/studio/ui/MainWindow.java
@@ -1,5 +1,19 @@
 package org.nmox.studio.ui;
 
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.util.List;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 import org.netbeans.api.settings.ConvertAsProperties;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -7,11 +21,12 @@ import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
-import org.openide.util.lookup.ServiceProvider;
 
 /**
- * Main window for NMOX Studio.
- * Provides the primary workspace and docking area for tools and editors.
+ * Main window for NMOX Studio: the Welcome launchpad. Start actions,
+ * the projects you were just in, every tool window with its shortcut,
+ * and an honest version line — the first screen reflects the whole
+ * product, not the product as of v1.0.
  */
 @ConvertAsProperties(
         dtd = "-//org.nmox.studio.ui//MainWindow//EN",
@@ -31,12 +46,14 @@ import org.openide.util.lookup.ServiceProvider;
 @Messages({
     "CTL_MainWindowAction=Welcome",
     "CTL_MainWindowTopComponent=Welcome",
-    "HINT_MainWindowTopComponent=Start here: new project, Project Studio, Task Rack"
+    "HINT_MainWindowTopComponent=Start here: projects, learning spaces, and every tool window"
 })
 public final class MainWindow extends TopComponent {
-    
+
     private static MainWindow instance;
     private static final String PREFERRED_ID = "MainWindowTopComponent";
+
+    private WelcomePanel welcomePanel;
 
     public MainWindow() {
         initComponents();
@@ -44,14 +61,14 @@ public final class MainWindow extends TopComponent {
         setToolTipText(NbBundle.getMessage(MainWindow.class, "HINT_MainWindowTopComponent"));
         putClientProperty(TopComponent.PROP_MAXIMIZATION_DISABLED, Boolean.TRUE);
     }
-    
+
     public static synchronized MainWindow getDefault() {
         if (instance == null) {
             instance = new MainWindow();
         }
         return instance;
     }
-    
+
     public static synchronized MainWindow findInstance() {
         TopComponent win = WindowManager.getDefault().findTopComponent(PREFERRED_ID);
         if (win == null) {
@@ -64,95 +81,192 @@ public final class MainWindow extends TopComponent {
     }
 
     private void initComponents() {
-        setLayout(new java.awt.BorderLayout());
-        add(new WelcomePanel(), java.awt.BorderLayout.CENTER);
+        setLayout(new BorderLayout());
+        welcomePanel = new WelcomePanel();
+        add(welcomePanel, BorderLayout.CENTER);
     }
 
-    /**
-     * The launch surface: rack-styled dark panel with the three doors
-     * into the studio. Buttons resolve windows by preferredID so the ui
-     * module needs no compile dependency on the rack module.
-     */
-    private static final class WelcomePanel extends javax.swing.JPanel {
+    /** The launchpad: dark rack-styled panel, three columns, honest footer. */
+    private static final class WelcomePanel extends JPanel {
+
+        private static final Color HEADING = new Color(150, 152, 158);
+        private static final Color LINK = new Color(210, 212, 218);
+        private static final Color DIM = new Color(110, 112, 118);
+
+        private final JPanel recentColumn = column("RECENT");
 
         WelcomePanel() {
-            setLayout(new java.awt.GridBagLayout());
-            java.awt.GridBagConstraints gc = new java.awt.GridBagConstraints();
+            setLayout(new GridBagLayout());
+            GridBagConstraints gc = new GridBagConstraints();
             gc.gridx = 0;
-            gc.insets = new java.awt.Insets(6, 0, 6, 0);
+            gc.insets = new Insets(6, 0, 6, 0);
 
-            javax.swing.JLabel title = new javax.swing.JLabel("NMOX STUDIO");
-            title.setFont(new java.awt.Font(java.awt.Font.SANS_SERIF, java.awt.Font.BOLD, 42));
-            title.setForeground(new java.awt.Color(235, 236, 240));
+            JLabel title = new JLabel("NMOX STUDIO");
+            title.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 42));
+            title.setForeground(new Color(235, 236, 240));
 
-            javax.swing.JLabel tagline = new javax.swing.JLabel(
+            JLabel tagline = new JLabel(
                     "The web studio with a rack — wire your tools like a synth.");
-            tagline.setFont(new java.awt.Font(java.awt.Font.SANS_SERIF, java.awt.Font.PLAIN, 15));
-            tagline.setForeground(new java.awt.Color(150, 152, 158));
+            tagline.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 15));
+            tagline.setForeground(HEADING);
 
-            javax.swing.JPanel buttons = new javax.swing.JPanel(
-                    new java.awt.FlowLayout(java.awt.FlowLayout.CENTER, 14, 0));
-            buttons.setOpaque(false);
-            buttons.add(launchButton("Project Studio",
-                    "Create, browse and configure projects", "ProjectStudioTopComponent",
-                    new java.awt.Color(64, 156, 255)));
-            buttons.add(launchButton("Task Rack",
-                    "Wire build, test, serve and deploy like a synth rack", "RackTopComponent",
-                    new java.awt.Color(236, 106, 168)));
-            buttons.add(launchButton("NPM Explorer",
-                    "Browse scripts and dependencies", "NpmExplorerTopComponent",
-                    new java.awt.Color(203, 56, 55)));
+            JPanel start = column("START");
+            start.add(actionLink("New Project…  ⇧⌘N", "File",
+                    "org.nmox.studio.ui.actions.NewProjectAction"));
+            start.add(actionLink("New Experiment…  ⇧⌘E", "File",
+                    "org.nmox.studio.ui.actions.NewExperimentAction"));
+            start.add(actionLink("New Learning Space…  ⇧⌘L", "File",
+                    "org.nmox.studio.ui.actions.NewLearningSpaceAction"));
+            start.add(actionLink("Open Folder…  ⇧⌘O", "File",
+                    "org.nmox.studio.ui.actions.OpenFolderAction"));
 
-            javax.swing.JLabel hint = new javax.swing.JLabel(
-                    "New Project lives in the Project Studio toolbar · Tab flips the rack");
-            hint.setFont(new java.awt.Font(java.awt.Font.SANS_SERIF, java.awt.Font.PLAIN, 12));
-            hint.setForeground(new java.awt.Color(110, 112, 118));
+            JPanel windows = column("TOOLING");
+            windows.add(windowLink("Task Rack  ⌘9", "RackTopComponent"));
+            windows.add(windowLink("Workbench  ⌘0", "ProjectExplorerTopComponent"));
+            windows.add(windowLink("Project Studio", "ProjectStudioTopComponent"));
+            windows.add(windowLink("API Studio  ⇧⌘8", "ApiClientTopComponent"));
+            windows.add(windowLink("Infra Designer  ⇧⌘9", "InfraDesignerTopComponent"));
+            windows.add(windowLink("Docker Panel  ⌘8", "DockerPanelTopComponent"));
+
+            JPanel columns = new JPanel(new java.awt.GridLayout(1, 3, 44, 0));
+            columns.setOpaque(false);
+            columns.add(start);
+            columns.add(recentColumn);
+            columns.add(windows);
+            refreshRecents();
+
+            JLabel version = new JLabel(footerText());
+            version.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+            version.setForeground(DIM);
+            JButton whatsNew = textButton("What's new ↗", DIM);
+            whatsNew.setToolTipText("Open the release notes on GitHub");
+            whatsNew.addActionListener(e -> browse(UpdateCheck.RELEASES_PAGE));
+            JPanel footer = new JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.CENTER, 10, 0));
+            footer.setOpaque(false);
+            footer.add(version);
+            footer.add(whatsNew);
 
             gc.gridy = 0;
             add(title, gc);
             gc.gridy = 1;
             add(tagline, gc);
             gc.gridy = 2;
-            gc.insets = new java.awt.Insets(28, 0, 6, 0);
-            add(buttons, gc);
+            gc.insets = new Insets(30, 0, 6, 0);
+            add(columns, gc);
             gc.gridy = 3;
-            gc.insets = new java.awt.Insets(18, 0, 6, 0);
-            add(hint, gc);
+            gc.insets = new Insets(26, 0, 6, 0);
+            add(footer, gc);
         }
 
-        private static javax.swing.JButton launchButton(String label, String tooltip,
-                String topComponentId, java.awt.Color accent) {
-            javax.swing.JButton button = new javax.swing.JButton(
-                    "<html><div style='text-align:center'><b>" + label + "</b></div></html>");
-            button.setToolTipText(tooltip);
-            button.setPreferredSize(new java.awt.Dimension(190, 64));
-            button.setBackground(new java.awt.Color(45, 46, 50));
-            button.setForeground(new java.awt.Color(230, 231, 235));
+        /** Rebuilds the recent-projects column from the live service. */
+        void refreshRecents() {
+            recentColumn.removeAll();
+            recentColumn.add(columnHeading("RECENT"));
+            List<File> recents = recentProjects();
+            if (recents.isEmpty()) {
+                JLabel none = new JLabel("projects you open gather here");
+                none.setFont(new Font(Font.SANS_SERIF, Font.ITALIC, 12));
+                none.setForeground(DIM);
+                none.setAlignmentX(Component.LEFT_ALIGNMENT);
+                recentColumn.add(none);
+            } else {
+                for (File dir : recents.subList(0, Math.min(6, recents.size()))) {
+                    JButton link = textButton(dir.getName(), LINK);
+                    link.setToolTipText(dir.getAbsolutePath());
+                    link.addActionListener(e ->
+                            org.nmox.studio.rack.service.RackService.getDefault().openProject(dir));
+                    recentColumn.add(link);
+                }
+            }
+            recentColumn.revalidate();
+            recentColumn.repaint();
+        }
+
+        private static List<File> recentProjects() {
+            try {
+                return org.nmox.studio.rack.service.RackService.getDefault().getRecentProjects();
+            } catch (RuntimeException rackUnavailable) {
+                return List.of();
+            }
+        }
+
+        private static JPanel column(String heading) {
+            JPanel col = new JPanel();
+            col.setOpaque(false);
+            col.setLayout(new BoxLayout(col, BoxLayout.Y_AXIS));
+            col.add(columnHeading(heading));
+            return col;
+        }
+
+        private static JLabel columnHeading(String text) {
+            JLabel label = new JLabel(text);
+            label.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 11));
+            label.setForeground(HEADING);
+            label.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 2, 6, 0));
+            label.setAlignmentX(Component.LEFT_ALIGNMENT);
+            return label;
+        }
+
+        private static JButton textButton(String text, Color color) {
+            JButton button = new JButton(text);
+            button.setForeground(color);
+            button.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 13));
+            button.setContentAreaFilled(false);
+            button.setBorder(javax.swing.BorderFactory.createEmptyBorder(3, 2, 3, 2));
             button.setFocusPainted(false);
-            button.setBorder(javax.swing.BorderFactory.createCompoundBorder(
-                    javax.swing.BorderFactory.createMatteBorder(0, 0, 3, 0, accent),
-                    javax.swing.BorderFactory.createEmptyBorder(10, 16, 9, 16)));
-            button.addActionListener(e -> {
+            button.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
+            button.setCursor(java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR));
+            button.setAlignmentX(Component.LEFT_ALIGNMENT);
+            return button;
+        }
+
+        private static JButton actionLink(String label, String category, String id) {
+            JButton link = textButton(label, LINK);
+            link.addActionListener(e -> {
+                javax.swing.Action action = org.openide.awt.Actions.forID(category, id);
+                if (action != null) {
+                    action.actionPerformed(e);
+                }
+            });
+            return link;
+        }
+
+        private static JButton windowLink(String label, String topComponentId) {
+            JButton link = textButton(label, LINK);
+            link.addActionListener(e -> {
                 TopComponent tc = WindowManager.getDefault().findTopComponent(topComponentId);
                 if (tc != null) {
                     tc.open();
                     tc.requestActive();
                 }
             });
-            return button;
+            return link;
+        }
+
+        private static String footerText() {
+            String version = UpdateCheck.currentVersion();
+            return version == null || version.isBlank() ? "NMOX Studio" : version;
+        }
+
+        private static void browse(String url) {
+            try {
+                java.awt.Desktop.getDesktop().browse(java.net.URI.create(url));
+            } catch (Exception ignored) {
+                // no browser wired up; the footer text still names the version
+            }
         }
 
         @Override
         protected void paintComponent(java.awt.Graphics g) {
             super.paintComponent(g);
             java.awt.Graphics2D g2 = (java.awt.Graphics2D) g.create();
-            g2.setPaint(new java.awt.GradientPaint(0, 0, new java.awt.Color(30, 30, 34),
-                    0, getHeight(), new java.awt.Color(22, 22, 25)));
+            g2.setPaint(new java.awt.GradientPaint(0, 0, new Color(30, 30, 34),
+                    0, getHeight(), new Color(22, 22, 25)));
             g2.fillRect(0, 0, getWidth(), getHeight());
             // rack-rail nod: accent pinstripes along the top
-            java.awt.Color[] stripes = {
-                new java.awt.Color(236, 106, 168), new java.awt.Color(64, 156, 255),
-                new java.awt.Color(232, 166, 35), new java.awt.Color(99, 197, 70)};
+            Color[] stripes = {
+                new Color(236, 106, 168), new Color(64, 156, 255),
+                new Color(232, 166, 35), new Color(99, 197, 70)};
             int w = getWidth() / stripes.length + 1;
             for (int i = 0; i < stripes.length; i++) {
                 g2.setColor(stripes[i]);
@@ -176,10 +290,18 @@ public final class MainWindow extends TopComponent {
     }
 
     @Override
-    public void componentClosed() {
-        // Clean up resources if needed
+    protected void componentShowing() {
+        // the recents column is live, not a launch-time snapshot
+        if (welcomePanel != null) {
+            welcomePanel.refreshRecents();
+        }
     }
-    
+
+    @Override
+    public void componentClosed() {
+        // nothing to release
+    }
+
     @Override
     protected String preferredID() {
         return PREFERRED_ID;

--- a/ui/src/main/java/org/nmox/studio/ui/UpdateCheck.java
+++ b/ui/src/main/java/org/nmox/studio/ui/UpdateCheck.java
@@ -1,0 +1,100 @@
+package org.nmox.studio.ui;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.prefs.Preferences;
+import org.nmox.studio.core.http.HttpClientFactory;
+import org.nmox.studio.core.util.Versions;
+import org.openide.modules.OnStart;
+import org.openide.util.NbPreferences;
+
+/**
+ * A daily driver should mention when a newer release exists. Once per
+ * day, well after startup and entirely off the EDT, this asks GitHub
+ * for the latest release tag and — only if it outranks the stamped
+ * version this build carries — shows one quiet notification linking to
+ * the release page. Dev builds (unstamped "1.0") never check; offline
+ * failures never nag; the {@code updateCheck} preference turns it off.
+ */
+@OnStart
+public class UpdateCheck implements Runnable {
+
+    static final String RELEASES_API =
+            "https://api.github.com/repos/NMOX/NMOX-Studio/releases/latest";
+    static final String RELEASES_PAGE =
+            "https://github.com/NMOX/NMOX-Studio/releases";
+
+    @Override
+    public void run() {
+        Preferences prefs = NbPreferences.forModule(UpdateCheck.class);
+        if (!prefs.getBoolean("updateCheck", true)) {
+            return;
+        }
+        long last = prefs.getLong("updateCheck.lastRun", 0);
+        if (System.currentTimeMillis() - last < Duration.ofDays(1).toMillis()) {
+            return;
+        }
+        String running = Versions.extract(currentVersion());
+        if (!Versions.isStamped(running)) {
+            return; // dev build: nothing meaningful to compare
+        }
+        org.openide.windows.WindowManager.getDefault().invokeWhenUIReady(() ->
+                org.openide.util.RequestProcessor.getDefault().post(
+                        () -> check(prefs, running), 15_000));
+    }
+
+    private void check(Preferences prefs, String running) {
+        prefs.putLong("updateCheck.lastRun", System.currentTimeMillis());
+        try {
+            HttpResponse<String> response = HttpClientFactory.shared().send(
+                    HttpRequest.newBuilder(URI.create(RELEASES_API))
+                            .timeout(Duration.ofSeconds(10))
+                            .header("Accept", "application/vnd.github+json")
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                return;
+            }
+            String latest = latestTag(response.body());
+            if (latest == null || Versions.compare(running, latest) >= 0) {
+                return;
+            }
+            javax.swing.SwingUtilities.invokeLater(() ->
+                    org.openide.awt.NotificationDisplayer.getDefault().notify(
+                            "NMOX Studio " + latest + " is available",
+                            javax.swing.UIManager.getIcon("OptionPane.informationIcon"),
+                            "You're on " + running + ". Click to open the releases page.",
+                            e -> openReleases()));
+        } catch (Exception offline) {
+            // no network, rate-limited, whatever — a check must never nag
+        }
+    }
+
+    /** Pulls the version out of the tag_name field without a JSON dependency. */
+    static String latestTag(String body) {
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("\"tag_name\"\\s*:\\s*\"v?([0-9][0-9.]*)\"").matcher(body);
+        return m.find() ? m.group(1) : null;
+    }
+
+    /** The branded product version — stamped by the release workflow. */
+    static String currentVersion() {
+        try {
+            return java.util.ResourceBundle
+                    .getBundle("org.netbeans.core.startup.Bundle")
+                    .getString("currentVersion");
+        } catch (RuntimeException missing) {
+            return null;
+        }
+    }
+
+    private static void openReleases() {
+        try {
+            java.awt.Desktop.getDesktop().browse(URI.create(RELEASES_PAGE));
+        } catch (Exception ignored) {
+            // the notification text carries enough to find it by hand
+        }
+    }
+}

--- a/ui/src/main/java/org/nmox/studio/ui/actions/EnvironmentDoctorAction.java
+++ b/ui/src/main/java/org/nmox/studio/ui/actions/EnvironmentDoctorAction.java
@@ -1,0 +1,87 @@
+package org.nmox.studio.ui.actions;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+import org.nmox.studio.rack.projectstudio.EnvironmentDoctor;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+import org.openide.util.RequestProcessor;
+
+/**
+ * Environment Doctor: one honest table of every external tool the
+ * studio leans on — the core four, the language toolchains, and every
+ * learning-space interpreter — probed live (never guessed from a
+ * cache) with its version or the install command that would fix it.
+ */
+@ActionID(category = "Tools", id = "org.nmox.studio.ui.actions.EnvironmentDoctorAction")
+@ActionRegistration(displayName = "#CTL_EnvironmentDoctorAction")
+@ActionReference(path = "Menu/Tools", position = 90)
+@Messages("CTL_EnvironmentDoctorAction=Environment Doctor...")
+public final class EnvironmentDoctorAction implements ActionListener {
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        DefaultTableModel model = new DefaultTableModel(
+                new Object[]{"", "Tool", "Status", "Used for", "Install"}, 0) {
+            @Override
+            public boolean isCellEditable(int r, int c) {
+                return false;
+            }
+        };
+        JTable table = new JTable(model);
+        table.setRowHeight(22);
+        table.getColumnModel().getColumn(0).setMaxWidth(28);
+        table.getColumnModel().getColumn(1).setPreferredWidth(90);
+        table.getColumnModel().getColumn(2).setPreferredWidth(230);
+        table.getColumnModel().getColumn(3).setPreferredWidth(200);
+        table.getColumnModel().getColumn(4).setPreferredWidth(200);
+
+        JLabel status = new JLabel("Probing…");
+        JPanel panel = new JPanel(new BorderLayout(0, 6));
+        panel.setBorder(javax.swing.BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        panel.add(new JLabel("Every tool the studio can drive, probed live on this machine:"),
+                BorderLayout.NORTH);
+        panel.add(new JScrollPane(table), BorderLayout.CENTER);
+        panel.add(status, BorderLayout.SOUTH);
+        panel.setPreferredSize(new Dimension(780, 480));
+
+        List<String[]> checks = EnvironmentDoctor.checklist();
+        // probes run off the EDT and stream into the table as they land
+        RequestProcessor.getDefault().post(() -> {
+            int found = 0;
+            for (String[] check : checks) {
+                EnvironmentDoctor.Finding f =
+                        EnvironmentDoctor.probe(check[0], check[1], check[2]);
+                if (f.found()) {
+                    found++;
+                }
+                int soFar = found;
+                int done = model.getRowCount() + 1;
+                SwingUtilities.invokeLater(() -> {
+                    model.addRow(new Object[]{f.found() ? "✓" : "✗", f.tool(),
+                        f.detail(), f.purpose(), f.found() ? "" : f.installHint()});
+                    status.setText(done < checks.size()
+                            ? "Probing…  " + done + "/" + checks.size()
+                            : soFar + " of " + checks.size() + " tools present");
+                });
+            }
+        });
+
+        DialogDescriptor descriptor = new DialogDescriptor(panel, "Environment Doctor",
+                false, new Object[]{DialogDescriptor.CLOSED_OPTION}, null, 0, null, null);
+        DialogDisplayer.getDefault().createDialog(descriptor).setVisible(true);
+    }
+}


### PR DESCRIPTION
## Summary
Claude-driven sprint (the user handed over the wheel). Thesis: after 24 releases of capability, the weakest surfaces were the first ones a user meets.

- **Welcome → launchpad**: frozen at v1.0 until now. Start actions with shortcuts, a live Recent column (RackService, refreshed on every showing), every tool window with its keystroke, and an honest footer (stamped version + What's-new link).
- **Environment Doctor** (Tools): every external tool the studio drives — core four, toolchains, all learning-space interpreters (self-extending checklist) — probed live with `--version` via ProcessSupport, streaming off-EDT: ✓ version or ✗ install command.
- **Update awareness**: daily, deferred, off-EDT GitHub releases/latest check; one quiet notification only when the stamped version is outranked. Dev builds never check; offline never nags; preference opt-out.
- **core.util.Versions**: numeric version arithmetic, tested.

Recon verified-and-dismissed: Maven rack support already exists — the IDE drives itself.

## Testing
VersionsTest (3), EnvironmentDoctorTest (3, incl. live probe of real git + honest miss), full `mvn clean verify` in this pipeline. Visual smoke of the Welcome/Doctor deferred (screen locking); the running desktop app is this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)